### PR TITLE
Expand backend test coverage: validation errors, edge cases, shared fixtures

### DIFF
--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -1,9 +1,11 @@
 """Shared test fixtures for backend tests."""
 
 import pytest
+from fastapi.testclient import TestClient
 
 from server.datasets import load_sample_data
 from server.engine import db_manager
+from server.main import app
 
 
 @pytest.fixture(autouse=True, scope="session")
@@ -13,3 +15,23 @@ def _init_test_db():
     load_sample_data(db_manager)
     yield
     db_manager.shutdown()
+
+
+@pytest.fixture
+def client() -> TestClient:
+    """Shared TestClient for API tests."""
+    return TestClient(app)
+
+
+@pytest.fixture
+def valid_date_range() -> dict:
+    return {"type": "single", "date": "2026-03-01"}
+
+
+@pytest.fixture
+def valid_tuples_body() -> dict:
+    return {
+        "dataset_id": "trades_v1",
+        "date_range": {"type": "single", "date": "2026-03-01"},
+        "query": {"axis": "rows", "fields": [{"field": "symbol"}], "paging": {"limit": 10, "offset": 0}},
+    }

--- a/server/tests/test_export_api.py
+++ b/server/tests/test_export_api.py
@@ -5,13 +5,7 @@ import time
 import pytest
 from fastapi.testclient import TestClient
 
-from server.main import app
 from server.routers import export as export_module
-
-
-@pytest.fixture
-def client() -> TestClient:
-    return TestClient(app)
 
 
 @pytest.fixture(autouse=True)
@@ -121,3 +115,43 @@ def test_ttl_cleanup(client: TestClient, tmp_path) -> None:
     assert r.status_code == 200
     assert "exp-old" not in export_module._exports
     assert not expired_file.exists()
+
+
+def test_download_for_failed_export(client: TestClient) -> None:
+    """GET /export/{id}/download for a failed export returns 409."""
+    export_module._exports["exp-fail"] = {
+        "status": "failed",
+        "created_at": time.time(),
+    }
+    r = client.get("/export/exp-fail/download")
+    assert r.status_code == 409
+
+
+def test_download_file_missing_on_disk(client: TestClient) -> None:
+    """GET /export/{id}/download when file was deleted returns 404."""
+    export_module._exports["exp-gone"] = {
+        "status": "complete",
+        "created_at": time.time(),
+        "file_path": "/tmp/nonexistent-file.csv",
+        "download_url": "/export/exp-gone/download",
+    }
+    r = client.get("/export/exp-gone/download")
+    assert r.status_code == 404
+
+
+def test_ttl_preserves_active_exports(client: TestClient) -> None:
+    """TTL cleanup does not remove recent exports."""
+    export_module._exports["exp-recent"] = {
+        "status": "complete",
+        "created_at": time.time(),
+    }
+    r = client.post("/export", json=_valid_body())
+    assert r.status_code == 200
+    assert "exp-recent" in export_module._exports
+
+
+def test_multiple_exports_unique_ids(client: TestClient) -> None:
+    """Multiple POSTs create distinct export IDs."""
+    r1 = client.post("/export", json=_valid_body())
+    r2 = client.post("/export", json=_valid_body())
+    assert r1.json()["export_id"] != r2.json()["export_id"]

--- a/server/tests/test_health.py
+++ b/server/tests/test_health.py
@@ -1,14 +1,6 @@
 """Tests for QueryService health endpoints."""
 
-import pytest
 from fastapi.testclient import TestClient
-
-from server.main import app
-
-
-@pytest.fixture
-def client() -> TestClient:
-    return TestClient(app)
 
 
 def test_liveness(client: TestClient) -> None:

--- a/server/tests/test_integration.py
+++ b/server/tests/test_integration.py
@@ -5,15 +5,7 @@ Exercises schema → query (tuples, cells, picklist) → export in sequence
 using the default dataset config (no S3 required).
 """
 
-import pytest
 from fastapi.testclient import TestClient
-
-from server.main import app
-
-
-@pytest.fixture
-def client() -> TestClient:
-    return TestClient(app)
 
 
 def test_full_api_flow(client: TestClient) -> None:

--- a/server/tests/test_query_cells_api.py
+++ b/server/tests/test_query_cells_api.py
@@ -1,14 +1,6 @@
 """Tests for POST /query/cells API."""
 
-import pytest
 from fastapi.testclient import TestClient
-
-from server.main import app
-
-
-@pytest.fixture
-def client() -> TestClient:
-    return TestClient(app)
 
 
 def test_query_cells_ok(client: TestClient) -> None:

--- a/server/tests/test_query_picklist_api.py
+++ b/server/tests/test_query_picklist_api.py
@@ -1,14 +1,6 @@
 """Tests for POST /query/picklist API."""
 
-import pytest
 from fastapi.testclient import TestClient
-
-from server.main import app
-
-
-@pytest.fixture
-def client() -> TestClient:
-    return TestClient(app)
 
 
 def test_query_picklist_ok(client: TestClient) -> None:

--- a/server/tests/test_query_tuples_api.py
+++ b/server/tests/test_query_tuples_api.py
@@ -1,14 +1,6 @@
 """Tests for POST /query/tuples API."""
 
-import pytest
 from fastapi.testclient import TestClient
-
-from server.main import app
-
-
-@pytest.fixture
-def client() -> TestClient:
-    return TestClient(app)
 
 
 def test_query_tuples_ok(client: TestClient) -> None:

--- a/server/tests/test_schema_api.py
+++ b/server/tests/test_schema_api.py
@@ -1,14 +1,6 @@
 """Tests for GET /schema API."""
 
-import pytest
 from fastapi.testclient import TestClient
-
-from server.main import app
-
-
-@pytest.fixture
-def client() -> TestClient:
-    return TestClient(app)
 
 
 def test_schema_found(client: TestClient) -> None:

--- a/server/tests/test_validation_errors.py
+++ b/server/tests/test_validation_errors.py
@@ -1,0 +1,151 @@
+"""Tests for request validation (422 errors) across all endpoints."""
+
+from fastapi.testclient import TestClient
+
+
+class TestTuplesValidation:
+    def test_missing_dataset_id(self, client: TestClient) -> None:
+        r = client.post("/query/tuples", json={
+            "date_range": {"type": "single", "date": "2026-01-01"},
+            "query": {},
+        })
+        assert r.status_code == 422
+
+    def test_empty_body(self, client: TestClient) -> None:
+        r = client.post("/query/tuples", json={})
+        assert r.status_code == 422
+
+    def test_not_json(self, client: TestClient) -> None:
+        r = client.post("/query/tuples", content="not json", headers={"Content-Type": "application/json"})
+        assert r.status_code == 422
+
+    def test_dataset_id_wrong_type(self, client: TestClient) -> None:
+        r = client.post("/query/tuples", json={
+            "dataset_id": 123,
+            "date_range": {"type": "single", "date": "2026-01-01"},
+            "query": {},
+        })
+        assert r.status_code == 422
+
+    def test_date_range_unknown_type(self, client: TestClient) -> None:
+        r = client.post("/query/tuples", json={
+            "dataset_id": "trades_v1",
+            "date_range": {"type": "weekly", "date": "2026-01-01"},
+            "query": {},
+        })
+        assert r.status_code == 422
+
+    def test_date_range_null(self, client: TestClient) -> None:
+        r = client.post("/query/tuples", json={
+            "dataset_id": "trades_v1",
+            "date_range": None,
+            "query": {},
+        })
+        assert r.status_code == 422
+
+    def test_date_range_missing_date_field(self, client: TestClient) -> None:
+        r = client.post("/query/tuples", json={
+            "dataset_id": "trades_v1",
+            "date_range": {"type": "single"},
+            "query": {},
+        })
+        assert r.status_code == 422
+
+    def test_range_missing_end(self, client: TestClient) -> None:
+        r = client.post("/query/tuples", json={
+            "dataset_id": "trades_v1",
+            "date_range": {"type": "range", "start": "2026-01-01"},
+            "query": {},
+        })
+        assert r.status_code == 422
+
+    def test_filter_missing_operator(self, client: TestClient) -> None:
+        r = client.post("/query/tuples", json={
+            "dataset_id": "trades_v1",
+            "date_range": {"type": "single", "date": "2026-03-01"},
+            "query": {
+                "fields": [{"field": "symbol"}],
+                "filters": [{"field": "symbol", "values": ["AAPL"]}],
+            },
+        })
+        assert r.status_code == 422
+
+    def test_filter_missing_values(self, client: TestClient) -> None:
+        r = client.post("/query/tuples", json={
+            "dataset_id": "trades_v1",
+            "date_range": {"type": "single", "date": "2026-03-01"},
+            "query": {
+                "fields": [{"field": "symbol"}],
+                "filters": [{"field": "symbol", "operator": "INCLUDE"}],
+            },
+        })
+        assert r.status_code == 422
+
+
+class TestCellsValidation:
+    def test_missing_dataset_id(self, client: TestClient) -> None:
+        r = client.post("/query/cells", json={
+            "date_range": {"type": "single", "date": "2026-01-01"},
+            "query": {},
+        })
+        assert r.status_code == 422
+
+    def test_dataset_id_wrong_type(self, client: TestClient) -> None:
+        r = client.post("/query/cells", json={
+            "dataset_id": 123,
+            "date_range": {"type": "single", "date": "2026-01-01"},
+            "query": {},
+        })
+        assert r.status_code == 422
+
+    def test_empty_body(self, client: TestClient) -> None:
+        r = client.post("/query/cells", json={})
+        assert r.status_code == 422
+
+
+class TestPicklistValidation:
+    def test_missing_dataset_id(self, client: TestClient) -> None:
+        r = client.post("/query/picklist", json={
+            "date_range": {"type": "single", "date": "2026-01-01"},
+            "query": {},
+        })
+        assert r.status_code == 422
+
+    def test_empty_body(self, client: TestClient) -> None:
+        r = client.post("/query/picklist", json={})
+        assert r.status_code == 422
+
+    def test_bad_date_format(self, client: TestClient) -> None:
+        r = client.post("/query/picklist", json={
+            "dataset_id": "trades_v1",
+            "date_range": {"type": "single", "date": "2026/03/01"},
+            "query": {},
+        })
+        assert r.status_code == 422
+
+
+class TestExportValidation:
+    def test_missing_dataset_id(self, client: TestClient) -> None:
+        r = client.post("/export", json={
+            "date_range": {"type": "single", "date": "2026-01-01"},
+            "query": {},
+        })
+        assert r.status_code == 422
+
+    def test_empty_body(self, client: TestClient) -> None:
+        r = client.post("/export", json={})
+        assert r.status_code == 422
+
+    def test_date_range_unknown_type(self, client: TestClient) -> None:
+        r = client.post("/export", json={
+            "dataset_id": "trades_v1",
+            "date_range": {"type": "invalid"},
+            "query": {},
+        })
+        assert r.status_code == 422
+
+
+class TestSchemaValidation:
+    def test_missing_dataset_id_param(self, client: TestClient) -> None:
+        r = client.get("/schema")
+        assert r.status_code == 422

--- a/server/tests/test_validators.py
+++ b/server/tests/test_validators.py
@@ -72,3 +72,44 @@ def test_validate_date_range_empty_or_not_dict() -> None:
     assert err2 == "Invalid date_range"
     _, err3 = validate_date_range([])
     assert err3 == "Invalid date_range"
+
+
+def test_validate_date_range_integer_input() -> None:
+    """Non-dict integer input returns error."""
+    _, err = validate_date_range(42)
+    assert err == "Invalid date_range"
+
+
+def test_validate_date_range_string_input() -> None:
+    """Bare string input returns error."""
+    _, err = validate_date_range("2026-03-01")
+    assert err == "Invalid date_range"
+
+
+def test_validate_date_range_boundary_dates() -> None:
+    """Regex-valid boundary dates pass (no calendar validation)."""
+    date_str, err = validate_date_range({"type": "single", "date": "2024-02-29"})
+    assert date_str == "2024-02-29"
+    assert err is None
+    date_str2, err2 = validate_date_range({"type": "single", "date": "9999-12-31"})
+    assert date_str2 == "9999-12-31"
+    assert err2 is None
+
+
+def test_validate_date_range_extra_fields_ignored() -> None:
+    """Extra fields in the dict are ignored."""
+    date_str, err = validate_date_range({"type": "single", "date": "2026-03-01", "extra": "ignored"})
+    assert date_str == "2026-03-01"
+    assert err is None
+
+
+def test_validate_date_range_range_missing_both() -> None:
+    """Range type with neither start nor end returns error."""
+    _, err = validate_date_range({"type": "range"})
+    assert err == "Invalid range start (use YYYY-MM-DD)"
+
+
+def test_validate_date_range_single_with_numeric_date() -> None:
+    """Single date with numeric value returns error."""
+    _, err = validate_date_range({"type": "single", "date": 20260301})
+    assert err == "Invalid date (use YYYY-MM-DD)"


### PR DESCRIPTION
## Summary
- Consolidates shared `client` fixture in `conftest.py`, removing 7 duplicates
- Adds 30 new tests covering malformed requests, validator edge cases, and export error paths

## Changes
- `server/tests/conftest.py` — shared `client`, `valid_date_range`, `valid_tuples_body` fixtures
- `server/tests/test_validation_errors.py` (new) — 19 tests: missing fields, wrong types, invalid discriminators, non-JSON, missing filter components, missing query params
- `server/tests/test_validators.py` — 6 new edge cases: integer/string input, boundary dates, extra fields, numeric date
- `server/tests/test_export_api.py` — 4 new tests: failed export download, missing file, TTL preservation, unique IDs
- 7 test files cleaned up: removed duplicate fixtures and unused imports

## Test plan
- [x] All 123 tests pass (up from 93)
- [x] Ruff lint clean
- [x] Every endpoint covered for 422 validation errors

Closes #71

Made with [Cursor](https://cursor.com)