### PR TITLE
Add background processing and TTL cleanup for export jobs

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -31,6 +31,11 @@ class Settings(BaseSettings):
     # DuckDB
     data_dir: Optional[str] = None  # Path to DuckDB database file; None = in-memory
 
+    # Export
+    export_ttl_seconds: int = 3600
+    export_max_concurrent: int = 5
+    export_output_dir: str = "/tmp/huey-exports"
+
     # Optional: S3 / engine config (for later issues)
     s3_bucket: Optional[str] = None
     s3_region: Optional[str] = None

--- a/server/routers/export.py
+++ b/server/routers/export.py
@@ -1,29 +1,103 @@
 """
-Export endpoint: POST /export, GET /export/{id} (MVP).
+Export endpoint: POST /export, GET /export/{id}, GET /export/{id}/download.
+
+Supports background processing via FastAPI BackgroundTasks, TTL-based cleanup,
+and a configurable max concurrent export limit.
 """
 
+import logging
+import time
 import uuid
+from pathlib import Path
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, BackgroundTasks, HTTPException
+from fastapi.responses import FileResponse
 
 from server import datasets
+from server.config import get_settings
+from server.engine import db_manager
 from server.models import ExportRequest, ExportResponse, ExportStatusResponse
+
+logger = logging.getLogger("query_service.export")
 
 router = APIRouter(prefix="/export", tags=["export"])
 
 _exports: dict[str, dict] = {}
 
 
+def _cleanup_expired() -> None:
+    """Remove exports older than TTL and delete their files."""
+    settings = get_settings()
+    now = time.time()
+    expired = [
+        k for k, v in _exports.items()
+        if now - v.get("created_at", 0) > settings.export_ttl_seconds
+    ]
+    for k in expired:
+        job = _exports.pop(k, None)
+        if job and job.get("file_path"):
+            Path(job["file_path"]).unlink(missing_ok=True)
+            logger.info("Expired export cleaned up", extra={"export_id": k})
+
+
+def _active_count() -> int:
+    """Count exports currently in pending or processing state."""
+    return sum(
+        1 for v in _exports.values()
+        if v.get("status") in ("pending", "processing")
+    )
+
+
+def _process_export(export_id: str, body: ExportRequest) -> None:
+    """Background task: run query, write CSV, update status."""
+    try:
+        _exports[export_id]["status"] = "processing"
+        settings = get_settings()
+        output_dir = Path(settings.export_output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        file_path = output_dir / f"{export_id}.csv"
+
+        # Placeholder: real SQL generation comes with #64
+        rows = db_manager.execute_sql("SELECT 1 AS placeholder")
+
+        with open(file_path, "w") as f:
+            for row in rows:
+                f.write(",".join(str(v) for v in row) + "\n")
+
+        _exports[export_id]["status"] = "complete"
+        _exports[export_id]["file_path"] = str(file_path)
+        _exports[export_id]["download_url"] = f"/export/{export_id}/download"
+        logger.info("Export complete", extra={"export_id": export_id})
+    except Exception:
+        _exports[export_id]["status"] = "failed"
+        logger.exception("Export failed", extra={"export_id": export_id})
+
+
 @router.post("", response_model=ExportResponse)
-async def post_export(body: ExportRequest) -> ExportResponse:
-    """
-    POST /export: submit export job. MVP returns pending; no background processing.
-    """
+async def post_export(
+    body: ExportRequest,
+    background_tasks: BackgroundTasks,
+) -> ExportResponse:
+    """POST /export: submit export job with background processing."""
     if datasets.get_schema(body.dataset_id) is None:
         raise HTTPException(status_code=404, detail=f"Dataset not found: {body.dataset_id}")
 
+    _cleanup_expired()
+
+    settings = get_settings()
+    if _active_count() >= settings.export_max_concurrent:
+        raise HTTPException(
+            status_code=429,
+            detail=f"Too many concurrent exports (max {settings.export_max_concurrent})",
+        )
+
     export_id = "exp-" + str(uuid.uuid4())[:8]
-    _exports[export_id] = {"status": "pending", "dataset_id": body.dataset_id}
+    _exports[export_id] = {
+        "status": "pending",
+        "dataset_id": body.dataset_id,
+        "created_at": time.time(),
+    }
+    background_tasks.add_task(_process_export, export_id, body)
     return ExportResponse(export_id=export_id, status="pending")
 
 
@@ -37,4 +111,22 @@ async def get_export_status(export_id: str) -> ExportStatusResponse:
         export_id=export_id,
         status=job.get("status", "pending"),
         download_url=job.get("download_url"),
+    )
+
+
+@router.get("/{export_id}/download")
+async def download_export(export_id: str) -> FileResponse:
+    """GET /export/{id}/download: download the completed export file."""
+    if export_id not in _exports:
+        raise HTTPException(status_code=404, detail="Export not found")
+    job = _exports[export_id]
+    if job.get("status") != "complete":
+        raise HTTPException(status_code=409, detail=f"Export not ready (status: {job.get('status')})")
+    file_path = job.get("file_path")
+    if not file_path or not Path(file_path).exists():
+        raise HTTPException(status_code=404, detail="Export file not found")
+    return FileResponse(
+        path=file_path,
+        filename=f"{export_id}.csv",
+        media_type="text/csv",
     )

--- a/server/tests/test_export_api.py
+++ b/server/tests/test_export_api.py
@@ -1,9 +1,12 @@
-"""Tests for POST /export and GET /export/{id}."""
+"""Tests for POST /export, GET /export/{id}, and GET /export/{id}/download."""
+
+import time
 
 import pytest
 from fastapi.testclient import TestClient
 
 from server.main import app
+from server.routers import export as export_module
 
 
 @pytest.fixture
@@ -11,29 +14,45 @@ def client() -> TestClient:
     return TestClient(app)
 
 
-def test_post_export_ok(client: TestClient) -> None:
-    """POST /export with valid envelope returns 200 and export_id."""
+@pytest.fixture(autouse=True)
+def _clear_exports():
+    """Reset the export store between tests."""
+    export_module._exports.clear()
+    yield
+    export_module._exports.clear()
+
+
+def _valid_body(**overrides):
     body = {
         "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
         "query": {"export_type": "pivot_results", "axes": {}, "filters": [], "max_rows": 1000, "format": "csv"},
     }
-    r = client.post("/export", json=body)
+    body.update(overrides)
+    return body
+
+
+def test_post_export_ok(client: TestClient) -> None:
+    """POST /export with valid envelope returns 200 and export_id."""
+    r = client.post("/export", json=_valid_body())
     assert r.status_code == 200
     data = r.json()
+    assert data["export_id"].startswith("exp-")
     assert data["status"] == "pending"
-    assert "export_id" in data and data["export_id"].startswith("exp-")
 
 
-def test_get_export_status(client: TestClient) -> None:
-    """GET /export/{id} after POST returns status."""
-    body = {"dataset_id": "trades_v1", "date_range": {"type": "single", "date": "2026-03-01"}, "query": {}}
-    post_r = client.post("/export", json=body)
+def test_export_lifecycle(client: TestClient) -> None:
+    """POST creates job, background task processes it, GET shows complete with download_url."""
+    post_r = client.post("/export", json=_valid_body())
     export_id = post_r.json()["export_id"]
+
     r = client.get(f"/export/{export_id}")
     assert r.status_code == 200
-    assert r.json()["export_id"] == export_id
-    assert r.json()["status"] == "pending"
+    status = r.json()["status"]
+    assert status in ("pending", "processing", "complete")
+
+    if status == "complete":
+        assert r.json()["download_url"] == f"/export/{export_id}/download"
 
 
 def test_get_export_not_found(client: TestClient) -> None:
@@ -44,6 +63,61 @@ def test_get_export_not_found(client: TestClient) -> None:
 
 def test_post_export_bad_date_range(client: TestClient) -> None:
     """POST /export with inverted date range returns 422."""
-    body = {"dataset_id": "trades_v1", "date_range": {"type": "range", "start": "2026-03-01", "end": "2026-01-01"}, "query": {}}
+    body = {
+        "dataset_id": "trades_v1",
+        "date_range": {"type": "range", "start": "2026-03-01", "end": "2026-01-01"},
+        "query": {},
+    }
     r = client.post("/export", json=body)
     assert r.status_code == 422
+
+
+def test_post_export_dataset_not_found(client: TestClient) -> None:
+    """POST /export with unknown dataset returns 404."""
+    r = client.post("/export", json=_valid_body(dataset_id="nonexistent"))
+    assert r.status_code == 404
+
+
+def test_download_not_found(client: TestClient) -> None:
+    """GET /export/{id}/download for unknown id returns 404."""
+    r = client.get("/export/exp-nonexistent/download")
+    assert r.status_code == 404
+
+
+def test_download_not_ready(client: TestClient) -> None:
+    """GET /export/{id}/download before completion returns 409."""
+    export_module._exports["exp-test"] = {
+        "status": "processing",
+        "created_at": time.time(),
+    }
+    r = client.get("/export/exp-test/download")
+    assert r.status_code == 409
+
+
+def test_max_concurrent_limit(client: TestClient) -> None:
+    """POST /export returns 429 when max concurrent exports exceeded."""
+    for i in range(5):
+        export_module._exports[f"exp-active-{i}"] = {
+            "status": "processing",
+            "created_at": time.time(),
+        }
+    r = client.post("/export", json=_valid_body())
+    assert r.status_code == 429
+    assert "concurrent" in r.json()["detail"].lower()
+
+
+def test_ttl_cleanup(client: TestClient, tmp_path) -> None:
+    """Expired exports are cleaned up on new POST."""
+    expired_file = tmp_path / "exp-old.csv"
+    expired_file.write_text("old data")
+
+    export_module._exports["exp-old"] = {
+        "status": "complete",
+        "created_at": time.time() - 7200,
+        "file_path": str(expired_file),
+    }
+
+    r = client.post("/export", json=_valid_body())
+    assert r.status_code == 200
+    assert "exp-old" not in export_module._exports
+    assert not expired_file.exists()

--- a/server/tests/test_integration.py
+++ b/server/tests/test_integration.py
@@ -86,11 +86,11 @@ def test_full_api_flow(client: TestClient) -> None:
     assert data["status"] == "pending"
     export_id = data["export_id"]
 
-    # 6. Export status
+    # 6. Export status (background task may have completed already)
     r_export_get = client.get(f"/export/{export_id}")
     assert r_export_get.status_code == 200
     assert r_export_get.json()["export_id"] == export_id
-    assert r_export_get.json()["status"] == "pending"
+    assert r_export_get.json()["status"] in ("pending", "processing", "complete")
 
 
 def test_health_then_schema(client: TestClient) -> None:


### PR DESCRIPTION
## Summary
- Export jobs are now processed via `BackgroundTasks` with full lifecycle tracking (pending → processing → complete/failed)
- Expired exports cleaned up automatically (TTL-based) with file deletion
- Configurable max concurrent exports; returns 429 when limit exceeded
- New `GET /export/{id}/download` endpoint serves completed CSV files

## Changes
- `server/config.py` — added `export_ttl_seconds`, `export_max_concurrent`, `export_output_dir`
- `server/routers/export.py` — rewritten with background processing, TTL cleanup, download endpoint
- `server/tests/test_export_api.py` — 9 tests: lifecycle, cleanup, concurrency, download
- `server/tests/test_integration.py` — updated export status assertion for async completion

## Test plan
- [x] All 73 tests pass
- [x] Ruff lint clean
- [x] TTL cleanup removes expired jobs and files
- [x] Max concurrent limit returns 429
- [x] Download endpoint returns 409 if not ready, 404 if not found

Closes #67

Made with [Cursor](https://cursor.com)