### PR TITLE
Reduce schema-cache lock contention with double-checked reload

### DIFF
--- a/server/datasets.py
+++ b/server/datasets.py
@@ -88,8 +88,7 @@ class _DatasetSchemaCache:
             mtime = None
         return str(path), mtime
 
-    def _invalidate_if_config_changed_locked(self) -> None:
-        path, mtime = self._config_identity()
+    def _invalidate_if_config_changed_locked(self, path: str, mtime: float | None) -> None:
         if self._config_path is None:
             self._config_path = path
             self._config_mtime = mtime
@@ -133,9 +132,12 @@ class _DatasetSchemaCache:
 
         Refreshes on cache miss, TTL expiry, or config change. The returned schema is shared and must be treated as read-only.
         """
+        # Resolve config identity before acquiring the lock so file stat I/O
+        # doesn't block unrelated cache operations.
+        identity = self._config_identity()
         with self._lock:
             self._refresh_settings()
-            self._invalidate_if_config_changed_locked()
+            self._invalidate_if_config_changed_locked(*identity)
             entry = self._schemas.get(dataset_id)
             if entry and not self._is_expired(entry.loaded_at):
                 self._counters["cache_hit"] += 1
@@ -144,17 +146,33 @@ class _DatasetSchemaCache:
                     extra={"cache_event": "hit", "dataset_id": dataset_id},
                 )
                 return entry.schema
+
+        # YAML parsing can be expensive; do it outside the lock.
+        schema = None
+        config = load_datasets_config()
+        for ds in config.get("datasets", []):
+            if isinstance(ds, dict) and ds.get("dataset_id") == dataset_id:
+                schema = {"dataset_id": dataset_id, "fields": ds.get("fields", [])}
+                break
+
+        # Double-check once more to avoid overwriting a fresh cache entry that
+        # may have been populated by another thread while we were loading YAML.
+        identity = self._config_identity()
+        with self._lock:
+            self._refresh_settings()
+            self._invalidate_if_config_changed_locked(*identity)
+            entry = self._schemas.get(dataset_id)
+            if entry and not self._is_expired(entry.loaded_at):
+                self._counters["cache_hit"] += 1
+                logger.debug(
+                    "dataset schema cache hit (post-load)",
+                    extra={"cache_event": "hit", "dataset_id": dataset_id},
+                )
+                return entry.schema
+
             if entry and self._is_expired(entry.loaded_at):
                 self._counters["refresh_count"] += 1
             self._counters["cache_miss"] += 1
-
-            schema = None
-            config = load_datasets_config()
-            for ds in config.get("datasets", []):
-                if isinstance(ds, dict) and ds.get("dataset_id") == dataset_id:
-                    schema = {"dataset_id": dataset_id, "fields": ds.get("fields", [])}
-                    break
-
             self._store_schema_locked(dataset_id, schema)
             logger.info(
                 "dataset schema cached",

--- a/server/tests/test_datasets_cache.py
+++ b/server/tests/test_datasets_cache.py
@@ -1,6 +1,8 @@
 """Caching tests for dataset metadata."""
 
+from concurrent.futures import ThreadPoolExecutor
 import os
+import threading
 import time
 from pathlib import Path
 
@@ -128,3 +130,35 @@ def test_partition_metadata_hooks(monkeypatch) -> None:
 
     datasets.clear_partition_metadata("ds")
     assert datasets.get_partition_metadata("ds") is None
+
+
+def test_schema_cache_concurrent_reads_consistent(monkeypatch) -> None:
+    calls = {"count": 0}
+
+    def fake_load():
+        calls["count"] += 1
+        time.sleep(0.02)
+        return {
+            "datasets": [
+                {"dataset_id": "concurrent_ds", "fields": [{"name": "id", "type": "string"}]}
+            ]
+        }
+
+    monkeypatch.setattr(datasets, "load_datasets_config", fake_load)
+    monkeypatch.setattr(datasets, "get_settings", lambda: _settings(None, ttl=1))
+    datasets.reset_cache()
+
+    start = threading.Barrier(8)
+
+    def worker():
+        start.wait()
+        return datasets.get_schema("concurrent_ds")
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(lambda _: worker(), range(8)))
+
+    assert all(r == results[0] for r in results)
+    assert results[0]["dataset_id"] == "concurrent_ds"
+    stats = datasets.get_cache_stats()
+    assert stats["cache_hit"] >= 1
+    assert calls["count"] >= 1


### PR DESCRIPTION
## Summary
Reduces schema-cache lock contention by moving config identity/file access and YAML parsing out of the cache critical section, while preserving cache correctness with a double-checked flow.

Closes #135.

## Changes
- Refactored `_DatasetSchemaCache.get_schema()` in `server/datasets.py`:
  - Compute config identity (`path`, `mtime`) before lock acquisition.
  - Perform quick in-lock cache check for hot hits.
  - Load/parse YAML outside the lock on miss/refresh.
  - Reacquire lock and re-check cache to avoid overwriting a fresh entry populated by another thread.
- Changed `_invalidate_if_config_changed_locked` to accept precomputed identity, removing file-stat I/O from lock scope.
- Added concurrency-focused test in `server/tests/test_datasets_cache.py`:
  - parallel callers resolve the same dataset consistently under concurrent misses.

## Validation
- `./.venv-server/bin/pytest server/tests/test_datasets_cache.py -q`
- `./.venv-server/bin/pytest server/tests -q`
- Result: `314 passed`
