### PR TITLE
[A3.2] S3 connectivity and sample partition read

### DIFF
--- a/server/s3.py
+++ b/server/s3.py
@@ -1,0 +1,77 @@
+"""
+S3 connectivity and partition path handling.
+
+Builds partition paths per tech spec and provides a sample partition read
+using DuckDB with the httpfs extension.
+"""
+
+from typing import Optional
+
+import duckdb
+
+from server.config import get_settings
+
+
+def build_partition_path(
+    bucket: str,
+    dataset_id: str,
+    date_str: str,
+) -> str:
+    """
+    Build S3 path for a partition per tech spec:
+    s3://<bucket>/<dataset_id>/date=<YYYY-MM-DD>/
+    """
+    return f"s3://{bucket}/{dataset_id}/date={date_str}/"
+
+
+def sample_partition_read(
+    bucket: str,
+    dataset_id: str,
+    date_str: str,
+    *,
+    region: Optional[str] = None,
+    path_override: Optional[str] = None,
+) -> int:
+    """
+    Run a sample read over a partition: COUNT(*) from parquet at the partition path.
+    Uses DuckDB with httpfs for S3; AWS credentials from env (e.g. AWS_ACCESS_KEY_ID).
+    Returns row count. Raises on connection/read errors.
+    If path_override is set (e.g. local path for tests), use it instead of S3 path.
+    """
+    if path_override is not None:
+        pattern = path_override
+    else:
+        path = build_partition_path(bucket, dataset_id, date_str)
+        pattern = f"{path}*.parquet"
+
+    conn = duckdb.connect(":memory:")
+    try:
+        if path_override is None:
+            conn.execute("INSTALL httpfs; LOAD httpfs;")
+            if region:
+                conn.execute(f"SET s3_region='{region}';")
+        rows = conn.execute(
+            "SELECT count(*) FROM read_parquet(?)", [pattern]
+        ).fetchone()
+        return int(rows[0]) if rows else 0
+    finally:
+        conn.close()
+
+
+def sample_partition_read_if_configured(
+    dataset_id: str,
+    date_str: str,
+) -> Optional[int]:
+    """
+    Run sample_partition_read if S3 is configured (bucket set).
+    Returns count or None if bucket not configured.
+    """
+    settings = get_settings()
+    if not settings.s3_bucket:
+        return None
+    return sample_partition_read(
+        settings.s3_bucket,
+        dataset_id,
+        date_str,
+        region=settings.s3_region,
+    )

--- a/server/tests/test_s3.py
+++ b/server/tests/test_s3.py
@@ -1,0 +1,35 @@
+"""Tests for S3 connectivity and sample partition read."""
+
+from pathlib import Path
+
+import duckdb
+
+from server import s3
+
+
+def test_build_partition_path() -> None:
+    """Partition path follows tech spec: s3://bucket/dataset_id/date=YYYY-MM-DD/."""
+    path = s3.build_partition_path("my-bucket", "trades_v1", "2026-03-01")
+    assert path == "s3://my-bucket/trades_v1/date=2026-03-01/"
+
+
+def test_sample_partition_read_local(tmp_path: Path) -> None:
+    """sample_partition_read with path_override reads local parquet."""
+    parquet_file = tmp_path / "part-0.parquet"
+    conn = duckdb.connect(":memory:")
+    conn.execute("CREATE TABLE t AS SELECT 1 AS a, 2 AS b")
+    conn.execute(f"COPY t TO '{parquet_file}' (FORMAT PARQUET)")
+    conn.close()
+
+    count = s3.sample_partition_read(
+        "b", "d", "2026-01-01",
+        path_override=str(parquet_file),
+    )
+    assert count == 1
+
+
+def test_sample_partition_read_if_configured_no_bucket() -> None:
+    """When s3_bucket is not set, returns None (default config)."""
+    # Default config has s3_bucket=None
+    result = s3.sample_partition_read_if_configured("ds", "2026-01-01")
+    assert result is None


### PR DESCRIPTION
Fixes #6

## Summary
- build_partition_path() per tech spec (s3://bucket/dataset_id/date=...)
- sample_partition_read() with DuckDB httpfs; path_override for tests
- sample_partition_read_if_configured() when bucket set in config
- Unit tests

Made with [Cursor](https://cursor.com)