### PR TITLE
[A2.1] Dataset configuration loader

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -25,6 +25,9 @@ class Settings(BaseSettings):
     port: int = 8000
     log_level: str = "INFO"
 
+    # Optional: path to datasets config YAML (for dataset/schema loader)
+    datasets_config_path: Optional[str] = None
+
     # Optional: S3 / engine config (for later issues)
     s3_bucket: Optional[str] = None
     s3_region: Optional[str] = None

--- a/server/datasets.py
+++ b/server/datasets.py
@@ -1,0 +1,57 @@
+"""
+Dataset configuration loader.
+
+Loads dataset and schema metadata from a YAML config file (e.g. dataset_id, fields).
+"""
+
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+from server.config import get_settings
+
+
+def _default_config_path() -> Path:
+    """Default path to datasets config (next to this file)."""
+    return Path(__file__).resolve().parent / "datasets_config" / "datasets.yaml"
+
+
+def load_datasets_config() -> dict[str, Any]:
+    """
+    Load the datasets config from YAML.
+    Returns a dict with key 'datasets': list of { dataset_id, fields }.
+    """
+    settings = get_settings()
+    path = settings.datasets_config_path
+    if path is None or path == "":
+        path = _default_config_path()
+    else:
+        path = Path(path)
+
+    if not path.exists():
+        return {"datasets": []}
+
+    with open(path, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+
+    if not data or not isinstance(data, dict):
+        return {"datasets": []}
+    if "datasets" not in data or not isinstance(data["datasets"], list):
+        return {"datasets": []}
+    return data
+
+
+def get_schema(dataset_id: str) -> Optional[dict[str, Any]]:
+    """
+    Return schema for a dataset: { dataset_id, fields }.
+    Returns None if dataset_id is not found.
+    """
+    config = load_datasets_config()
+    for ds in config.get("datasets", []):
+        if isinstance(ds, dict) and ds.get("dataset_id") == dataset_id:
+            return {
+                "dataset_id": dataset_id,
+                "fields": ds.get("fields", []),
+            }
+    return None

--- a/server/datasets_config/datasets.yaml
+++ b/server/datasets_config/datasets.yaml
@@ -1,0 +1,15 @@
+# Example dataset definitions for QueryService.
+# Override path via QUERYSERVICE_DATASETS_CONFIG_PATH.
+
+datasets:
+  - dataset_id: trades_v1
+    fields:
+      - name: date
+        type: date
+        is_dimension: true
+      - name: symbol
+        type: string
+        is_dimension: true
+      - name: volume
+        type: int64
+        is_measure: true

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -4,6 +4,7 @@
 fastapi>=0.109.0,<1.0
 uvicorn[standard]>=0.27.0,<1.0
 pydantic-settings>=2.0.0,<3.0
+pyyaml>=6.0,<7.0
 
 # Tests
 pytest>=7.0.0,<9.0

--- a/server/tests/test_datasets.py
+++ b/server/tests/test_datasets.py
@@ -1,0 +1,63 @@
+"""Tests for dataset configuration loader."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from server import datasets
+
+
+def test_load_datasets_config_missing_file(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When config path points to missing file, return empty datasets."""
+    with tempfile.TemporaryDirectory() as d:
+        path = Path(d) / "nonexistent.yaml"
+        monkeypatch.setattr(
+            "server.datasets.get_settings",
+            lambda: type("S", (), {"datasets_config_path": str(path)})(),
+        )
+        # Force reload of config path
+        assert path.exists() is False
+        result = datasets.load_datasets_config()
+    assert result == {"datasets": []}
+
+
+def test_get_schema_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    """get_schema returns schema when dataset_id exists in config."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        f.write("""
+datasets:
+  - dataset_id: test_ds
+    fields:
+      - name: id
+        type: string
+        is_dimension: true
+""")
+        path = f.name
+    try:
+        monkeypatch.setattr(
+            "server.datasets.get_settings",
+            lambda: type("S", (), {"datasets_config_path": path})(),
+        )
+        schema = datasets.get_schema("test_ds")
+        assert schema is not None
+        assert schema["dataset_id"] == "test_ds"
+        assert len(schema["fields"]) == 1
+        assert schema["fields"][0]["name"] == "id"
+    finally:
+        Path(path).unlink()
+
+
+def test_get_schema_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    """get_schema returns None when dataset_id is not in config."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        f.write("datasets: []")
+        path = f.name
+    try:
+        monkeypatch.setattr(
+            "server.datasets.get_settings",
+            lambda: type("S", (), {"datasets_config_path": path})(),
+        )
+        assert datasets.get_schema("missing") is None
+    finally:
+        Path(path).unlink()


### PR DESCRIPTION
Fixes #3

## Summary
- Dataset config loader: YAML with dataset_id and fields (name, type, is_dimension, is_measure)
- Config path: QUERYSERVICE_DATASETS_CONFIG_PATH or server/datasets_config/datasets.yaml
- get_schema(dataset_id) for GET /schema (issue #4)
- Unit tests; pyyaml dependency

Made with [Cursor](https://cursor.com)