### PR TITLE
Tune DuckDB runtime settings and deployment profile

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -13,7 +13,8 @@ COPY server/ server/
 
 ENV PYTHONPATH=/app
 ENV PYTHONUNBUFFERED=1
+ENV UVICORN_WORKERS=1
 
 EXPOSE 8000
 
-CMD ["uvicorn", "server.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["sh", "-c", "uvicorn server.main:app --host 0.0.0.0 --port 8000 --workers ${UVICORN_WORKERS}"]

--- a/server/README.md
+++ b/server/README.md
@@ -39,7 +39,7 @@ PYTHONPATH=. ./.venv-server/bin/python -m server.main
 - `POST /query/picklist` – distinct values for a field with search/paging
 - `POST /export` – submit an export job (background processing)
 - `GET /export/{export_id}` – poll export status/download URL
-- `GET /export/{export_id}/download` – download completed CSV
+- `GET /export/{export_id}/download` – download completed export artifact
 - `GET /health/liveness` – liveness probe
 - `GET /health/readiness` – readiness probe
 
@@ -63,7 +63,7 @@ From the repo root:
 
 ```bash
 docker build -f server/Dockerfile -t query-service .
-docker run -p 8000:8000 query-service
+docker run -p 8000:8000 -e UVICORN_WORKERS=1 query-service
 ```
 
 ## Config
@@ -77,6 +77,10 @@ Environment variables (prefix `QUERYSERVICE_`):
 - `QUERYSERVICE_DATASETS_CONFIG_PATH` (default bundled `datasets_config/datasets.yaml`)
 - `QUERYSERVICE_SEED_SAMPLE_DATA` (default `true`)
 - `QUERYSERVICE_DATA_DIR` (default `None`, DuckDB in-memory; set to persist)
+- `QUERYSERVICE_DUCKDB_THREADS` (default auto, conservative: `min(4, CPU/worker)`)
+- `QUERYSERVICE_DUCKDB_MEMORY_LIMIT` (default unset, DuckDB default)
+- `QUERYSERVICE_DUCKDB_TEMP_DIRECTORY` (default `/tmp/huey-duckdb-tmp`)
+- `QUERYSERVICE_DUCKDB_ENABLE_OBJECT_CACHE` (default `true`)
 - `QUERYSERVICE_EXPORT_TTL_SECONDS` (default `3600`)
 - `QUERYSERVICE_EXPORT_MAX_CONCURRENT` (default `5`)
 - `QUERYSERVICE_EXPORT_OUTPUT_DIR` (default `/tmp/huey-exports`)
@@ -90,6 +94,32 @@ config file changes on disk or when the TTL elapses. Use the TTL env var to tune
 refresh cadence for your deployment.
 
 Optional `.env` in the working directory is also loaded.
+
+## Runtime Tuning Profile
+
+QueryService applies DuckDB runtime settings at startup and logs the effective
+values (`threads`, `memory_limit`, `temp_directory`, `enable_object_cache`).
+
+Recommended baseline profiles:
+
+- `dev`:
+  - `UVICORN_WORKERS=1`
+  - `QUERYSERVICE_DUCKDB_THREADS` unset (auto)
+  - `QUERYSERVICE_DUCKDB_MEMORY_LIMIT=2GB`
+- `staging`:
+  - `UVICORN_WORKERS=1`
+  - `QUERYSERVICE_DUCKDB_THREADS=4` (or unset for auto)
+  - `QUERYSERVICE_DUCKDB_MEMORY_LIMIT=8GB`
+- `prod` (large analytical workloads):
+  - Start with `UVICORN_WORKERS=1` to avoid CPU oversubscription.
+  - Scale workers only when needed for mixed/short queries.
+  - If `UVICORN_WORKERS>1`, reduce `QUERYSERVICE_DUCKDB_THREADS` per worker so total threads do not exceed available vCPUs.
+
+Resource sizing baseline:
+
+- CPU: keep total `workers * duckdb_threads <= vCPU count`
+- Memory: reserve headroom for app and OS (`duckdb_memory_limit` set with explicit units, e.g. `8GB`)
+- Disk: place `duckdb_temp_directory` on fast local SSD for spill-heavy queries
 
 ## Try Huey with this backend (remote datasource)
 

--- a/server/config.py
+++ b/server/config.py
@@ -6,6 +6,7 @@ Loads settings from environment variables and optional config file.
 
 from functools import lru_cache
 
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -33,6 +34,10 @@ class Settings(BaseSettings):
 
     # DuckDB
     data_dir: str | None = None  # Path to DuckDB database file; None = in-memory
+    duckdb_threads: int | None = Field(default=None, ge=1, le=128)
+    duckdb_memory_limit: str | None = None
+    duckdb_temp_directory: str | None = "/tmp/huey-duckdb-tmp"
+    duckdb_enable_object_cache: bool = True
 
     # Export
     export_ttl_seconds: int = 3600
@@ -46,6 +51,17 @@ class Settings(BaseSettings):
     # Optional: S3 / engine config (for later issues)
     s3_bucket: str | None = None
     s3_region: str | None = None
+
+    @field_validator("duckdb_memory_limit", "duckdb_temp_directory")
+    @classmethod
+    def _empty_string_to_none_or_value(cls, v: str | None) -> str | None:
+        """Normalize optional string settings and reject blank values."""
+        if v is None:
+            return None
+        value = v.strip()
+        if value == "":
+            return None
+        return value
 
 
 @lru_cache

--- a/server/engine.py
+++ b/server/engine.py
@@ -7,9 +7,11 @@ The manager is initialized at application startup and shut down on exit.
 
 import asyncio
 import logging
+import os
 import threading
 from collections.abc import Generator
 from contextlib import contextmanager
+from pathlib import Path
 from typing import Any
 
 import duckdb
@@ -41,7 +43,64 @@ class DuckDBManager:
         data_dir = getattr(settings, "data_dir", None)
         db_path = data_dir if data_dir else database
         self._conn = duckdb.connect(db_path)
+        self._apply_runtime_tuning(self._conn, settings)
         logger.info("DuckDB connection opened", extra={"database": db_path})
+
+    @staticmethod
+    def _resolved_default_threads() -> int:
+        """Choose a conservative thread default to avoid CPU oversubscription."""
+        cpu_count = max(1, os.cpu_count() or 1)
+        try:
+            workers = int(os.environ.get("UVICORN_WORKERS", "1"))
+        except ValueError:
+            workers = 1
+        workers = max(1, workers)
+        return max(1, min(4, cpu_count // workers))
+
+    def _apply_runtime_tuning(self, conn: duckdb.DuckDBPyConnection, settings: Any) -> None:
+        """Apply startup/session settings for DuckDB runtime performance."""
+        threads = getattr(settings, "duckdb_threads", None)
+        if threads is None:
+            threads = self._resolved_default_threads()
+        conn.execute("SET threads = ?", [threads])
+
+        memory_limit = getattr(settings, "duckdb_memory_limit", None)
+        if memory_limit:
+            conn.execute("SET memory_limit = ?", [memory_limit])
+
+        temp_directory = getattr(settings, "duckdb_temp_directory", None)
+        if temp_directory:
+            Path(temp_directory).mkdir(parents=True, exist_ok=True)
+            conn.execute("SET temp_directory = ?", [temp_directory])
+
+        object_cache = getattr(settings, "duckdb_enable_object_cache", True)
+        conn.execute("SET enable_object_cache = ?", [bool(object_cache)])
+
+        with self._lock:
+            cur = conn.cursor()
+        try:
+            active_threads = int(cur.execute("SELECT current_setting('threads')").fetchone()[0])
+            active_memory_limit = str(
+                cur.execute("SELECT current_setting('memory_limit')").fetchone()[0]
+            )
+            active_temp_directory = str(
+                cur.execute("SELECT current_setting('temp_directory')").fetchone()[0]
+            )
+            active_object_cache = bool(
+                cur.execute("SELECT current_setting('enable_object_cache')").fetchone()[0]
+            )
+        finally:
+            cur.close()
+
+        logger.info(
+            "DuckDB runtime tuning applied",
+            extra={
+                "duckdb_threads": active_threads,
+                "duckdb_memory_limit": active_memory_limit,
+                "duckdb_temp_directory": active_temp_directory,
+                "duckdb_enable_object_cache": active_object_cache,
+            },
+        )
 
     def shutdown(self) -> None:
         """Close the persistent connection."""

--- a/server/tests/test_config.py
+++ b/server/tests/test_config.py
@@ -1,5 +1,8 @@
 """Unit tests for QueryService config."""
 
+import pytest
+from pydantic import ValidationError
+
 from server.config import Settings, get_settings
 
 
@@ -23,3 +26,17 @@ def test_settings_defaults() -> None:
     assert hasattr(s, "datasets_config_path")
     assert hasattr(s, "s3_bucket")
     assert hasattr(s, "s3_region")
+    assert s.duckdb_memory_limit is None
+    assert s.duckdb_temp_directory == "/tmp/huey-duckdb-tmp"
+    assert s.duckdb_enable_object_cache is True
+
+
+def test_duckdb_threads_validation() -> None:
+    with pytest.raises(ValidationError):
+        Settings(duckdb_threads=0)
+
+
+def test_duckdb_optional_strings_normalized() -> None:
+    s = Settings(duckdb_memory_limit="  ", duckdb_temp_directory=" ")
+    assert s.duckdb_memory_limit is None
+    assert s.duckdb_temp_directory is None

--- a/server/tests/test_engine.py
+++ b/server/tests/test_engine.py
@@ -1,5 +1,7 @@
 """Tests for DuckDB engine integration and DuckDBManager."""
 
+import os
+
 import pytest
 
 from server.engine import DuckDBManager, get_connection
@@ -80,6 +82,36 @@ class TestDuckDBManager:
             assert rows == [[7]]
         finally:
             mgr.shutdown()
+
+    def test_initialize_applies_runtime_tuning(self, monkeypatch, tmp_path) -> None:
+        class MockSettings:
+            data_dir = None
+            duckdb_threads = 2
+            duckdb_memory_limit = "512MB"
+            duckdb_temp_directory = str(tmp_path / "duckdb-spill")
+            duckdb_enable_object_cache = False
+
+        monkeypatch.setattr("server.engine.get_settings", lambda: MockSettings())
+        mgr = DuckDBManager()
+        mgr.initialize()
+        try:
+            with mgr.cursor() as cur:
+                assert cur.execute("SELECT current_setting('threads')").fetchone()[0] == 2
+                assert cur.execute("SELECT current_setting('temp_directory')").fetchone()[0] == str(tmp_path / "duckdb-spill")
+                assert cur.execute("SELECT current_setting('enable_object_cache')").fetchone()[0] is False
+                assert cur.execute("SELECT current_setting('memory_limit')").fetchone()[0]
+        finally:
+            mgr.shutdown()
+
+    def test_default_threads_considers_uvicorn_workers(self, monkeypatch) -> None:
+        monkeypatch.setattr(os, "cpu_count", lambda: 8)
+        monkeypatch.setenv("UVICORN_WORKERS", "2")
+        assert DuckDBManager._resolved_default_threads() == 4
+
+    def test_default_threads_handles_invalid_worker_env(self, monkeypatch) -> None:
+        monkeypatch.setattr(os, "cpu_count", lambda: 8)
+        monkeypatch.setenv("UVICORN_WORKERS", "not-a-number")
+        assert DuckDBManager._resolved_default_threads() == 4
 
 
 class TestGetConnection:


### PR DESCRIPTION
## Summary
Implements DuckDB runtime tuning controls and deployment guidance for analytical throughput.

Closes #110.

## What changed
- Added DuckDB tuning settings in `server/config.py`:
  - `duckdb_threads` (optional, validated >=1)
  - `duckdb_memory_limit` (optional)
  - `duckdb_temp_directory` (optional)
  - `duckdb_enable_object_cache` (bool)
- Applied tuning during engine startup in `server/engine.py`:
  - sets `threads`, `memory_limit`, `temp_directory`, and `enable_object_cache`
  - creates temp spill directory when configured
  - logs effective runtime settings at startup
  - conservative auto-thread default: `min(4, cpu_count / UVICORN_WORKERS)`
- Added tests:
  - config validation/default tests (`server/tests/test_config.py`)
  - engine smoke test proving startup settings apply without errors (`server/tests/test_engine.py`)
  - auto-thread default behavior tests with worker env values
- Updated deployment docs:
  - backend config env vars and tuning profile guidance (`server/README.md`)
  - Docker runtime worker env (`UVICORN_WORKERS`) in `server/Dockerfile`

## Validation
- `./.venv-server/bin/pytest server/tests/test_config.py server/tests/test_engine.py -q`
- `./.venv-server/bin/pytest server/tests -q`
- Result: `319 passed`
