### PR TITLE
[A4.1] Implement POST /query/tuples (basic)

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -11,7 +11,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
 from server.config import get_settings
-from server.routers import health, schema
+from server.routers import health, query, schema
 
 
 # Configure logging before creating app
@@ -44,6 +44,7 @@ app = FastAPI(
 )
 
 app.include_router(health.router)
+app.include_router(query.router)
 app.include_router(schema.router)
 
 

--- a/server/models.py
+++ b/server/models.py
@@ -1,0 +1,66 @@
+"""
+Request/response models for QueryService API (tech spec).
+"""
+
+from typing import Any, Optional
+
+from pydantic import BaseModel
+
+
+# --- Date range (envelope) ---
+class DateRangeSingle(BaseModel):
+    type: str = "single"
+    date: str
+
+
+class DateRangeRange(BaseModel):
+    type: str = "range"
+    start: str
+    end: str
+
+
+# --- Common envelope ---
+class ClientContext(BaseModel):
+    user_id: Optional[str] = None
+    request_id: Optional[str] = None
+    huey_version: Optional[str] = None
+
+
+class QueryTuplesRequest(BaseModel):
+    """POST /query/tuples body (envelope)."""
+
+    dataset_id: str
+    date_range: dict[str, Any]  # single: {type, date} | range: {type, start, end}
+    query: dict[str, Any]  # axis, fields, filters, paging
+    client_context: Optional[ClientContext] = None
+
+
+# --- Tuples query (inside query field) ---
+class TupleFieldSpec(BaseModel):
+    field: str
+    derivation: Optional[str] = None
+    sort: Optional[str] = None
+    include_totals: Optional[bool] = None
+
+
+class TupleFilter(BaseModel):
+    field: str
+    operator: str
+    values: list[Any]
+
+
+class PagingSpec(BaseModel):
+    limit: int = 100
+    offset: int = 0
+
+
+# --- Tuples response ---
+class TupleItem(BaseModel):
+    values: list[Any]
+    grouping_id: Optional[int] = None
+
+
+class TuplesResponse(BaseModel):
+    total_count: int
+    items: list[TupleItem]
+    paging: dict[str, int]  # limit, offset, returned

--- a/server/routers/query.py
+++ b/server/routers/query.py
@@ -1,0 +1,51 @@
+"""
+Query endpoints: /query/tuples, /query/cells, /query/picklist (tech spec).
+"""
+
+from fastapi import APIRouter, HTTPException
+
+from server import datasets
+from server.models import QueryTuplesRequest, TuplesResponse
+
+router = APIRouter(prefix="/query", tags=["query"])
+
+
+def _get_date_from_range(date_range: dict) -> str | None:
+    """Extract a single date for partition path (single day or range start)."""
+    if not date_range:
+        return None
+    t = date_range.get("type")
+    if t == "single":
+        return date_range.get("date")
+    if t == "range":
+        return date_range.get("start")
+    return None
+
+
+@router.post("/tuples", response_model=TuplesResponse)
+def post_query_tuples(body: QueryTuplesRequest) -> TuplesResponse:
+    """
+    POST /query/tuples: fetch row or column headers (tuples) for one axis.
+    Basic implementation: validates request, returns empty result or stub.
+    """
+    dataset_id = body.dataset_id
+    schema = datasets.get_schema(dataset_id)
+    if schema is None:
+        raise HTTPException(status_code=404, detail=f"Dataset not found: {dataset_id}")
+
+    date_range = body.date_range
+    date_str = _get_date_from_range(date_range)
+    if not date_str:
+        raise HTTPException(status_code=400, detail="Invalid date_range")
+
+    query = body.query or {}
+    paging = query.get("paging") or {}
+    limit = paging.get("limit", 200)
+    offset = paging.get("offset", 0)
+
+    # Basic: return empty tuple set; real engine wiring in later iterations
+    return TuplesResponse(
+        total_count=0,
+        items=[],
+        paging={"limit": limit, "offset": offset, "returned": 0},
+    )

--- a/server/tests/test_query_tuples_api.py
+++ b/server/tests/test_query_tuples_api.py
@@ -1,0 +1,49 @@
+"""Tests for POST /query/tuples API."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from server.main import app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def test_query_tuples_ok(client: TestClient) -> None:
+    """POST /query/tuples with valid envelope returns 200 and tuple response shape."""
+    body = {
+        "dataset_id": "trades_v1",
+        "date_range": {"type": "single", "date": "2026-03-01"},
+        "query": {"axis": "rows", "fields": [{"field": "symbol"}], "paging": {"limit": 10, "offset": 0}},
+    }
+    r = client.post("/query/tuples", json=body)
+    assert r.status_code == 200
+    data = r.json()
+    assert "total_count" in data
+    assert "items" in data
+    assert "paging" in data
+    assert data["paging"]["returned"] == 0
+
+
+def test_query_tuples_dataset_not_found(client: TestClient) -> None:
+    """POST /query/tuples with unknown dataset_id returns 404."""
+    body = {
+        "dataset_id": "nonexistent",
+        "date_range": {"type": "single", "date": "2026-03-01"},
+        "query": {},
+    }
+    r = client.post("/query/tuples", json=body)
+    assert r.status_code == 404
+
+
+def test_query_tuples_bad_date_range(client: TestClient) -> None:
+    """POST /query/tuples with invalid date_range returns 400."""
+    body = {
+        "dataset_id": "trades_v1",
+        "date_range": {},
+        "query": {},
+    }
+    r = client.post("/query/tuples", json=body)
+    assert r.status_code == 400


### PR DESCRIPTION
Fixes #7

## Summary
- POST /query/tuples with envelope (dataset_id, date_range, query)
- Validates dataset and date_range; returns TuplesResponse (basic: empty items)
- Pydantic models; API tests

Made with [Cursor](https://cursor.com)