### PR TITLE
Fix readiness probe to return 503 when unhealthy

### DIFF
--- a/server/routers/health.py
+++ b/server/routers/health.py
@@ -6,6 +6,7 @@ Health check endpoints for QueryService.
 """
 
 from fastapi import APIRouter
+from fastapi.responses import JSONResponse
 
 from server.engine import db_manager
 
@@ -19,8 +20,8 @@ async def liveness() -> dict:
 
 
 @router.get("/readiness")
-async def readiness() -> dict:
+async def readiness() -> JSONResponse:
     """Readiness: service is ready to accept traffic (engine must be healthy)."""
     if not db_manager.health_check():
-        return {"status": "unavailable"}
-    return {"status": "ok"}
+        return JSONResponse(status_code=503, content={"status": "unavailable"})
+    return JSONResponse(status_code=200, content={"status": "ok"})

--- a/server/tests/test_health.py
+++ b/server/tests/test_health.py
@@ -2,6 +2,8 @@
 
 from fastapi.testclient import TestClient
 
+from server.routers import health
+
 
 def test_liveness(client: TestClient) -> None:
     """GET /health/liveness returns 200 and status ok."""
@@ -15,3 +17,11 @@ def test_readiness(client: TestClient) -> None:
     r = client.get("/health/readiness")
     assert r.status_code == 200
     assert r.json() == {"status": "ok"}
+
+
+def test_readiness_unhealthy_returns_503(client: TestClient, monkeypatch) -> None:
+    """GET /health/readiness returns 503 when engine health check fails."""
+    monkeypatch.setattr(health.db_manager, "health_check", lambda: False)
+    r = client.get("/health/readiness")
+    assert r.status_code == 503
+    assert r.json() == {"status": "unavailable"}


### PR DESCRIPTION
## Summary
Fixes readiness semantics so unhealthy instances return HTTP 503 instead of HTTP 200.

Closes #133.

## Changes
- Updated `GET /health/readiness` to return:
  - `200` + `{"status":"ok"}` when healthy
  - `503` + `{"status":"unavailable"}` when unhealthy
- Added test coverage for unhealthy readiness by monkeypatching `db_manager.health_check`.

## Validation
- `./.venv-server/bin/pytest server/tests/test_health.py -q`
- Result: `3 passed`
