### PR TITLE
Make sample-data bootstrap schema-aware and environment-safe (#100)

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -29,6 +29,9 @@ class Settings(BaseSettings):
     # Optional: path to datasets config YAML (for dataset/schema loader)
     datasets_config_path: Optional[str] = None
 
+    # Sample data seeding (disable in production)
+    seed_sample_data: bool = True
+
     # DuckDB
     data_dir: Optional[str] = None  # Path to DuckDB database file; None = in-memory
 

--- a/server/datasets.py
+++ b/server/datasets.py
@@ -82,21 +82,61 @@ _DUCKDB_TYPE_MAP = {
     "boolean": "BOOLEAN",
 }
 
+_SAMPLE_VALUES: dict[str, list] = {
+    "date": [
+        "2026-03-01", "2026-03-01", "2026-03-01", "2026-03-01",
+        "2026-03-01", "2026-03-02", "2026-03-02", "2026-03-02",
+    ],
+    "string": ["AAPL", "GOOG", "MSFT", "AMZN", "TSLA", "AAPL", "GOOG", "MSFT"],
+    "int64": [1500, 2200, 1800, 3100, 900, 1600, 2100, 1900],
+    "float64": [150.50, 220.30, 180.00, 310.70, 90.20, 160.10, 210.80, 190.40],
+    "boolean": [True, False, True, False, True, False, True, False],
+}
+
+_NUM_SAMPLE_ROWS = 8
+
+
+def generate_sample_rows(fields: list[dict[str, Any]]) -> list[tuple]:
+    """Generate deterministic sample rows from field type definitions.
+
+    Returns a list of tuples, each matching the column order in *fields*.
+    """
+    rows: list[tuple] = []
+    for i in range(_NUM_SAMPLE_ROWS):
+        row: list[Any] = []
+        for f in fields:
+            ftype = f.get("type", "string")
+            pool = _SAMPLE_VALUES.get(ftype, _SAMPLE_VALUES["string"])
+            row.append(pool[i % len(pool)])
+        rows.append(tuple(row))
+    return rows
+
 
 def load_sample_data(db_manager: DuckDBManager) -> None:
-    """
-    Create tables with sample data for each configured dataset.
+    """Create tables with schema-aware sample data for each configured dataset.
 
-    In production, data comes from parquet/S3. For development and testing,
-    this populates in-memory DuckDB tables matching the dataset schemas.
+    Controlled by the QUERYSERVICE_SEED_SAMPLE_DATA setting (default True).
+    In production, set to False so startup has no seeding side effects.
     """
+    settings = get_settings()
+    if not settings.seed_sample_data:
+        logger.info("Sample data seeding disabled (QUERYSERVICE_SEED_SAMPLE_DATA=false)")
+        return
+
     config = load_datasets_config()
+    seeded = 0
     for ds in config.get("datasets", []):
         if not isinstance(ds, dict):
             continue
         dataset_id = ds.get("dataset_id", "")
         fields = ds.get("fields", [])
         if not dataset_id or not fields:
+            logger.warning("Skipping dataset entry with missing id or fields")
+            continue
+
+        valid_fields = [f for f in fields if isinstance(f, dict) and f.get("name")]
+        if not valid_fields:
+            logger.warning("Dataset %s has no valid fields, skipping", dataset_id)
             continue
 
         quoted_id = quote_identifier(dataset_id)
@@ -108,7 +148,7 @@ def load_sample_data(db_manager: DuckDBManager) -> None:
             continue
 
         col_defs = []
-        for f in fields:
+        for f in valid_fields:
             name = f.get("name", "")
             ftype = _DUCKDB_TYPE_MAP.get(f.get("type", "string"), "VARCHAR")
             col_defs.append(f'"{name}" {ftype}')
@@ -116,16 +156,18 @@ def load_sample_data(db_manager: DuckDBManager) -> None:
         create_sql = f"CREATE TABLE {quoted_id} ({', '.join(col_defs)})"
         db_manager.execute_sql(create_sql)
 
-        insert_sql = f"""
-            INSERT INTO {quoted_id} VALUES
-            ('2026-03-01', 'AAPL', 1500),
-            ('2026-03-01', 'GOOG', 2200),
-            ('2026-03-01', 'MSFT', 1800),
-            ('2026-03-01', 'AMZN', 3100),
-            ('2026-03-01', 'TSLA', 900),
-            ('2026-03-02', 'AAPL', 1600),
-            ('2026-03-02', 'GOOG', 2100),
-            ('2026-03-02', 'MSFT', 1900)
-        """
-        db_manager.execute_sql(insert_sql)
-        logger.info("Loaded sample data for %s (%d rows)", dataset_id, 8)
+        rows = generate_sample_rows(valid_fields)
+        if rows:
+            placeholders = ", ".join("?" for _ in valid_fields)
+            insert_sql = f"INSERT INTO {quoted_id} VALUES ({placeholders})"
+            for row in rows:
+                db_manager.execute_sql(insert_sql, row)
+
+        seeded += 1
+        logger.info("Seeded sample data for %s (%d rows)", dataset_id, len(rows))
+
+    logger.info(
+        "Sample data seeding complete (%d dataset(s))",
+        seeded,
+        extra={"seeded_count": seeded},
+    )

--- a/server/tests/test_sample_seeding.py
+++ b/server/tests/test_sample_seeding.py
@@ -1,0 +1,210 @@
+"""Tests for schema-aware sample data seeding."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from server.datasets import generate_sample_rows, load_sample_data
+from server.engine import DuckDBManager
+
+
+@pytest.fixture
+def fresh_db():
+    """A clean DuckDB instance with no tables."""
+    db = DuckDBManager()
+    db.initialize()
+    yield db
+    db.shutdown()
+
+
+class TestGenerateSampleRows:
+    def test_basic_trades_schema(self) -> None:
+        fields = [
+            {"name": "date", "type": "date"},
+            {"name": "symbol", "type": "string"},
+            {"name": "volume", "type": "int64"},
+        ]
+        rows = generate_sample_rows(fields)
+        assert len(rows) == 8
+        assert all(len(r) == 3 for r in rows)
+
+    def test_deterministic(self) -> None:
+        fields = [{"name": "x", "type": "string"}]
+        assert generate_sample_rows(fields) == generate_sample_rows(fields)
+
+    def test_all_types(self) -> None:
+        fields = [
+            {"name": "d", "type": "date"},
+            {"name": "s", "type": "string"},
+            {"name": "i", "type": "int64"},
+            {"name": "f", "type": "float64"},
+            {"name": "b", "type": "boolean"},
+        ]
+        rows = generate_sample_rows(fields)
+        assert len(rows) == 8
+        assert all(len(r) == 5 for r in rows)
+        assert isinstance(rows[0][0], str)
+        assert isinstance(rows[0][2], int)
+        assert isinstance(rows[0][3], float)
+        assert isinstance(rows[0][4], bool)
+
+    def test_unknown_type_falls_back_to_string(self) -> None:
+        fields = [{"name": "custom", "type": "custom_type"}]
+        rows = generate_sample_rows(fields)
+        assert len(rows) == 8
+        assert all(isinstance(r[0], str) for r in rows)
+
+    def test_single_field(self) -> None:
+        fields = [{"name": "id", "type": "int64"}]
+        rows = generate_sample_rows(fields)
+        assert len(rows) == 8
+        assert all(isinstance(r[0], int) for r in rows)
+
+    def test_schema_with_extra_metadata(self) -> None:
+        fields = [
+            {"name": "date", "type": "date", "is_dimension": True},
+            {"name": "val", "type": "float64", "is_measure": True},
+        ]
+        rows = generate_sample_rows(fields)
+        assert len(rows) == 8
+        assert all(len(r) == 2 for r in rows)
+
+
+class TestLoadSampleData:
+    def test_seeds_when_enabled(self, fresh_db: DuckDBManager) -> None:
+        config_yaml = """
+datasets:
+  - dataset_id: test_ds
+    fields:
+      - name: id
+        type: int64
+      - name: label
+        type: string
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(config_yaml)
+            path = f.name
+        try:
+            with patch("server.datasets.get_settings") as mock_settings:
+                mock_settings.return_value = type("S", (), {
+                    "datasets_config_path": path,
+                    "seed_sample_data": True,
+                })()
+                load_sample_data(fresh_db)
+
+            rows = fresh_db.execute_sql("SELECT count(*) FROM test_ds")
+            assert rows[0][0] == 8
+        finally:
+            Path(path).unlink()
+
+    def test_skips_when_disabled(self, fresh_db: DuckDBManager) -> None:
+        config_yaml = """
+datasets:
+  - dataset_id: disabled_ds
+    fields:
+      - name: id
+        type: int64
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(config_yaml)
+            path = f.name
+        try:
+            with patch("server.datasets.get_settings") as mock_settings:
+                mock_settings.return_value = type("S", (), {
+                    "datasets_config_path": path,
+                    "seed_sample_data": False,
+                })()
+                load_sample_data(fresh_db)
+
+            tables = fresh_db.execute_sql(
+                "SELECT count(*) FROM information_schema.tables WHERE table_name = 'disabled_ds'"
+            )
+            assert tables[0][0] == 0
+        finally:
+            Path(path).unlink()
+
+    def test_resilient_to_schema_evolution(self, fresh_db: DuckDBManager) -> None:
+        """Adding a new field to the schema doesn't crash seeding."""
+        config_yaml = """
+datasets:
+  - dataset_id: evolved_ds
+    fields:
+      - name: date
+        type: date
+      - name: symbol
+        type: string
+      - name: volume
+        type: int64
+      - name: price
+        type: float64
+      - name: is_active
+        type: boolean
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(config_yaml)
+            path = f.name
+        try:
+            with patch("server.datasets.get_settings") as mock_settings:
+                mock_settings.return_value = type("S", (), {
+                    "datasets_config_path": path,
+                    "seed_sample_data": True,
+                })()
+                load_sample_data(fresh_db)
+
+            rows = fresh_db.execute_sql("SELECT count(*) FROM evolved_ds")
+            assert rows[0][0] == 8
+            sample = fresh_db.execute_sql("SELECT * FROM evolved_ds LIMIT 1")
+            assert len(sample[0]) == 5
+        finally:
+            Path(path).unlink()
+
+    def test_skips_dataset_with_no_fields(self, fresh_db: DuckDBManager) -> None:
+        config_yaml = """
+datasets:
+  - dataset_id: empty_fields
+    fields: []
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(config_yaml)
+            path = f.name
+        try:
+            with patch("server.datasets.get_settings") as mock_settings:
+                mock_settings.return_value = type("S", (), {
+                    "datasets_config_path": path,
+                    "seed_sample_data": True,
+                })()
+                load_sample_data(fresh_db)
+
+            tables = fresh_db.execute_sql(
+                "SELECT count(*) FROM information_schema.tables WHERE table_name = 'empty_fields'"
+            )
+            assert tables[0][0] == 0
+        finally:
+            Path(path).unlink()
+
+    def test_idempotent_does_not_duplicate(self, fresh_db: DuckDBManager) -> None:
+        config_yaml = """
+datasets:
+  - dataset_id: idempotent_ds
+    fields:
+      - name: val
+        type: int64
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(config_yaml)
+            path = f.name
+        try:
+            with patch("server.datasets.get_settings") as mock_settings:
+                mock_settings.return_value = type("S", (), {
+                    "datasets_config_path": path,
+                    "seed_sample_data": True,
+                })()
+                load_sample_data(fresh_db)
+                load_sample_data(fresh_db)
+
+            rows = fresh_db.execute_sql("SELECT count(*) FROM idempotent_ds")
+            assert rows[0][0] == 8
+        finally:
+            Path(path).unlink()


### PR DESCRIPTION
## Summary
- Replace hardcoded `INSERT INTO ... VALUES ('2026-03-01', 'AAPL', 1500), ...` with schema-aware `generate_sample_rows()` that produces deterministic rows from field type definitions
- Add `QUERYSERVICE_SEED_SAMPLE_DATA` config flag (default `True`) — set to `False` in production to skip seeding entirely
- Validates fields before creating tables; warns on missing/empty schemas
- Logs summary of seeding activity on startup ("Sample data seeding complete (N dataset(s))")
- `generate_sample_rows()` is a public function for direct use in tests

## Test plan
- [x] 6 unit tests for `generate_sample_rows`: trades schema, determinism, all types, unknown type fallback, single field, extra metadata
- [x] 5 integration tests for `load_sample_data`: enable/disable config, schema evolution (5-column schema), empty fields skip, idempotency
- [x] All 242 tests pass (including all existing API tests — data values preserved)
- [x] Ruff lint clean

Closes #100


Made with [Cursor](https://cursor.com)