### PR TITLE
[D1.1] Containerization (Dockerfile for QueryService)

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,19 @@
+# QueryService – Huey OLAP backend
+# Build from repo root: docker build -f server/Dockerfile .
+
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Copy only server package and deps for smaller layer
+COPY server/requirements.txt server/requirements.txt
+RUN pip install --no-cache-dir -r server/requirements.txt
+
+COPY server/ server/
+
+ENV PYTHONPATH=/app
+ENV PYTHONUNBUFFERED=1
+
+EXPOSE 8000
+
+CMD ["uvicorn", "server.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/server/README.md
+++ b/server/README.md
@@ -41,6 +41,15 @@ From the repo root:
 PYTHONPATH=. python -m pytest server/tests -v
 ```
 
+## Docker
+
+From the repo root:
+
+```bash
+docker build -f server/Dockerfile -t query-service .
+docker run -p 8000:8000 query-service
+```
+
 ## Config
 
 Environment variables (optional, prefix `QUERYSERVICE_`):


### PR DESCRIPTION
Fixes #31

## Summary
- Add `server/Dockerfile`: Python 3.12-slim, install deps, run uvicorn on port 8000
- Build from repo root: `docker build -f server/Dockerfile .`
- README: Docker build and run instructions

Made with [Cursor](https://cursor.com)