### PR TITLE
[A3.1] Analytical engine integration (DuckDB in-process)

### DIFF
--- a/server/engine.py
+++ b/server/engine.py
@@ -1,0 +1,31 @@
+"""
+Analytical engine integration: DuckDB in-process.
+
+Provides a thin wrapper to execute SQL (e.g. over parquet). S3 connectivity
+and partition paths are added in a later issue.
+"""
+
+from typing import Any
+
+import duckdb
+
+
+def execute_sql(sql: str, parameters: tuple[Any, ...] | None = None) -> list[list[Any]]:
+    """
+    Execute a SQL query using an in-process DuckDB connection.
+    Returns rows as list of lists. Use for read-only queries.
+    """
+    conn = duckdb.connect(":memory:")
+    try:
+        if parameters:
+            result = conn.execute(sql, parameters).fetchall()
+        else:
+            result = conn.execute(sql).fetchall()
+        return [list(row) for row in result]
+    finally:
+        conn.close()
+
+
+def get_connection() -> duckdb.DuckDBPyConnection:
+    """Return a new in-memory DuckDB connection for callers that need a connection."""
+    return duckdb.connect(":memory:")

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -5,6 +5,7 @@ fastapi>=0.109.0,<1.0
 uvicorn[standard]>=0.27.0,<1.0
 pydantic-settings>=2.0.0,<3.0
 pyyaml>=6.0,<7.0
+duckdb>=0.10.0,<1.0
 
 # Tests
 pytest>=7.0.0,<9.0

--- a/server/tests/test_engine.py
+++ b/server/tests/test_engine.py
@@ -1,0 +1,25 @@
+"""Tests for DuckDB engine integration."""
+
+from server import engine
+
+
+def test_execute_sql_simple() -> None:
+    """execute_sql runs a simple query and returns rows."""
+    rows = engine.execute_sql("SELECT 1 AS x")
+    assert rows == [[1]]
+
+
+def test_execute_sql_with_params() -> None:
+    """execute_sql accepts parameters."""
+    rows = engine.execute_sql("SELECT ?::int AS v", (42,))
+    assert rows == [[42]]
+
+
+def test_get_connection() -> None:
+    """get_connection returns a DuckDB connection that can run queries."""
+    conn = engine.get_connection()
+    try:
+        r = conn.execute("SELECT 2").fetchone()
+        assert r == (2,)
+    finally:
+        conn.close()


### PR DESCRIPTION
Fixes #5

## Summary
- DuckDB in-process: server/engine.py with execute_sql() and get_connection()
- Used by query endpoints; S3 in #6
- Unit tests

Made with [Cursor](https://cursor.com)