### PR TITLE
[A2.2] Implement GET /schema

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -11,7 +11,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
 from server.config import get_settings
-from server.routers import health
+from server.routers import health, schema
 
 
 # Configure logging before creating app
@@ -44,6 +44,7 @@ app = FastAPI(
 )
 
 app.include_router(health.router)
+app.include_router(schema.router)
 
 
 if __name__ == "__main__":

--- a/server/routers/schema.py
+++ b/server/routers/schema.py
@@ -1,0 +1,21 @@
+"""
+Schema endpoint: GET /schema per tech spec.
+"""
+
+from fastapi import APIRouter, HTTPException
+
+from server import datasets
+
+router = APIRouter(tags=["schema"])
+
+
+@router.get("/schema")
+def get_schema(dataset_id: str) -> dict:
+    """
+    Fetch schema metadata for a dataset.
+    GET /schema?dataset_id=trades_v1
+    """
+    schema = datasets.get_schema(dataset_id)
+    if schema is None:
+        raise HTTPException(status_code=404, detail=f"Dataset not found: {dataset_id}")
+    return schema

--- a/server/tests/test_schema_api.py
+++ b/server/tests/test_schema_api.py
@@ -1,0 +1,27 @@
+"""Tests for GET /schema API."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from server.main import app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def test_schema_found(client: TestClient) -> None:
+    """GET /schema?dataset_id=trades_v1 returns 200 and schema (from default config)."""
+    r = client.get("/schema", params={"dataset_id": "trades_v1"})
+    assert r.status_code == 200
+    data = r.json()
+    assert data["dataset_id"] == "trades_v1"
+    assert "fields" in data
+    assert any(f["name"] == "symbol" for f in data["fields"])
+
+
+def test_schema_not_found(client: TestClient) -> None:
+    """GET /schema?dataset_id=nonexistent returns 404."""
+    r = client.get("/schema", params={"dataset_id": "nonexistent"})
+    assert r.status_code == 404


### PR DESCRIPTION
Fixes #4

## Summary
- GET /schema?dataset_id=<id> returns schema (dataset_id, fields) from config loader
- 404 when dataset not found
- API tests added

Made with [Cursor](https://cursor.com)