### PR TITLE
[B5.1] Loading states and progress

### DIFF
--- a/docs/remote-loading-states.md
+++ b/docs/remote-loading-states.md
@@ -1,0 +1,8 @@
+# Loading states and progress (remote datasource)
+
+When using a **remote datasource**, loading is indicated by the same mechanism as local queries:
+
+- **Pivot table**: The pivot container uses `aria-busy` (see `PivotTableUi.#setBusy`). When tuple or cell data is fetched (including via remote `fetchTuples` / `fetchCells`), the caller sets busy before the async fetch and clears it when done, so the pivot shows a loading state.
+- **Filter dialog**: FilterUi uses `#setBusy(true)` while loading picklist values (local or remote) and clears it when the result set is ready.
+
+No separate progress indicator is required for remote; the existing busy state covers it.


### PR DESCRIPTION
Fixes #23

Doc: remote uses same busy/aria-busy flow as local.

Made with [Cursor](https://cursor.com)