### PR TITLE
Add request tracing with correlation IDs (#82)

### DIFF
--- a/server/logging_config.py
+++ b/server/logging_config.py
@@ -4,12 +4,24 @@ Logging configuration for QueryService.
 Supports two formats controlled by QUERYSERVICE_LOG_FORMAT:
 - "text" (default): human-readable for development
 - "json": structured JSON for production observability
+
+All log records are enriched with the current request_id via RequestIdFilter.
 """
 
 import logging
 import sys
 
 from pythonjsonlogger.json import JsonFormatter
+
+from server.request_context import get_request_id
+
+
+class RequestIdFilter(logging.Filter):
+    """Inject the current correlation ID into every log record."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.request_id = get_request_id()  # type: ignore[attr-defined]
+        return True
 
 
 def setup_logging(level: str = "INFO", log_format: str = "text") -> None:
@@ -21,16 +33,17 @@ def setup_logging(level: str = "INFO", log_format: str = "text") -> None:
         root.handlers.clear()
 
     handler = logging.StreamHandler(sys.stdout)
+    handler.addFilter(RequestIdFilter())
 
     if log_format == "json":
         formatter = JsonFormatter(
-            fmt="%(asctime)s %(levelname)s %(name)s %(message)s",
+            fmt="%(asctime)s %(levelname)s %(name)s %(request_id)s %(message)s",
             rename_fields={"asctime": "timestamp", "levelname": "level"},
             datefmt="%Y-%m-%dT%H:%M:%S",
         )
     else:
         formatter = logging.Formatter(
-            "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+            "%(asctime)s [%(levelname)s] %(name)s [%(request_id)s]: %(message)s",
             datefmt="%Y-%m-%dT%H:%M:%S",
         )
 

--- a/server/main.py
+++ b/server/main.py
@@ -14,7 +14,7 @@ from server.config import get_settings
 from server.datasets import load_sample_data
 from server.engine import db_manager
 from server.logging_config import setup_logging
-from server.middleware import AccessLogMiddleware
+from server.middleware import AccessLogMiddleware, CorrelationIdMiddleware
 from server.routers import export, health, query, schema
 
 settings = get_settings()
@@ -40,6 +40,7 @@ app = FastAPI(
 )
 
 app.add_middleware(AccessLogMiddleware)
+app.add_middleware(CorrelationIdMiddleware)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["http://localhost:8765", "http://127.0.0.1:8765", "http://localhost:8080", "http://127.0.0.1:8080"],

--- a/server/middleware.py
+++ b/server/middleware.py
@@ -7,7 +7,29 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
 
+from server.request_context import generate_request_id, set_request_id
+
 logger = logging.getLogger("query_service.access")
+
+
+class CorrelationIdMiddleware(BaseHTTPMiddleware):
+    """Extract or generate a correlation ID and attach it to the response.
+
+    The ID is stored on request.state so route handlers can override it
+    (e.g. from client_context.request_id) and the override propagates
+    back to the response header.
+    """
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        request_id = request.headers.get("X-Request-ID") or generate_request_id()
+        request.state.request_id = request_id
+        set_request_id(request_id)
+
+        response = await call_next(request)
+        response.headers["X-Request-ID"] = getattr(
+            request.state, "request_id", request_id
+        )
+        return response
 
 
 class AccessLogMiddleware(BaseHTTPMiddleware):

--- a/server/request_context.py
+++ b/server/request_context.py
@@ -1,0 +1,28 @@
+"""
+Contextvars-based request context for correlation ID propagation.
+
+The request ID is set by CorrelationIdMiddleware and flows through
+the entire request lifecycle for logging and tracing.
+"""
+
+import contextvars
+import uuid
+
+request_id_var: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "request_id", default=""
+)
+
+
+def get_request_id() -> str:
+    """Return the current request's correlation ID."""
+    return request_id_var.get()
+
+
+def set_request_id(request_id: str) -> contextvars.Token:
+    """Set the correlation ID for the current request context."""
+    return request_id_var.set(request_id)
+
+
+def generate_request_id() -> str:
+    """Generate a short unique request ID."""
+    return str(uuid.uuid4())[:8]

--- a/server/routers/export.py
+++ b/server/routers/export.py
@@ -11,7 +11,7 @@ import time
 import uuid
 from pathlib import Path
 
-from fastapi import APIRouter, BackgroundTasks, HTTPException
+from fastapi import APIRouter, BackgroundTasks, HTTPException, Request
 from fastapi.responses import FileResponse
 
 from server import datasets
@@ -19,6 +19,7 @@ from server.config import get_settings
 from server.engine import db_manager
 from server.models import ExportRequest, ExportResponse, ExportStatusResponse
 from server.query_builder import build_export_sql
+from server.request_context import set_request_id
 
 logger = logging.getLogger("query_service.export")
 
@@ -89,9 +90,14 @@ def _process_export(export_id: str, body: ExportRequest) -> None:
 @router.post("", response_model=ExportResponse)
 async def post_export(
     body: ExportRequest,
+    request: Request,
     background_tasks: BackgroundTasks,
 ) -> ExportResponse:
     """POST /export: submit export job with background processing."""
+    if body.client_context and body.client_context.request_id:
+        rid = body.client_context.request_id
+        set_request_id(rid)
+        request.state.request_id = rid
     if datasets.get_schema(body.dataset_id) is None:
         raise HTTPException(status_code=404, detail=f"Dataset not found: {body.dataset_id}")
 

--- a/server/routers/query.py
+++ b/server/routers/query.py
@@ -5,7 +5,7 @@ Query endpoints: /query/tuples, /query/cells, /query/picklist (tech spec).
 import logging
 import time
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 
 from server import datasets
 from server.engine import db_manager
@@ -26,14 +26,24 @@ from server.query_builder import (
     build_tuples_count_sql,
     build_tuples_sql,
 )
+from server.request_context import set_request_id
 
 logger = logging.getLogger("query_service.query")
 router = APIRouter(prefix="/query", tags=["query"])
 
 
+def _apply_client_request_id(body, request: Request) -> None:
+    """Override correlation ID with client_context.request_id when provided."""
+    if body.client_context and body.client_context.request_id:
+        rid = body.client_context.request_id
+        set_request_id(rid)
+        request.state.request_id = rid
+
+
 @router.post("/tuples", response_model=TuplesResponse)
-async def post_query_tuples(body: QueryTuplesRequest) -> TuplesResponse:
+async def post_query_tuples(body: QueryTuplesRequest, request: Request) -> TuplesResponse:
     """POST /query/tuples: fetch distinct dimension values for one axis."""
+    _apply_client_request_id(body, request)
     schema = datasets.get_schema(body.dataset_id)
     if schema is None:
         raise HTTPException(status_code=404, detail=f"Dataset not found: {body.dataset_id}")
@@ -72,8 +82,9 @@ async def post_query_tuples(body: QueryTuplesRequest) -> TuplesResponse:
 
 
 @router.post("/cells", response_model=CellsResponse)
-async def post_query_cells(body: QueryCellsRequest) -> CellsResponse:
+async def post_query_cells(body: QueryCellsRequest, request: Request) -> CellsResponse:
     """POST /query/cells: fetch aggregated cell values grouped by dimensions."""
+    _apply_client_request_id(body, request)
     schema = datasets.get_schema(body.dataset_id)
     if schema is None:
         raise HTTPException(status_code=404, detail=f"Dataset not found: {body.dataset_id}")
@@ -102,8 +113,9 @@ async def post_query_cells(body: QueryCellsRequest) -> CellsResponse:
 
 
 @router.post("/picklist", response_model=PicklistResponse)
-async def post_query_picklist(body: QueryPicklistRequest) -> PicklistResponse:
+async def post_query_picklist(body: QueryPicklistRequest, request: Request) -> PicklistResponse:
     """POST /query/picklist: fetch distinct values for a field (filter UI)."""
+    _apply_client_request_id(body, request)
     schema = datasets.get_schema(body.dataset_id)
     if schema is None:
         raise HTTPException(status_code=404, detail=f"Dataset not found: {body.dataset_id}")

--- a/server/tests/test_correlation.py
+++ b/server/tests/test_correlation.py
@@ -1,0 +1,129 @@
+"""Tests for correlation ID propagation (request tracing)."""
+
+import logging
+
+import pytest
+from fastapi.testclient import TestClient
+
+from server.request_context import generate_request_id, get_request_id, set_request_id
+
+
+def _query_body(**overrides):
+    body = {
+        "dataset_id": "trades_v1",
+        "date_range": {"type": "single", "date": "2026-03-01"},
+        "query": {"fields": [{"field": "symbol"}]},
+    }
+    body.update(overrides)
+    return body
+
+
+class TestRequestContext:
+    def test_set_and_get(self) -> None:
+        token = set_request_id("test-123")
+        assert get_request_id() == "test-123"
+        set_request_id("")
+        token  # noqa: B018
+
+    def test_generate_request_id_format(self) -> None:
+        rid = generate_request_id()
+        assert len(rid) == 8
+        assert isinstance(rid, str)
+
+    def test_default_is_empty(self) -> None:
+        set_request_id("")
+        assert get_request_id() == ""
+
+
+class TestCorrelationIdMiddleware:
+    def test_response_includes_request_id(self, client: TestClient) -> None:
+        r = client.get("/health/liveness")
+        assert "X-Request-ID" in r.headers
+        assert len(r.headers["X-Request-ID"]) > 0
+
+    def test_custom_request_id_echoed(self, client: TestClient) -> None:
+        r = client.get(
+            "/health/liveness",
+            headers={"X-Request-ID": "my-trace-123"},
+        )
+        assert r.headers["X-Request-ID"] == "my-trace-123"
+
+    def test_generated_id_when_no_header(self, client: TestClient) -> None:
+        r = client.get("/health/liveness")
+        rid = r.headers["X-Request-ID"]
+        assert len(rid) == 8
+
+    def test_unique_ids_per_request(self, client: TestClient) -> None:
+        r1 = client.get("/health/liveness")
+        r2 = client.get("/health/liveness")
+        assert r1.headers["X-Request-ID"] != r2.headers["X-Request-ID"]
+
+    def test_post_endpoint_gets_correlation_id(self, client: TestClient) -> None:
+        r = client.post("/query/tuples", json=_query_body())
+        assert "X-Request-ID" in r.headers
+        assert len(r.headers["X-Request-ID"]) > 0
+
+
+class TestClientContextOverride:
+    def test_client_context_request_id_overrides(self, client: TestClient) -> None:
+        body = _query_body(client_context={"request_id": "frontend-456"})
+        r = client.post("/query/tuples", json=body)
+        assert r.headers["X-Request-ID"] == "frontend-456"
+
+    def test_client_context_on_cells(self, client: TestClient) -> None:
+        body = {
+            "dataset_id": "trades_v1",
+            "date_range": {"type": "single", "date": "2026-03-01"},
+            "query": {
+                "axes": {
+                    "rows": [{"field": "symbol"}],
+                    "measures": [{"field": "volume", "aggregation": "SUM", "alias": "vol"}],
+                },
+            },
+            "client_context": {"request_id": "cells-trace-789"},
+        }
+        r = client.post("/query/cells", json=body)
+        assert r.headers["X-Request-ID"] == "cells-trace-789"
+
+    def test_client_context_on_picklist(self, client: TestClient) -> None:
+        body = {
+            "dataset_id": "trades_v1",
+            "date_range": {"type": "single", "date": "2026-03-01"},
+            "query": {"field": "symbol"},
+            "client_context": {"request_id": "picklist-trace-abc"},
+        }
+        r = client.post("/query/picklist", json=body)
+        assert r.headers["X-Request-ID"] == "picklist-trace-abc"
+
+    def test_client_context_on_export(self, client: TestClient) -> None:
+        body = {
+            "dataset_id": "trades_v1",
+            "date_range": {"type": "single", "date": "2026-03-01"},
+            "query": {"axes": {}, "format": "csv"},
+            "client_context": {"request_id": "export-trace-def"},
+        }
+        r = client.post("/export", json=body)
+        assert r.headers["X-Request-ID"] == "export-trace-def"
+
+    def test_no_client_context_uses_header(self, client: TestClient) -> None:
+        body = _query_body()
+        r = client.post(
+            "/query/tuples",
+            json=body,
+            headers={"X-Request-ID": "header-id-999"},
+        )
+        assert r.headers["X-Request-ID"] == "header-id-999"
+
+
+class TestLoggingIncludesRequestId:
+    def test_log_records_contain_request_id(
+        self, client: TestClient, caplog: "pytest.LogCaptureFixture"
+    ) -> None:
+        with caplog.at_level(logging.INFO, logger="query_service"):
+            client.post(
+                "/query/tuples",
+                json=_query_body(client_context={"request_id": "log-check-42"}),
+            )
+        matching = [r for r in caplog.records if hasattr(r, "request_id")]
+        assert len(matching) > 0
+        assert any(r.request_id == "log-check-42" for r in matching)  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary
- Create `server/request_context.py` with contextvars-based request ID storage (`get_request_id`, `set_request_id`, `generate_request_id`)
- Add `CorrelationIdMiddleware` to extract `X-Request-ID` from incoming headers or auto-generate an 8-char UUID; return it in every response
- Add `RequestIdFilter` logging filter — injects `request_id` into all log records (both JSON and text formats)
- Wire `client_context.request_id` override in all POST endpoints (tuples, cells, picklist, export) — when the frontend provides a request ID in the body, it takes priority and flows to both the response header and all log entries
- Uses `request.state` for middleware<->handler communication to work around BaseHTTPMiddleware contextvars isolation

## Test plan
- [x] 3 unit tests for `request_context` module (set/get, generate format, default)
- [x] 5 middleware tests (header presence, custom ID echo, auto-generation, uniqueness, POST endpoints)
- [x] 5 client_context override tests (tuples, cells, picklist, export, header fallback)
- [x] 1 logging enrichment test (verifies `request_id` attribute on log records)
- [x] Full 196-test suite passes
- [x] Ruff lint clean

Closes #82


Made with [Cursor](https://cursor.com)