### PR TITLE
Backend unit tests: validators, config, date-range API (#25)

### DIFF
--- a/server/tests/test_config.py
+++ b/server/tests/test_config.py
@@ -1,0 +1,27 @@
+"""Unit tests for QueryService config."""
+
+import pytest
+
+from server.config import Settings, get_settings
+
+
+def test_get_settings_returns_settings() -> None:
+    """get_settings returns a Settings instance."""
+    s = get_settings()
+    assert isinstance(s, Settings)
+    assert s.host == "0.0.0.0"
+    assert s.port == 8000
+    assert s.log_level == "INFO"
+
+
+def test_get_settings_cached() -> None:
+    """get_settings is cached (same instance)."""
+    assert get_settings() is get_settings()
+
+
+def test_settings_defaults() -> None:
+    """Settings have expected defaults for optional fields."""
+    s = get_settings()
+    assert hasattr(s, "datasets_config_path")
+    assert hasattr(s, "s3_bucket")
+    assert hasattr(s, "s3_region")

--- a/server/tests/test_export_api.py
+++ b/server/tests/test_export_api.py
@@ -40,3 +40,10 @@ def test_get_export_not_found(client: TestClient) -> None:
     """GET /export/{id} for unknown id returns 404."""
     r = client.get("/export/exp-nonexistent")
     assert r.status_code == 404
+
+
+def test_post_export_bad_date_range(client: TestClient) -> None:
+    """POST /export with invalid date_range returns 400."""
+    body = {"dataset_id": "trades_v1", "date_range": {"type": "range", "start": "2026-03-01", "end": "2026-01-01"}, "query": {}}
+    r = client.post("/export", json=body)
+    assert r.status_code == 400

--- a/server/tests/test_query_cells_api.py
+++ b/server/tests/test_query_cells_api.py
@@ -33,3 +33,10 @@ def test_query_cells_dataset_not_found(client: TestClient) -> None:
     body = {"dataset_id": "nonexistent", "date_range": {"type": "single", "date": "2026-03-01"}, "query": {}}
     r = client.post("/query/cells", json=body)
     assert r.status_code == 404
+
+
+def test_query_cells_bad_date_range(client: TestClient) -> None:
+    """POST /query/cells with invalid date_range returns 400."""
+    body = {"dataset_id": "trades_v1", "date_range": {}, "query": {}}
+    r = client.post("/query/cells", json=body)
+    assert r.status_code == 400

--- a/server/tests/test_query_picklist_api.py
+++ b/server/tests/test_query_picklist_api.py
@@ -31,3 +31,10 @@ def test_query_picklist_dataset_not_found(client: TestClient) -> None:
     body = {"dataset_id": "nonexistent", "date_range": {"type": "single", "date": "2026-03-01"}, "query": {}}
     r = client.post("/query/picklist", json=body)
     assert r.status_code == 404
+
+
+def test_query_picklist_bad_date_range(client: TestClient) -> None:
+    """POST /query/picklist with invalid date_range returns 400."""
+    body = {"dataset_id": "trades_v1", "date_range": {"type": "single", "date": "not-a-date"}, "query": {}}
+    r = client.post("/query/picklist", json=body)
+    assert r.status_code == 400

--- a/server/tests/test_validators.py
+++ b/server/tests/test_validators.py
@@ -1,0 +1,76 @@
+"""Unit tests for request validators (date-range guardrails)."""
+
+import pytest
+
+from server.validators import validate_date_range
+
+
+def test_validate_date_range_single_ok() -> None:
+    """Single date YYYY-MM-DD returns (date, None)."""
+    date_str, err = validate_date_range({"type": "single", "date": "2026-03-01"})
+    assert date_str == "2026-03-01"
+    assert err is None
+
+
+def test_validate_date_range_single_invalid_date() -> None:
+    """Single date with bad format returns error."""
+    _, err = validate_date_range({"type": "single", "date": "03-01-2026"})
+    assert err == "Invalid date (use YYYY-MM-DD)"
+    _, err2 = validate_date_range({"type": "single", "date": ""})
+    assert err2 == "Invalid date (use YYYY-MM-DD)"
+    _, err3 = validate_date_range({"type": "single"})
+    assert err3 == "Invalid date (use YYYY-MM-DD)"
+
+
+def test_validate_date_range_range_ok() -> None:
+    """Range with start <= end returns (start, None)."""
+    date_str, err = validate_date_range({
+        "type": "range",
+        "start": "2026-01-01",
+        "end": "2026-03-01",
+    })
+    assert date_str == "2026-01-01"
+    assert err is None
+    date_str2, err2 = validate_date_range({
+        "type": "range",
+        "start": "2026-03-01",
+        "end": "2026-03-01",
+    })
+    assert date_str2 == "2026-03-01"
+    assert err2 is None
+
+
+def test_validate_date_range_range_start_after_end() -> None:
+    """Range with start > end returns error."""
+    _, err = validate_date_range({
+        "type": "range",
+        "start": "2026-03-01",
+        "end": "2026-01-01",
+    })
+    assert err == "Date range start must be <= end"
+
+
+def test_validate_date_range_range_invalid_start_or_end() -> None:
+    """Range with invalid start or end returns error."""
+    _, err = validate_date_range({"type": "range", "start": "2026-01-01", "end": "bad"})
+    assert err == "Invalid range end (use YYYY-MM-DD)"
+    _, err2 = validate_date_range({"type": "range", "start": "bad", "end": "2026-01-01"})
+    assert err2 == "Invalid range start (use YYYY-MM-DD)"
+    _, err3 = validate_date_range({"type": "range", "end": "2026-01-01"})
+    assert err3 == "Invalid range start (use YYYY-MM-DD)"
+
+
+def test_validate_date_range_invalid_type() -> None:
+    """Unknown type returns error."""
+    _, err = validate_date_range({"type": "weekly", "date": "2026-03-01"})
+    assert err == "Invalid date_range type (use single or range)"
+
+
+def test_validate_date_range_empty_or_not_dict() -> None:
+    """Missing or non-dict date_range returns error."""
+    _, err = validate_date_range({})
+    assert err == "Invalid date_range"
+    _, err2 = validate_date_range(None)
+    assert err2 == "Invalid date_range"
+    _, err3 = validate_date_range([])
+    assert err3 == "Invalid date_range"


### PR DESCRIPTION
Fixes #25

[C1.1] Expand backend unit test coverage:
- test_validators.py: full coverage of validate_date_range (single, range, invalid type, empty)
- test_config.py: get_settings and Settings defaults
- test_query_cells_api, test_query_picklist_api, test_export_api: 400 on invalid date_range

Made with [Cursor](https://cursor.com)