### PR TITLE
Add Python 3.11 runtime guardrails and CI enforcement

### DIFF
--- a/.github/workflows/query-service.yml
+++ b/.github/workflows/query-service.yml
@@ -28,13 +28,19 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: ${{ matrix.python-version }}
+
+      - name: Verify Python version requirement
+        run: python -c "import sys; assert sys.version_info >= (3, 11), f'Python 3.11+ required, got {sys.version_info.major}.{sys.version_info.minor}'"
 
       - name: Cache pip
         uses: actions/cache@v4
@@ -63,7 +69,10 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.11'
+
+      - name: Verify Python version requirement
+        run: python -c "import sys; assert sys.version_info >= (3, 11), f'Python 3.11+ required, got {sys.version_info.major}.{sys.version_info.minor}'"
 
       - name: Install ruff
         run: pip install ruff

--- a/server/README.md
+++ b/server/README.md
@@ -7,9 +7,9 @@ Huey OLAP query service backend (Python, FastAPI, DuckDB). Serves health checks 
 From the repo root:
 
 ```bash
+python3 --version  # requires Python 3.11+
 python3 -m venv .venv-server
-. .venv-server/bin/activate  # or .venv-server\Scripts\activate on Windows
-pip install -r server/requirements.txt
+./.venv-server/bin/pip install -r server/requirements.txt
 ```
 
 ## Run
@@ -17,14 +17,13 @@ pip install -r server/requirements.txt
 From the repo root (so `server` is the package):
 
 ```bash
-. .venv-server/bin/activate
-uvicorn server.main:app --host 0.0.0.0 --port 8000
+./.venv-server/bin/uvicorn server.main:app --host 0.0.0.0 --port 8000
 ```
 
 Or:
 
 ```bash
-PYTHONPATH=. python -m server.main
+PYTHONPATH=. ./.venv-server/bin/python -m server.main
 ```
 
 ## Health
@@ -49,14 +48,13 @@ PYTHONPATH=. python -m server.main
 From the repo root:
 
 ```bash
-. .venv-server/bin/activate
-PYTHONPATH=. python -m pytest server/tests -v
+PYTHONPATH=. ./.venv-server/bin/python -m pytest server/tests -v
 ```
 
 To include coverage:
 
 ```bash
-PYTHONPATH=. python -m pytest server/tests --cov=server --cov-report=term-missing
+PYTHONPATH=. ./.venv-server/bin/python -m pytest server/tests --cov=server --cov-report=term-missing
 ```
 
 ## Docker

--- a/server/main.py
+++ b/server/main.py
@@ -7,6 +7,11 @@ FastAPI application with health endpoints, config loader, and structured logging
 import logging
 from contextlib import asynccontextmanager
 
+# Fail fast with a clear message before importing modules that require modern syntax.
+from server.runtime import ensure_supported_python
+
+ensure_supported_python()
+
 from fastapi import FastAPI
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -1,3 +1,8 @@
+[project]
+name = "queryservice"
+version = "0.1.0"
+requires-python = ">=3.11"
+
 [tool.coverage.run]
 source = ["server"]
 omit = ["server/tests/*"]

--- a/server/runtime.py
+++ b/server/runtime.py
@@ -1,0 +1,17 @@
+"""Runtime guardrails for supported Python versions."""
+
+import sys
+from collections.abc import Sequence
+
+MIN_PYTHON = (3, 11)
+
+
+def ensure_supported_python(version_info: Sequence[int] | None = None) -> None:
+    """Raise RuntimeError when running on an unsupported Python version."""
+    current = version_info if version_info is not None else sys.version_info
+    current_major_minor = (int(current[0]), int(current[1]))
+    if current_major_minor < MIN_PYTHON:
+        raise RuntimeError(
+            "QueryService requires Python 3.11+; "
+            f"detected {current_major_minor[0]}.{current_major_minor[1]}"
+        )

--- a/server/tests/test_runtime.py
+++ b/server/tests/test_runtime.py
@@ -1,0 +1,15 @@
+"""Tests for runtime Python version guardrails."""
+
+import pytest
+
+from server.runtime import ensure_supported_python
+
+
+def test_runtime_guard_accepts_supported_version() -> None:
+    ensure_supported_python((3, 11, 0))
+    ensure_supported_python((3, 12, 1))
+
+
+def test_runtime_guard_rejects_older_version() -> None:
+    with pytest.raises(RuntimeError, match="Python 3.11\\+"):
+        ensure_supported_python((3, 10, 13))


### PR DESCRIPTION
## Summary
Adds explicit Python 3.11+ guardrails for QueryService runtime, documentation, tests, and CI enforcement.

Closes #139.

## Changes
- Added runtime guard module:
  - `server/runtime.py` with `ensure_supported_python()` and minimum `(3, 11)`.
- Added fail-fast guard invocation at startup in `server/main.py` before importing runtime-heavy modules.
- Added unit tests for guard behavior:
  - `server/tests/test_runtime.py`.
- Added project metadata version constraint:
  - `server/pyproject.toml` now includes `requires-python = ">=3.11"`.
- Updated backend README commands to consistently use repo virtualenv binaries (`./.venv-server/bin/...`) and documented Python 3.11+ requirement.
- Updated CI workflow:
  - Test job runs on matrix `3.11` and `3.12`.
  - Added explicit Python version requirement check steps in test and lint jobs.

## Validation
- `./.venv-server/bin/pytest server/tests -q`
- Result: `307 passed`
