### PR TITLE
Convert all route handlers to async def

### DIFF
--- a/server/routers/export.py
+++ b/server/routers/export.py
@@ -15,7 +15,7 @@ _exports: dict[str, dict] = {}
 
 
 @router.post("", response_model=ExportResponse)
-def post_export(body: ExportRequest) -> ExportResponse:
+async def post_export(body: ExportRequest) -> ExportResponse:
     """
     POST /export: submit export job. MVP returns pending; no background processing.
     """
@@ -28,7 +28,7 @@ def post_export(body: ExportRequest) -> ExportResponse:
 
 
 @router.get("/{export_id}", response_model=ExportStatusResponse)
-def get_export_status(export_id: str) -> ExportStatusResponse:
+async def get_export_status(export_id: str) -> ExportStatusResponse:
     """GET /export/{id}: return export job status (and download_url when complete)."""
     if export_id not in _exports:
         raise HTTPException(status_code=404, detail="Export not found")

--- a/server/routers/health.py
+++ b/server/routers/health.py
@@ -11,12 +11,12 @@ router = APIRouter(prefix="/health", tags=["health"])
 
 
 @router.get("/liveness")
-def liveness() -> dict:
+async def liveness() -> dict:
     """Basic liveness: process is running."""
     return {"status": "ok"}
 
 
 @router.get("/readiness")
-def readiness() -> dict:
+async def readiness() -> dict:
     """Readiness: service is ready to accept traffic. Engine/S3 checks TBD in later issues."""
     return {"status": "ok"}

--- a/server/routers/query.py
+++ b/server/routers/query.py
@@ -28,7 +28,7 @@ def _get_date_str(date_range: DateRangeSingle | DateRangeRange) -> str:
 
 
 @router.post("/tuples", response_model=TuplesResponse)
-def post_query_tuples(body: QueryTuplesRequest) -> TuplesResponse:
+async def post_query_tuples(body: QueryTuplesRequest) -> TuplesResponse:
     """
     POST /query/tuples: fetch row or column headers (tuples) for one axis.
     Basic implementation: validates request, returns empty result or stub.
@@ -49,7 +49,7 @@ def post_query_tuples(body: QueryTuplesRequest) -> TuplesResponse:
 
 
 @router.post("/cells", response_model=CellsResponse)
-def post_query_cells(body: QueryCellsRequest) -> CellsResponse:
+async def post_query_cells(body: QueryCellsRequest) -> CellsResponse:
     """
     POST /query/cells: fetch cell values for a window of row/column tuples.
     Basic implementation: validates request, returns empty cells.
@@ -62,7 +62,7 @@ def post_query_cells(body: QueryCellsRequest) -> CellsResponse:
 
 
 @router.post("/picklist", response_model=PicklistResponse)
-def post_query_picklist(body: QueryPicklistRequest) -> PicklistResponse:
+async def post_query_picklist(body: QueryPicklistRequest) -> PicklistResponse:
     """
     POST /query/picklist: fetch distinct values for a field (filter UI).
     Basic implementation: validates request, returns empty values.

--- a/server/routers/schema.py
+++ b/server/routers/schema.py
@@ -10,7 +10,7 @@ router = APIRouter(tags=["schema"])
 
 
 @router.get("/schema")
-def get_schema(dataset_id: str) -> dict:
+async def get_schema(dataset_id: str) -> dict:
     """
     Fetch schema metadata for a dataset.
     GET /schema?dataset_id=trades_v1


### PR DESCRIPTION
## Summary
- Converts all 8 route handlers across 4 router files from sync `def` to `async def`
- Prepares handlers for non-blocking DuckDB execution via `asyncio.to_thread` (when #64 wires in real queries)

## Changes
- `server/routers/query.py` — 3 handlers: `post_query_tuples`, `post_query_cells`, `post_query_picklist`
- `server/routers/export.py` — 2 handlers: `post_export`, `get_export_status`
- `server/routers/schema.py` — 1 handler: `get_schema`
- `server/routers/health.py` — 2 handlers: `liveness`, `readiness`

## Test plan
- [x] All 68 tests pass (FastAPI TestClient handles async handlers transparently)
- [x] Ruff lint clean

Closes #68

Made with [Cursor](https://cursor.com)