### PR TITLE
Add structured JSON logging for production observability

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -24,6 +24,7 @@ class Settings(BaseSettings):
     host: str = "0.0.0.0"
     port: int = 8000
     log_level: str = "INFO"
+    log_format: str = "text"  # "text" for dev, "json" for production
 
     # Optional: path to datasets config YAML (for dataset/schema loader)
     datasets_config_path: Optional[str] = None

--- a/server/logging_config.py
+++ b/server/logging_config.py
@@ -1,0 +1,38 @@
+"""
+Logging configuration for QueryService.
+
+Supports two formats controlled by QUERYSERVICE_LOG_FORMAT:
+- "text" (default): human-readable for development
+- "json": structured JSON for production observability
+"""
+
+import logging
+import sys
+
+from pythonjsonlogger.json import JsonFormatter
+
+
+def setup_logging(level: str = "INFO", log_format: str = "text") -> None:
+    """Configure the root logger with the specified level and format."""
+    root = logging.getLogger()
+    root.setLevel(getattr(logging, level.upper(), logging.INFO))
+
+    if root.handlers:
+        root.handlers.clear()
+
+    handler = logging.StreamHandler(sys.stdout)
+
+    if log_format == "json":
+        formatter = JsonFormatter(
+            fmt="%(asctime)s %(levelname)s %(name)s %(message)s",
+            rename_fields={"asctime": "timestamp", "levelname": "level"},
+            datefmt="%Y-%m-%dT%H:%M:%S",
+        )
+    else:
+        formatter = logging.Formatter(
+            "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+            datefmt="%Y-%m-%dT%H:%M:%S",
+        )
+
+    handler.setFormatter(formatter)
+    root.addHandler(handler)

--- a/server/main.py
+++ b/server/main.py
@@ -5,7 +5,6 @@ FastAPI application with health endpoints, config loader, and structured logging
 """
 
 import logging
-import sys
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
@@ -14,21 +13,12 @@ from fastapi.middleware.cors import CORSMiddleware
 from server.config import get_settings
 from server.datasets import load_sample_data
 from server.engine import db_manager
+from server.logging_config import setup_logging
+from server.middleware import AccessLogMiddleware
 from server.routers import export, health, query, schema
 
-
-# Configure logging before creating app
-def _setup_logging(level: str) -> None:
-    logging.basicConfig(
-        level=getattr(logging, level.upper(), logging.INFO),
-        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-        datefmt="%Y-%m-%dT%H:%M:%S",
-        stream=sys.stdout,
-    )
-
-
 settings = get_settings()
-_setup_logging(settings.log_level)
+setup_logging(settings.log_level, settings.log_format)
 logger = logging.getLogger("query_service")
 
 
@@ -49,6 +39,7 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
+app.add_middleware(AccessLogMiddleware)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["http://localhost:8765", "http://127.0.0.1:8765", "http://localhost:8080", "http://127.0.0.1:8080"],

--- a/server/middleware.py
+++ b/server/middleware.py
@@ -1,0 +1,35 @@
+"""Request middleware for QueryService."""
+
+import logging
+import time
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+logger = logging.getLogger("query_service.access")
+
+
+class AccessLogMiddleware(BaseHTTPMiddleware):
+    """Log method, path, status code, and duration for every request."""
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        start = time.perf_counter()
+        response = await call_next(request)
+        duration_ms = (time.perf_counter() - start) * 1000
+
+        logger.info(
+            "%s %s %d (%.1fms)",
+            request.method,
+            request.url.path,
+            response.status_code,
+            duration_ms,
+            extra={
+                "method": request.method,
+                "path": request.url.path,
+                "status_code": response.status_code,
+                "duration_ms": round(duration_ms, 2),
+                "client_ip": request.client.host if request.client else None,
+            },
+        )
+        return response

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -6,6 +6,7 @@ uvicorn[standard]>=0.27.0,<1.0
 pydantic-settings>=2.0.0,<3.0
 pyyaml>=6.0,<7.0
 duckdb>=0.10.0,<1.0
+python-json-logger>=3.0.0,<5.0
 
 # Tests
 pytest>=7.0.0,<9.0

--- a/server/routers/query.py
+++ b/server/routers/query.py
@@ -2,6 +2,9 @@
 Query endpoints: /query/tuples, /query/cells, /query/picklist (tech spec).
 """
 
+import logging
+import time
+
 from fastapi import APIRouter, HTTPException
 
 from server import datasets
@@ -24,6 +27,7 @@ from server.query_builder import (
     build_tuples_sql,
 )
 
+logger = logging.getLogger("query_service.query")
 router = APIRouter(prefix="/query", tags=["query"])
 
 
@@ -39,12 +43,25 @@ async def post_query_tuples(body: QueryTuplesRequest) -> TuplesResponse:
     limit = paging.limit if paging else 200
     offset = paging.offset if paging else 0
 
+    start = time.perf_counter()
     sql, params = build_tuples_sql(body.dataset_id, body.query, body.date_range, schema_fields)
     rows = await db_manager.execute_sql_async(sql, tuple(params) if params else None)
 
     count_sql, count_params = build_tuples_count_sql(body.dataset_id, body.query, body.date_range, schema_fields)
     count_rows = await db_manager.execute_sql_async(count_sql, tuple(count_params) if count_params else None)
     total_count = count_rows[0][0] if count_rows else 0
+    duration_ms = (time.perf_counter() - start) * 1000
+
+    logger.info(
+        "tuples query executed",
+        extra={
+            "dataset_id": body.dataset_id,
+            "endpoint": "tuples",
+            "duration_ms": round(duration_ms, 2),
+            "row_count": len(rows),
+            "total_count": total_count,
+        },
+    )
 
     items = [TupleItem(values=list(row)) for row in rows]
     return TuplesResponse(
@@ -63,8 +80,20 @@ async def post_query_cells(body: QueryCellsRequest) -> CellsResponse:
 
     schema_fields = datasets.get_schema_field_names(body.dataset_id)
 
+    start = time.perf_counter()
     sql, params = build_cells_sql(body.dataset_id, body.query, body.date_range, schema_fields)
     rows = await db_manager.execute_sql_async(sql, tuple(params) if params else None)
+    duration_ms = (time.perf_counter() - start) * 1000
+
+    logger.info(
+        "cells query executed",
+        extra={
+            "dataset_id": body.dataset_id,
+            "endpoint": "cells",
+            "duration_ms": round(duration_ms, 2),
+            "row_count": len(rows),
+        },
+    )
 
     cells = []
     for i, row in enumerate(rows):
@@ -84,12 +113,25 @@ async def post_query_picklist(body: QueryPicklistRequest) -> PicklistResponse:
     limit = paging.limit if paging else 100
     offset = paging.offset if paging else 0
 
+    start = time.perf_counter()
     sql, params = build_picklist_sql(body.dataset_id, body.query, body.date_range, schema_fields)
     rows = await db_manager.execute_sql_async(sql, tuple(params) if params else None)
 
     count_sql, count_params = build_picklist_count_sql(body.dataset_id, body.query, body.date_range, schema_fields)
     count_rows = await db_manager.execute_sql_async(count_sql, tuple(count_params) if count_params else None)
     total_count = count_rows[0][0] if count_rows else 0
+    duration_ms = (time.perf_counter() - start) * 1000
+
+    logger.info(
+        "picklist query executed",
+        extra={
+            "dataset_id": body.dataset_id,
+            "endpoint": "picklist",
+            "duration_ms": round(duration_ms, 2),
+            "row_count": len(rows),
+            "total_count": total_count,
+        },
+    )
 
     values = [{"value": str(row[0]), "label": str(row[0])} for row in rows]
     return PicklistResponse(

--- a/server/tests/test_logging.py
+++ b/server/tests/test_logging.py
@@ -1,0 +1,172 @@
+"""Tests for structured logging configuration and access log middleware."""
+
+import json
+import logging
+
+from fastapi.testclient import TestClient
+
+from server.logging_config import setup_logging
+
+
+class TestSetupLogging:
+    def test_json_format_produces_valid_json(self, capfd) -> None:
+        setup_logging("INFO", "json")
+        test_logger = logging.getLogger("test.json")
+        test_logger.info("hello", extra={"key": "val"})
+
+        captured = capfd.readouterr()
+        record = json.loads(captured.out.strip())
+        assert record["message"] == "hello"
+        assert record["level"] == "INFO"
+        assert record["key"] == "val"
+        assert "timestamp" in record
+
+    def test_json_format_includes_extra_fields(self, capfd) -> None:
+        setup_logging("INFO", "json")
+        test_logger = logging.getLogger("test.json.extra")
+        test_logger.info("query done", extra={"duration_ms": 12.5, "row_count": 42})
+
+        record = json.loads(capfd.readouterr().out.strip())
+        assert record["duration_ms"] == 12.5
+        assert record["row_count"] == 42
+
+    def test_text_format_produces_readable_output(self, capfd) -> None:
+        setup_logging("INFO", "text")
+        test_logger = logging.getLogger("test.text")
+        test_logger.info("startup")
+
+        captured = capfd.readouterr()
+        assert "[INFO]" in captured.out
+        assert "test.text" in captured.out
+        assert "startup" in captured.out
+
+    def test_text_is_default_format(self, capfd) -> None:
+        setup_logging("INFO")
+        test_logger = logging.getLogger("test.default")
+        test_logger.info("check")
+
+        captured = capfd.readouterr()
+        assert "[INFO]" in captured.out
+        assert "check" in captured.out
+
+    def test_log_level_respected(self, capfd) -> None:
+        setup_logging("WARNING", "text")
+        test_logger = logging.getLogger("test.level")
+        test_logger.info("should not appear")
+        test_logger.warning("should appear")
+
+        captured = capfd.readouterr()
+        assert "should not appear" not in captured.out
+        assert "should appear" in captured.out
+
+    def test_clears_existing_handlers(self) -> None:
+        setup_logging("INFO", "text")
+        handler_count_1 = len(logging.getLogger().handlers)
+        setup_logging("INFO", "json")
+        handler_count_2 = len(logging.getLogger().handlers)
+        assert handler_count_1 == 1
+        assert handler_count_2 == 1
+
+
+class TestAccessLogMiddleware:
+    def test_logs_request_details(self, client: TestClient, capfd) -> None:
+        setup_logging("INFO", "json")
+        client.get("/health/liveness")
+
+        output = capfd.readouterr().out
+        lines = [line for line in output.strip().split("\n") if line.strip()]
+        access_records = []
+        for line in lines:
+            try:
+                record = json.loads(line)
+                if record.get("path") == "/health/liveness":
+                    access_records.append(record)
+            except json.JSONDecodeError:
+                continue
+
+        assert len(access_records) >= 1
+        rec = access_records[0]
+        assert rec["method"] == "GET"
+        assert rec["status_code"] == 200
+        assert "duration_ms" in rec
+
+    def test_logs_post_request(self, client: TestClient, capfd) -> None:
+        setup_logging("INFO", "json")
+        client.post("/query/tuples", json={
+            "dataset_id": "trades_v1",
+            "date_range": {"type": "single", "date": "2026-03-01"},
+            "query": {"fields": [{"field": "symbol"}]},
+        })
+
+        output = capfd.readouterr().out
+        lines = output.strip().split("\n")
+        access_records = []
+        for line in lines:
+            try:
+                record = json.loads(line)
+                if record.get("path") == "/query/tuples":
+                    access_records.append(record)
+            except json.JSONDecodeError:
+                continue
+
+        assert len(access_records) >= 1
+        assert access_records[0]["method"] == "POST"
+        assert access_records[0]["status_code"] == 200
+
+
+class TestQueryExecutionLogging:
+    def test_tuples_query_logged(self, client: TestClient, capfd) -> None:
+        setup_logging("INFO", "json")
+        client.post("/query/tuples", json={
+            "dataset_id": "trades_v1",
+            "date_range": {"type": "single", "date": "2026-03-01"},
+            "query": {"fields": [{"field": "symbol"}]},
+        })
+
+        output = capfd.readouterr().out
+        query_records = []
+        for line in output.strip().split("\n"):
+            try:
+                record = json.loads(line)
+                if record.get("endpoint") == "tuples":
+                    query_records.append(record)
+            except json.JSONDecodeError:
+                continue
+
+        assert len(query_records) >= 1
+        rec = query_records[0]
+        assert rec["dataset_id"] == "trades_v1"
+        assert "duration_ms" in rec
+        assert "row_count" in rec
+
+    def test_cells_query_logged(self, client: TestClient, capfd) -> None:
+        setup_logging("INFO", "json")
+        client.post("/query/cells", json={
+            "dataset_id": "trades_v1",
+            "date_range": {"type": "single", "date": "2026-03-01"},
+            "query": {"axes": {"rows": [{"field": "symbol"}], "columns": [], "measures": []}},
+        })
+
+        output = capfd.readouterr().out
+        query_records = [
+            json.loads(line) for line in output.strip().split("\n")
+            if "endpoint" in line and "cells" in line
+        ]
+        assert len(query_records) >= 1
+        assert query_records[0]["endpoint"] == "cells"
+
+    def test_picklist_query_logged(self, client: TestClient, capfd) -> None:
+        setup_logging("INFO", "json")
+        client.post("/query/picklist", json={
+            "dataset_id": "trades_v1",
+            "date_range": {"type": "single", "date": "2026-03-01"},
+            "query": {"field": "symbol"},
+        })
+
+        output = capfd.readouterr().out
+        query_records = [
+            json.loads(line) for line in output.strip().split("\n")
+            if "endpoint" in line and "picklist" in line
+        ]
+        assert len(query_records) >= 1
+        assert query_records[0]["endpoint"] == "picklist"


### PR DESCRIPTION
## Summary

- Add structured JSON logging support controlled by `QUERYSERVICE_LOG_FORMAT` env var ("text" for dev, "json" for production)
- Add `AccessLogMiddleware` that logs every HTTP request with method, path, status code, duration, and client IP
- Add query execution timing to all query endpoints with dataset_id and row counts

## Changes

| File | Change |
|------|--------|
| `server/requirements.txt` | Added `python-json-logger>=3.0.0,<5.0` |
| `server/config.py` | Added `log_format: str = "text"` setting |
| `server/logging_config.py` | **New** — `setup_logging()` with JSON/text format switching |
| `server/middleware.py` | **New** — `AccessLogMiddleware` with request timing |
| `server/main.py` | Refactored to use `logging_config.setup_logging()` and `AccessLogMiddleware` |
| `server/routers/query.py` | Added `time.perf_counter()` instrumentation to tuples/cells/picklist |
| `server/tests/test_logging.py` | **New** — 11 tests for both log formats, access middleware, query logging |

## JSON log output example
```json
{"timestamp": "2026-03-03T12:00:00", "level": "INFO", "name": "query_service.query", "message": "tuples query executed", "dataset_id": "trades_v1", "endpoint": "tuples", "duration_ms": 1.23, "row_count": 5}
```

## Test plan
- [x] 164 tests passing
- [x] Ruff lint clean
- [x] Text format unchanged from previous behavior (default)
- [x] JSON format produces valid parseable JSON with structured fields

Closes #81

Made with [Cursor](https://cursor.com)