### PR TITLE
Implement real export query execution for /export (#97)

### DIFF
--- a/server/query_builder.py
+++ b/server/query_builder.py
@@ -13,6 +13,7 @@ from server.models import (
     DateRange,
     DateRangeRange,
     DateRangeSingle,
+    ExportQueryBody,
     PicklistQueryBody,
     TupleFilter,
     TuplesQueryBody,
@@ -271,3 +272,79 @@ def build_picklist_count_sql(
 
     sql = f"SELECT COUNT(DISTINCT {col}) FROM {table}{where_clause}"
     return sql, params
+
+
+def build_export_sql(
+    dataset_id: str,
+    query: ExportQueryBody,
+    date_range: DateRange,
+    schema_fields: set[str],
+) -> tuple[str, list[Any], list[str]]:
+    """
+    Generate SQL for an export query: flat rows of dimensions + aggregated measures.
+
+    Returns (sql, params, headers) where headers is the list of column names
+    for the CSV header row.
+    """
+    params: list[Any] = []
+    table = _quote(dataset_id)
+    axes = query.axes or {}
+    max_rows = min(query.max_rows or 10000, 100000)
+
+    row_fields = [
+        f["field"]
+        for f in axes.get("rows", [])
+        if isinstance(f, dict) and f.get("field") in schema_fields
+    ]
+    col_fields = [
+        f["field"]
+        for f in axes.get("columns", [])
+        if isinstance(f, dict) and f.get("field") in schema_fields
+    ]
+    measures = axes.get("measures", [])
+
+    dim_cols = [_quote(f) for f in row_fields + col_fields]
+    dim_headers = row_fields + col_fields
+    agg_exprs = []
+    agg_headers: list[str] = []
+    for m in measures:
+        if not isinstance(m, dict):
+            continue
+        field = m.get("field", "")
+        agg = m.get("aggregation", "SUM").upper()
+        alias = m.get("alias", f"{agg.lower()}_{field}")
+        if field not in schema_fields:
+            continue
+        if agg in ("SUM", "COUNT", "AVG", "MIN", "MAX"):
+            agg_exprs.append(f"{agg}({_quote(field)}) AS {_quote(alias)}")
+            agg_headers.append(alias)
+
+    if not dim_cols and not agg_exprs:
+        # No dimensions and no measures: export all columns as raw rows
+        all_fields = sorted(schema_fields)
+        select_clause = ", ".join(_quote(f) for f in all_fields)
+        headers = all_fields
+    else:
+        select_parts = dim_cols + agg_exprs
+        select_clause = ", ".join(select_parts)
+        headers = dim_headers + agg_headers
+
+    where_parts = []
+    date_clause = _build_date_clause(date_range, params)
+    if date_clause:
+        where_parts.append(date_clause)
+    where_parts.extend(_build_filter_clauses(query.filters, params, schema_fields))
+    where_clause = (" WHERE " + " AND ".join(where_parts)) if where_parts else ""
+
+    group_clause = ""
+    if dim_cols and agg_exprs:
+        group_clause = " GROUP BY " + ", ".join(dim_cols)
+
+    order_clause = ""
+    if dim_cols:
+        order_clause = " ORDER BY " + ", ".join(dim_cols)
+
+    limit_clause = f" LIMIT {max_rows}"
+
+    sql = f"SELECT {select_clause} FROM {table}{where_clause}{group_clause}{order_clause}{limit_clause}"
+    return sql, params, headers

--- a/server/routers/export.py
+++ b/server/routers/export.py
@@ -5,6 +5,7 @@ Supports background processing via FastAPI BackgroundTasks, TTL-based cleanup,
 and a configurable max concurrent export limit.
 """
 
+import csv
 import logging
 import time
 import uuid
@@ -17,6 +18,7 @@ from server import datasets
 from server.config import get_settings
 from server.engine import db_manager
 from server.models import ExportRequest, ExportResponse, ExportStatusResponse
+from server.query_builder import build_export_sql
 
 logger = logging.getLogger("query_service.export")
 
@@ -57,17 +59,28 @@ def _process_export(export_id: str, body: ExportRequest) -> None:
         output_dir.mkdir(parents=True, exist_ok=True)
         file_path = output_dir / f"{export_id}.csv"
 
-        # TODO: generate real export SQL from body.query axes/filters
-        rows = db_manager.execute_sql("SELECT 1 AS placeholder")
+        schema_fields = datasets.get_schema_field_names(body.dataset_id)
+        sql, params, headers = build_export_sql(
+            body.dataset_id, body.query, body.date_range, schema_fields,
+        )
 
-        with open(file_path, "w") as f:
+        rows = db_manager.execute_sql(sql, params)
+
+        with open(file_path, "w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(headers)
             for row in rows:
-                f.write(",".join(str(v) for v in row) + "\n")
+                writer.writerow(row)
 
+        row_count = len(rows) if rows else 0
         _exports[export_id]["status"] = "complete"
         _exports[export_id]["file_path"] = str(file_path)
+        _exports[export_id]["row_count"] = row_count
         _exports[export_id]["download_url"] = f"/export/{export_id}/download"
-        logger.info("Export complete", extra={"export_id": export_id})
+        logger.info(
+            "Export complete",
+            extra={"export_id": export_id, "row_count": row_count},
+        )
     except Exception:
         _exports[export_id]["status"] = "failed"
         logger.exception("Export failed", extra={"export_id": export_id})

--- a/server/tests/test_export_api.py
+++ b/server/tests/test_export_api.py
@@ -1,5 +1,7 @@
 """Tests for POST /export, GET /export/{id}, and GET /export/{id}/download."""
 
+import csv
+import io
 import time
 
 import pytest
@@ -20,100 +22,197 @@ def _valid_body(**overrides):
     body = {
         "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {"export_type": "pivot_results", "axes": {}, "filters": [], "max_rows": 1000, "format": "csv"},
+        "query": {
+            "export_type": "pivot_results",
+            "axes": {
+                "rows": [{"field": "symbol"}],
+                "measures": [{"field": "volume", "aggregation": "SUM", "alias": "total_volume"}],
+            },
+            "filters": [],
+            "max_rows": 1000,
+            "format": "csv",
+        },
     }
     body.update(overrides)
     return body
 
 
-def test_post_export_returns_pending(client: TestClient) -> None:
-    r = client.post("/export", json=_valid_body())
+def _run_export_and_download(client: TestClient, body: dict) -> tuple[str, list[list[str]]]:
+    """Submit an export, wait for completion, download, parse CSV rows."""
+    r = client.post("/export", json=body)
     assert r.status_code == 200
-    data = r.json()
-    assert data["export_id"].startswith("exp-")
-    assert data["status"] == "pending"
+    export_id = r.json()["export_id"]
+
+    for _ in range(20):
+        status_r = client.get(f"/export/{export_id}")
+        assert status_r.status_code == 200
+        if status_r.json()["status"] == "complete":
+            break
+        time.sleep(0.05)
+    else:
+        pytest.fail("Export did not complete in time")
+
+    dl = client.get(f"/export/{export_id}/download")
+    assert dl.status_code == 200
+    reader = csv.reader(io.StringIO(dl.text))
+    return export_id, list(reader)
 
 
-def test_export_lifecycle(client: TestClient) -> None:
-    post_r = client.post("/export", json=_valid_body())
-    export_id = post_r.json()["export_id"]
+class TestExportLifecycle:
+    def test_post_export_returns_pending(self, client: TestClient) -> None:
+        r = client.post("/export", json=_valid_body())
+        assert r.status_code == 200
+        data = r.json()
+        assert data["export_id"].startswith("exp-")
+        assert data["status"] == "pending"
 
-    r = client.get(f"/export/{export_id}")
-    assert r.status_code == 200
-    assert r.json()["export_id"] == export_id
-    assert r.json()["status"] in ("pending", "processing", "complete")
-    if r.json()["status"] == "complete":
-        assert r.json()["download_url"] == f"/export/{export_id}/download"
+    def test_export_completes_with_real_data(self, client: TestClient) -> None:
+        _, rows = _run_export_and_download(client, _valid_body())
+        header = rows[0]
+        assert header == ["symbol", "total_volume"]
+        data_rows = rows[1:]
+        assert len(data_rows) > 0
+        symbols = {r[0] for r in data_rows}
+        assert symbols & {"AAPL", "GOOG", "MSFT", "AMZN", "TSLA"}
 
-
-def test_get_export_not_found(client: TestClient) -> None:
-    r = client.get("/export/exp-nonexistent")
-    assert r.status_code == 404
-
-
-def test_post_export_dataset_not_found(client: TestClient) -> None:
-    r = client.post("/export", json=_valid_body(dataset_id="nonexistent"))
-    assert r.status_code == 404
-
-
-def test_download_not_found(client: TestClient) -> None:
-    r = client.get("/export/exp-nonexistent/download")
-    assert r.status_code == 404
+    def test_csv_values_are_correct_aggregations(self, client: TestClient) -> None:
+        _, rows = _run_export_and_download(client, _valid_body())
+        lookup = {r[0]: int(r[1]) for r in rows[1:]}
+        assert lookup["AAPL"] == 1500
+        assert lookup["GOOG"] == 2200
 
 
-def test_download_not_ready(client: TestClient) -> None:
-    export_module._exports["exp-test"] = {"status": "processing", "created_at": time.time()}
-    r = client.get("/export/exp-test/download")
-    assert r.status_code == 409
+class TestExportWithFilters:
+    def test_include_filter(self, client: TestClient) -> None:
+        body = _valid_body()
+        body["query"]["filters"] = [
+            {"field": "symbol", "operator": "INCLUDE", "values": ["AAPL", "GOOG"]},
+        ]
+        _, rows = _run_export_and_download(client, body)
+        symbols = {r[0] for r in rows[1:]}
+        assert symbols == {"AAPL", "GOOG"}
+
+    def test_exclude_filter(self, client: TestClient) -> None:
+        body = _valid_body()
+        body["query"]["filters"] = [
+            {"field": "symbol", "operator": "EXCLUDE", "values": ["AAPL"]},
+        ]
+        _, rows = _run_export_and_download(client, body)
+        symbols = {r[0] for r in rows[1:]}
+        assert "AAPL" not in symbols
+        assert len(symbols) >= 3
 
 
-def test_download_for_failed_export(client: TestClient) -> None:
-    export_module._exports["exp-fail"] = {"status": "failed", "created_at": time.time()}
-    r = client.get("/export/exp-fail/download")
-    assert r.status_code == 409
+class TestExportDateRange:
+    def test_single_date(self, client: TestClient) -> None:
+        body = _valid_body()
+        body["date_range"] = {"type": "single", "date": "2026-03-02"}
+        _, rows = _run_export_and_download(client, body)
+        symbols = {r[0] for r in rows[1:]}
+        assert "AMZN" not in symbols
+
+    def test_date_range(self, client: TestClient) -> None:
+        body = _valid_body()
+        body["date_range"] = {"type": "range", "start": "2026-03-01", "end": "2026-03-02"}
+        _, rows = _run_export_and_download(client, body)
+        data_rows = rows[1:]
+        lookup = {r[0]: int(r[1]) for r in data_rows}
+        assert lookup["AAPL"] == 1500 + 1600
 
 
-def test_download_file_missing_on_disk(client: TestClient) -> None:
-    export_module._exports["exp-gone"] = {
-        "status": "complete",
-        "created_at": time.time(),
-        "file_path": "/tmp/nonexistent-file.csv",
-        "download_url": "/export/exp-gone/download",
-    }
-    r = client.get("/export/exp-gone/download")
-    assert r.status_code == 404
+class TestExportMaxRows:
+    def test_max_rows_truncates(self, client: TestClient) -> None:
+        body = _valid_body()
+        body["query"]["max_rows"] = 2
+        _, rows = _run_export_and_download(client, body)
+        data_rows = rows[1:]
+        assert len(data_rows) == 2
 
 
-def test_max_concurrent_limit(client: TestClient) -> None:
-    for i in range(5):
-        export_module._exports[f"exp-active-{i}"] = {"status": "processing", "created_at": time.time()}
-    r = client.post("/export", json=_valid_body())
-    assert r.status_code == 429
-    assert "concurrent" in r.json()["detail"].lower()
+class TestExportRawColumns:
+    def test_empty_axes_exports_all_fields(self, client: TestClient) -> None:
+        body = _valid_body()
+        body["query"]["axes"] = {}
+        _, rows = _run_export_and_download(client, body)
+        header = rows[0]
+        assert set(header) == {"date", "symbol", "volume"}
+        assert len(rows) > 1
 
 
-def test_ttl_cleanup(client: TestClient, tmp_path) -> None:
-    expired_file = tmp_path / "exp-old.csv"
-    expired_file.write_text("old data")
-    export_module._exports["exp-old"] = {
-        "status": "complete",
-        "created_at": time.time() - 7200,
-        "file_path": str(expired_file),
-    }
-    r = client.post("/export", json=_valid_body())
-    assert r.status_code == 200
-    assert "exp-old" not in export_module._exports
-    assert not expired_file.exists()
+class TestExportCsvFormat:
+    def test_csv_header_always_present(self, client: TestClient) -> None:
+        _, rows = _run_export_and_download(client, _valid_body())
+        assert len(rows) >= 2
+        assert rows[0] == ["symbol", "total_volume"]
+
+    def test_csv_proper_quoting(self, client: TestClient) -> None:
+        _, rows = _run_export_and_download(client, _valid_body())
+        for row in rows:
+            assert all(isinstance(cell, str) for cell in row)
 
 
-def test_ttl_preserves_active_exports(client: TestClient) -> None:
-    export_module._exports["exp-recent"] = {"status": "complete", "created_at": time.time()}
-    r = client.post("/export", json=_valid_body())
-    assert r.status_code == 200
-    assert "exp-recent" in export_module._exports
+class TestExportErrors:
+    def test_dataset_not_found(self, client: TestClient) -> None:
+        r = client.post("/export", json=_valid_body(dataset_id="nonexistent"))
+        assert r.status_code == 404
+
+    def test_get_export_not_found(self, client: TestClient) -> None:
+        r = client.get("/export/exp-nonexistent")
+        assert r.status_code == 404
+
+    def test_download_not_found(self, client: TestClient) -> None:
+        r = client.get("/export/exp-nonexistent/download")
+        assert r.status_code == 404
+
+    def test_download_not_ready(self, client: TestClient) -> None:
+        export_module._exports["exp-test"] = {"status": "processing", "created_at": time.time()}
+        r = client.get("/export/exp-test/download")
+        assert r.status_code == 409
+
+    def test_download_for_failed_export(self, client: TestClient) -> None:
+        export_module._exports["exp-fail"] = {"status": "failed", "created_at": time.time()}
+        r = client.get("/export/exp-fail/download")
+        assert r.status_code == 409
+
+    def test_download_file_missing_on_disk(self, client: TestClient) -> None:
+        export_module._exports["exp-gone"] = {
+            "status": "complete",
+            "created_at": time.time(),
+            "file_path": "/tmp/nonexistent-file.csv",
+            "download_url": "/export/exp-gone/download",
+        }
+        r = client.get("/export/exp-gone/download")
+        assert r.status_code == 404
 
 
-def test_multiple_exports_unique_ids(client: TestClient) -> None:
-    r1 = client.post("/export", json=_valid_body())
-    r2 = client.post("/export", json=_valid_body())
-    assert r1.json()["export_id"] != r2.json()["export_id"]
+class TestExportConcurrencyAndTtl:
+    def test_max_concurrent_limit(self, client: TestClient) -> None:
+        for i in range(5):
+            export_module._exports[f"exp-active-{i}"] = {"status": "processing", "created_at": time.time()}
+        r = client.post("/export", json=_valid_body())
+        assert r.status_code == 429
+        assert "concurrent" in r.json()["detail"].lower()
+
+    def test_ttl_cleanup(self, client: TestClient, tmp_path) -> None:
+        expired_file = tmp_path / "exp-old.csv"
+        expired_file.write_text("old data")
+        export_module._exports["exp-old"] = {
+            "status": "complete",
+            "created_at": time.time() - 7200,
+            "file_path": str(expired_file),
+        }
+        r = client.post("/export", json=_valid_body())
+        assert r.status_code == 200
+        assert "exp-old" not in export_module._exports
+        assert not expired_file.exists()
+
+    def test_ttl_preserves_active_exports(self, client: TestClient) -> None:
+        export_module._exports["exp-recent"] = {"status": "complete", "created_at": time.time()}
+        r = client.post("/export", json=_valid_body())
+        assert r.status_code == 200
+        assert "exp-recent" in export_module._exports
+
+    def test_multiple_exports_unique_ids(self, client: TestClient) -> None:
+        r1 = client.post("/export", json=_valid_body())
+        r2 = client.post("/export", json=_valid_body())
+        assert r1.json()["export_id"] != r2.json()["export_id"]

--- a/server/tests/test_query_builder.py
+++ b/server/tests/test_query_builder.py
@@ -4,6 +4,7 @@ from server.models import (
     CellsQueryBody,
     DateRangeRange,
     DateRangeSingle,
+    ExportQueryBody,
     PagingSpec,
     PicklistQueryBody,
     TupleFieldSpec,
@@ -12,6 +13,7 @@ from server.models import (
 )
 from server.query_builder import (
     build_cells_sql,
+    build_export_sql,
     build_picklist_count_sql,
     build_picklist_sql,
     build_tuples_count_sql,
@@ -267,3 +269,97 @@ class TestBuildPicklistCountSql:
         query = PicklistQueryBody(field=None)
         sql, _ = build_picklist_count_sql("trades_v1", query, DR_SINGLE, SCHEMA_FIELDS)
         assert sql == "SELECT 0"
+
+
+class TestBuildExportSql:
+    def test_basic_export_with_dimensions_and_measures(self) -> None:
+        query = ExportQueryBody(
+            axes={
+                "rows": [{"field": "symbol"}],
+                "measures": [{"field": "volume", "aggregation": "SUM", "alias": "total_volume"}],
+            },
+            max_rows=500,
+        )
+        sql, params, headers = build_export_sql("trades_v1", query, DR_SINGLE, SCHEMA_FIELDS)
+        assert '"symbol"' in sql
+        assert 'SUM("volume")' in sql
+        assert "GROUP BY" in sql
+        assert "ORDER BY" in sql
+        assert "LIMIT 500" in sql
+        assert headers == ["symbol", "total_volume"]
+        assert params == ["2026-03-01"]
+
+    def test_date_range(self) -> None:
+        query = ExportQueryBody(
+            axes={"rows": [{"field": "symbol"}], "measures": []},
+        )
+        sql, params, headers = build_export_sql("trades_v1", query, DR_RANGE, SCHEMA_FIELDS)
+        assert "BETWEEN ? AND ?" in sql
+        assert params == ["2026-03-01", "2026-03-31"]
+
+    def test_with_filter(self) -> None:
+        query = ExportQueryBody(
+            axes={
+                "rows": [{"field": "symbol"}],
+                "measures": [{"field": "volume", "aggregation": "SUM", "alias": "vol"}],
+            },
+            filters=[TupleFilter(field="symbol", operator="INCLUDE", values=["AAPL"])],
+        )
+        sql, params, _ = build_export_sql("trades_v1", query, DR_SINGLE, SCHEMA_FIELDS)
+        assert '"symbol" IN (?)' in sql
+        assert "AAPL" in params
+
+    def test_max_rows_capped_at_100k(self) -> None:
+        query = ExportQueryBody(
+            axes={"rows": [{"field": "symbol"}], "measures": []},
+            max_rows=999999,
+        )
+        sql, _, _ = build_export_sql("trades_v1", query, DR_SINGLE, SCHEMA_FIELDS)
+        assert "LIMIT 100000" in sql
+
+    def test_default_max_rows(self) -> None:
+        query = ExportQueryBody(
+            axes={"rows": [{"field": "symbol"}], "measures": []},
+        )
+        sql, _, _ = build_export_sql("trades_v1", query, DR_SINGLE, SCHEMA_FIELDS)
+        assert "LIMIT 10000" in sql
+
+    def test_empty_axes_exports_all_columns(self) -> None:
+        query = ExportQueryBody(axes={}, max_rows=100)
+        sql, params, headers = build_export_sql("trades_v1", query, DR_SINGLE, SCHEMA_FIELDS)
+        assert "GROUP BY" not in sql
+        assert "LIMIT 100" in sql
+        assert set(headers) == {"date", "symbol", "volume"}
+
+    def test_dimensions_only_no_group_by(self) -> None:
+        query = ExportQueryBody(
+            axes={"rows": [{"field": "symbol"}, {"field": "date"}], "measures": []},
+        )
+        sql, _, headers = build_export_sql("trades_v1", query, DR_SINGLE, SCHEMA_FIELDS)
+        assert "GROUP BY" not in sql
+        assert headers == ["symbol", "date"]
+
+    def test_row_and_column_fields(self) -> None:
+        query = ExportQueryBody(
+            axes={
+                "rows": [{"field": "date"}],
+                "columns": [{"field": "symbol"}],
+                "measures": [{"field": "volume", "aggregation": "SUM", "alias": "vol"}],
+            },
+        )
+        sql, _, headers = build_export_sql("trades_v1", query, DR_SINGLE, SCHEMA_FIELDS)
+        assert '"date"' in sql
+        assert '"symbol"' in sql
+        assert "GROUP BY" in sql
+        assert headers == ["date", "symbol", "vol"]
+
+    def test_unknown_field_skipped(self) -> None:
+        query = ExportQueryBody(
+            axes={
+                "rows": [{"field": "nonexistent"}],
+                "measures": [{"field": "volume", "aggregation": "SUM", "alias": "vol"}],
+            },
+        )
+        sql, _, headers = build_export_sql("trades_v1", query, DR_SINGLE, SCHEMA_FIELDS)
+        assert "nonexistent" not in sql
+        assert headers == ["vol"]


### PR DESCRIPTION
## Summary
- Replace placeholder `SELECT 1 AS placeholder` SQL with real query generation using `ExportQueryBody` fields (axes, filters, date_range, max_rows)
- Add `build_export_sql()` to `query_builder.py` — generates dimension + aggregated measure SQL with GROUP BY, ORDER BY, and LIMIT
- Hard caps max_rows at 100K for safety; defaults to 10K
- Empty axes fallback exports all schema columns as raw rows
- Uses `csv.writer` for proper CSV output with header row (no more manual comma-join)

## Test plan
- [x] 9 unit tests for `build_export_sql` (dimensions + measures, date range, filters, max_rows cap, empty axes, unknown fields)
- [x] 20 API tests covering: real data lifecycle, correct aggregation values, include/exclude filters, date range scoping, max_rows truncation, raw column export, CSV format, error cases, concurrency limits, TTL cleanup
- [x] Full 182-test suite passes
- [x] Ruff lint clean

Closes #97


Made with [Cursor](https://cursor.com)