### PR TITLE
Harden date_range validation with strict calendar parsing

### DIFF
--- a/server/models.py
+++ b/server/models.py
@@ -5,12 +5,10 @@ All user-facing fields use Literal types and Pydantic Field constraints
 so invalid requests fail fast with clear 422 errors.
 """
 
-import re
+from datetime import date
 from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, Field, field_validator, model_validator
-
-_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 FilterOperator = Literal["INCLUDE", "EXCLUDE", "LIKE", "BETWEEN"]
 SortDirection = Literal["ASC", "DESC"]
@@ -18,6 +16,17 @@ ExportFormat = Literal["parquet", "csv"]
 
 MAX_PAGE_LIMIT = 10000
 MAX_EXPORT_ROWS = 100000
+
+
+def _parse_iso_date(value: str) -> str:
+    """Validate strict calendar date strings in YYYY-MM-DD format."""
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError as exc:
+        raise ValueError("Invalid date, use real YYYY-MM-DD date") from exc
+    if parsed.isoformat() != value:
+        raise ValueError("Invalid date, use real YYYY-MM-DD date")
+    return value
 
 
 # --- Date range (envelope) ---
@@ -30,10 +39,8 @@ class DateRangeSingle(BaseModel):
     @field_validator("date")
     @classmethod
     def validate_date_format(cls, v: str) -> str:
-        """Ensure date strings follow YYYY-MM-DD."""
-        if not _DATE_RE.match(v):
-            raise ValueError("Invalid date format, use YYYY-MM-DD")
-        return v
+        """Ensure date strings follow real calendar dates in YYYY-MM-DD."""
+        return _parse_iso_date(v)
 
 
 class DateRangeRange(BaseModel):
@@ -46,15 +53,13 @@ class DateRangeRange(BaseModel):
     @field_validator("start", "end")
     @classmethod
     def validate_date_format(cls, v: str) -> str:
-        """Ensure start/end date strings follow YYYY-MM-DD."""
-        if not _DATE_RE.match(v):
-            raise ValueError("Invalid date format, use YYYY-MM-DD")
-        return v
+        """Ensure start/end strings are real calendar dates in YYYY-MM-DD."""
+        return _parse_iso_date(v)
 
     @model_validator(mode="after")
     def check_start_before_end(self) -> "DateRangeRange":
         """Validate that the range start is not after the end."""
-        if self.start > self.end:
+        if date.fromisoformat(self.start) > date.fromisoformat(self.end):
             raise ValueError("Date range start must be <= end")
         return self
 

--- a/server/tests/test_models.py
+++ b/server/tests/test_models.py
@@ -34,6 +34,14 @@ class TestDateRangeSingle:
         with pytest.raises(ValidationError, match="YYYY-MM-DD"):
             DateRangeSingle(type="single", date="")
 
+    def test_invalid_calendar_day(self) -> None:
+        with pytest.raises(ValidationError, match="YYYY-MM-DD"):
+            DateRangeSingle(type="single", date="2026-02-30")
+
+    def test_invalid_calendar_month(self) -> None:
+        with pytest.raises(ValidationError, match="YYYY-MM-DD"):
+            DateRangeSingle(type="single", date="2026-13-01")
+
     def test_wrong_type_literal(self) -> None:
         with pytest.raises(ValidationError):
             DateRangeSingle(type="range", date="2026-03-01")
@@ -60,6 +68,14 @@ class TestDateRangeRange:
     def test_bad_end_format(self) -> None:
         with pytest.raises(ValidationError, match="YYYY-MM-DD"):
             DateRangeRange(type="range", start="2026-01-01", end="bad")
+
+    def test_bad_start_calendar_date(self) -> None:
+        with pytest.raises(ValidationError, match="YYYY-MM-DD"):
+            DateRangeRange(type="range", start="2026-02-30", end="2026-03-01")
+
+    def test_bad_end_calendar_date(self) -> None:
+        with pytest.raises(ValidationError, match="YYYY-MM-DD"):
+            DateRangeRange(type="range", start="2026-03-01", end="2026-13-01")
 
 
 class TestTupleFieldSpec:

--- a/server/tests/test_validation_errors.py
+++ b/server/tests/test_validation_errors.py
@@ -79,6 +79,14 @@ class TestCommonValidation:
         })
         assert r.status_code == 422
 
+    def test_date_invalid_calendar_value(self, client: TestClient, endpoint: str) -> None:
+        r = client.post(endpoint, json={
+            "dataset_id": "trades_v1",
+            "date_range": {"type": "single", "date": "2026-02-30"},
+            "query": {},
+        })
+        assert r.status_code == 422
+
     def test_date_range_inverted(self, client: TestClient, endpoint: str) -> None:
         r = client.post(endpoint, json={
             "dataset_id": "trades_v1",
@@ -99,6 +107,14 @@ class TestCommonValidation:
         r = client.post(endpoint, json={
             "dataset_id": "trades_v1",
             "date_range": {"type": "single"},
+            "query": {},
+        })
+        assert r.status_code == 422
+
+    def test_date_range_invalid_calendar_value(self, client: TestClient, endpoint: str) -> None:
+        r = client.post(endpoint, json={
+            "dataset_id": "trades_v1",
+            "date_range": {"type": "range", "start": "2026-01-01", "end": "2026-13-01"},
             "query": {},
         })
         assert r.status_code == 422


### PR DESCRIPTION
## Summary
Replaces regex-only date validation with strict calendar parsing for `date_range` fields.

Closes #134.

## Changes
- `server/models.py`
  - Added `_parse_iso_date()` using `datetime.date.fromisoformat`.
  - `DateRangeSingle.date` and `DateRangeRange.start/end` validators now require real calendar dates in strict `YYYY-MM-DD` form.
  - Preserved range-order validation (`start <= end`) using parsed dates.
- `server/tests/test_models.py`
  - Added model-level invalid-calendar tests:
    - `2026-02-30`
    - `2026-13-01`
- `server/tests/test_validation_errors.py`
  - Added API-level 422 tests for invalid calendar dates in both single and range date payloads across all POST endpoints.

## Validation
- `./.venv-server/bin/pytest server/tests/test_models.py server/tests/test_validation_errors.py -q`
- `./.venv-server/bin/pytest server/tests -q`
- Result: `340 passed`
