### PR TITLE
Handle configured-but-unavailable datasets as domain errors

### DIFF
--- a/server/auth.py
+++ b/server/auth.py
@@ -1,6 +1,6 @@
 """Authentication dependency for QueryService."""
 
-from fastapi import Depends, HTTPException, Security
+from fastapi import HTTPException, Security
 from fastapi.security import APIKeyHeader
 
 from server.config import get_settings

--- a/server/engine.py
+++ b/server/engine.py
@@ -17,8 +17,17 @@ from typing import Any
 import duckdb
 
 from server.config import get_settings
+from server.errors import DatasetUnavailableError
 
 logger = logging.getLogger("query_service.engine")
+
+
+def is_missing_table_error(exc: Exception) -> bool:
+    """Return True when DuckDB error indicates a missing table/catalog relation."""
+    if not isinstance(exc, duckdb.CatalogException):
+        return False
+    msg = str(exc).lower()
+    return "table with name" in msg and "does not exist" in msg
 
 
 class DuckDBManager:
@@ -126,18 +135,48 @@ class DuckDBManager:
         finally:
             cur.close()
 
-    def execute_sql(self, sql: str, parameters: tuple[Any, ...] | None = None) -> list[list[Any]]:
+    def execute_sql(
+        self,
+        sql: str,
+        parameters: tuple[Any, ...] | None = None,
+        *,
+        dataset_id: str | None = None,
+    ) -> list[list[Any]]:
         """Execute a SQL query and return rows as list of lists."""
         with self.cursor() as cur:
-            if parameters:
-                result = cur.execute(sql, parameters).fetchall()
-            else:
-                result = cur.execute(sql).fetchall()
-            return [list(row) for row in result]
+            try:
+                if parameters:
+                    result = cur.execute(sql, parameters).fetchall()
+                else:
+                    result = cur.execute(sql).fetchall()
+                return [list(row) for row in result]
+            except Exception as exc:
+                if dataset_id and is_missing_table_error(exc):
+                    raise DatasetUnavailableError(dataset_id) from exc
+                raise
 
-    async def execute_sql_async(self, sql: str, parameters: tuple[Any, ...] | None = None) -> list[list[Any]]:
+    async def execute_sql_async(
+        self,
+        sql: str,
+        parameters: tuple[Any, ...] | None = None,
+        *,
+        dataset_id: str | None = None,
+    ) -> list[list[Any]]:
         """Run SQL in a thread pool to avoid blocking the event loop."""
-        return await asyncio.to_thread(self.execute_sql, sql, parameters)
+        return await asyncio.to_thread(
+            self.execute_sql,
+            sql,
+            parameters,
+            dataset_id=dataset_id,
+        )
+
+    def table_exists(self, table_name: str) -> bool:
+        """Return True when a table is present in DuckDB catalog."""
+        rows = self.execute_sql(
+            "SELECT COUNT(*) FROM information_schema.tables WHERE table_name = ?",
+            (table_name,),
+        )
+        return bool(rows and rows[0][0] > 0)
 
     def health_check(self) -> bool:
         """Return True if the connection is alive."""

--- a/server/errors.py
+++ b/server/errors.py
@@ -49,6 +49,18 @@ class DatasetNotFoundError(AppError):
         )
 
 
+class DatasetUnavailableError(AppError):
+    """Raised when dataset metadata exists but backing table/data is unavailable."""
+
+    def __init__(self, dataset_id: str) -> None:
+        super().__init__(
+            code="DATASET_UNAVAILABLE",
+            message="Dataset is configured but not available for querying",
+            status_code=409,
+            details={"dataset_id": dataset_id},
+        )
+
+
 class ExportNotFoundError(AppError):
     """Raised when an export job ID does not exist in the job store."""
 

--- a/server/export_service.py
+++ b/server/export_service.py
@@ -11,8 +11,9 @@ from pathlib import Path
 
 from server import datasets
 from server.config import get_settings
-from server.engine import db_manager
+from server.engine import db_manager, is_missing_table_error
 from server.errors import (
+    DatasetUnavailableError,
     ExportFileNotFoundError,
     ExportNotFoundError,
     ExportNotReadyError,
@@ -88,7 +89,11 @@ class ExportService:
             query_params = tuple(params) if params else None
 
             count_sql = f"SELECT COUNT(*) FROM ({sql}) AS export_rows"
-            count_rows = db_manager.execute_sql(count_sql, query_params)
+            count_rows = db_manager.execute_sql(
+                count_sql,
+                query_params,
+                dataset_id=body.dataset_id,
+            )
             row_count = int(count_rows[0][0]) if count_rows else 0
 
             escaped_path = _escape_sql_string(str(file_path))
@@ -97,10 +102,15 @@ class ExportService:
             else:
                 copy_sql = f"COPY ({sql}) TO '{escaped_path}' (FORMAT CSV, HEADER TRUE)"
             with db_manager.cursor() as cur:
-                if query_params:
-                    cur.execute(copy_sql, query_params)
-                else:
-                    cur.execute(copy_sql)
+                try:
+                    if query_params:
+                        cur.execute(copy_sql, query_params)
+                    else:
+                        cur.execute(copy_sql)
+                except Exception as exc:
+                    if is_missing_table_error(exc):
+                        raise DatasetUnavailableError(body.dataset_id) from exc
+                    raise
 
             self._store.update_status(
                 job_id, "complete",
@@ -111,6 +121,16 @@ class ExportService:
             logger.info(
                 "Export complete",
                 extra={"export_id": job_id, "row_count": row_count},
+            )
+        except DatasetUnavailableError as exc:
+            self._store.update_status(
+                job_id,
+                "failed",
+                error_message=f"{exc.code}: {exc.message} ({body.dataset_id})",
+            )
+            logger.warning(
+                "Export failed due to unavailable dataset",
+                extra={"export_id": job_id, "dataset_id": body.dataset_id, "error_code": exc.code},
             )
         except Exception:
             self._store.update_status(job_id, "failed", error_message="Export processing failed")

--- a/server/main.py
+++ b/server/main.py
@@ -3,6 +3,7 @@ QueryService – Huey OLAP backend.
 
 FastAPI application with health endpoints, config loader, and structured logging.
 """
+# ruff: noqa: E402
 
 import logging
 from contextlib import asynccontextmanager

--- a/server/routers/export.py
+++ b/server/routers/export.py
@@ -13,7 +13,8 @@ from fastapi.responses import FileResponse
 
 from server import datasets
 from server.auth import require_api_key
-from server.errors import DatasetNotFoundError
+from server.engine import db_manager
+from server.errors import DatasetNotFoundError, DatasetUnavailableError
 from server.export_service import get_export_service
 from server.models import ExportRequest, ExportResponse, ExportStatusResponse
 from server.request_context import set_request_id
@@ -37,6 +38,8 @@ async def post_export(
         request.state.request_id = rid
     if datasets.get_schema(body.dataset_id) is None:
         raise DatasetNotFoundError(body.dataset_id)
+    if not db_manager.table_exists(body.dataset_id):
+        raise DatasetUnavailableError(body.dataset_id)
 
     service = get_export_service()
     job = service.submit(body)

--- a/server/routers/query.py
+++ b/server/routers/query.py
@@ -25,8 +25,8 @@ from server.query_builder import (
     build_cells_sql,
     build_picklist_count_sql,
     build_picklist_sql,
-    build_tuples_sql,
     build_tuples_count_sql,
+    build_tuples_sql,
 )
 from server.request_context import set_request_id
 
@@ -57,7 +57,11 @@ async def post_query_tuples(body: QueryTuplesRequest, request: Request, _api_key
 
     start = time.perf_counter()
     sql, params = build_tuples_sql(body.dataset_id, body.query, body.date_range, schema_fields)
-    rows = await db_manager.execute_sql_async(sql, tuple(params) if params else None)
+    rows = await db_manager.execute_sql_async(
+        sql,
+        tuple(params) if params else None,
+        dataset_id=body.dataset_id,
+    )
     if rows:
         total_count = int(rows[0][-1])
         items = [TupleItem(values=list(row[:-1])) for row in rows]
@@ -68,7 +72,11 @@ async def post_query_tuples(body: QueryTuplesRequest, request: Request, _api_key
     # Fallback to a lightweight count when page is empty (e.g., offset beyond results)
     if total_count == 0 and (paging.offset if paging else 0) > 0:
         count_sql, count_params = build_tuples_count_sql(body.dataset_id, body.query, body.date_range, schema_fields)
-        count_rows = await db_manager.execute_sql_async(count_sql, tuple(count_params) if count_params else None)
+        count_rows = await db_manager.execute_sql_async(
+            count_sql,
+            tuple(count_params) if count_params else None,
+            dataset_id=body.dataset_id,
+        )
         if count_rows:
             total_count = int(count_rows[0][0])
     duration_ms = (time.perf_counter() - start) * 1000
@@ -103,7 +111,11 @@ async def post_query_cells(body: QueryCellsRequest, request: Request, _api_key: 
 
     start = time.perf_counter()
     sql, params = build_cells_sql(body.dataset_id, body.query, body.date_range, schema_fields)
-    rows = await db_manager.execute_sql_async(sql, tuple(params) if params else None)
+    rows = await db_manager.execute_sql_async(
+        sql,
+        tuple(params) if params else None,
+        dataset_id=body.dataset_id,
+    )
     duration_ms = (time.perf_counter() - start) * 1000
 
     logger.info(
@@ -137,7 +149,11 @@ async def post_query_picklist(body: QueryPicklistRequest, request: Request, _api
 
     start = time.perf_counter()
     sql, params = build_picklist_sql(body.dataset_id, body.query, body.date_range, schema_fields)
-    rows = await db_manager.execute_sql_async(sql, tuple(params) if params else None)
+    rows = await db_manager.execute_sql_async(
+        sql,
+        tuple(params) if params else None,
+        dataset_id=body.dataset_id,
+    )
     if rows:
         total_count = int(rows[0][-1])
         values = [{"value": str(row[0]), "label": str(row[0])} for row in rows]
@@ -148,7 +164,11 @@ async def post_query_picklist(body: QueryPicklistRequest, request: Request, _api
     # Fallback to count when page is empty (e.g., offset beyond available values)
     if total_count == 0 and (paging.offset if paging else 0) > 0:
         count_sql, count_params = build_picklist_count_sql(body.dataset_id, body.query, body.date_range, schema_fields)
-        count_rows = await db_manager.execute_sql_async(count_sql, tuple(count_params) if count_params else None)
+        count_rows = await db_manager.execute_sql_async(
+            count_sql,
+            tuple(count_params) if count_params else None,
+            dataset_id=body.dataset_id,
+        )
         if count_rows:
             total_count = int(count_rows[0][0])
     duration_ms = (time.perf_counter() - start) * 1000

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -1,8 +1,9 @@
 """Shared test fixtures for backend tests."""
 
+from unittest.mock import patch
+
 import pytest
 from fastapi.testclient import TestClient
-from unittest.mock import patch
 
 from server.config import get_settings
 from server.datasets import load_sample_data

--- a/server/tests/test_datasets_cache.py
+++ b/server/tests/test_datasets_cache.py
@@ -1,9 +1,9 @@
 """Caching tests for dataset metadata."""
 
-from concurrent.futures import ThreadPoolExecutor
 import os
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest

--- a/server/tests/test_engine.py
+++ b/server/tests/test_engine.py
@@ -5,6 +5,7 @@ import os
 import pytest
 
 from server.engine import DuckDBManager, get_connection
+from server.errors import DatasetUnavailableError
 
 
 class TestDuckDBManager:
@@ -72,6 +73,17 @@ class TestDuckDBManager:
     def test_health_check_unhealthy(self) -> None:
         mgr = DuckDBManager()
         assert mgr.health_check() is False
+
+    def test_missing_table_maps_to_dataset_unavailable(self) -> None:
+        mgr = DuckDBManager()
+        mgr.initialize()
+        try:
+            with pytest.raises(DatasetUnavailableError) as exc:
+                mgr.execute_sql("SELECT * FROM missing_table", dataset_id="missing_ds")
+            assert exc.value.code == "DATASET_UNAVAILABLE"
+            assert exc.value.details["dataset_id"] == "missing_ds"
+        finally:
+            mgr.shutdown()
 
     @pytest.mark.anyio
     async def test_execute_sql_async(self) -> None:

--- a/server/tests/test_error_contract.py
+++ b/server/tests/test_error_contract.py
@@ -11,6 +11,7 @@ from starlette.testclient import TestClient
 from server.errors import (
     AppError,
     DatasetNotFoundError,
+    DatasetUnavailableError,
     ExportFileNotFoundError,
     ExportNotFoundError,
     ExportNotReadyError,
@@ -123,6 +124,56 @@ class TestErrorResponseSchema:
         assert body["code"] == "TOO_MANY_EXPORTS"
         assert body["details"]["max_concurrent"] == 5
 
+    @pytest.mark.parametrize("endpoint", ["/query/tuples", "/query/cells", "/query/picklist"])
+    def test_query_409_dataset_unavailable_envelope(self, client: TestClient, endpoint: str, monkeypatch) -> None:
+        import server.routers.query as query_router
+
+        monkeypatch.setattr(
+            query_router.datasets,
+            "get_schema",
+            lambda dataset_id: {"dataset_id": dataset_id, "fields": [{"name": "symbol"}, {"name": "date"}]},
+        )
+        monkeypatch.setattr(
+            query_router.datasets,
+            "get_schema_field_names",
+            lambda _dataset_id: {"symbol", "date", "volume"},
+        )
+
+        body = _query_body(dataset_id="not_materialized_ds")
+        if endpoint == "/query/tuples":
+            body["query"] = {"fields": [{"field": "symbol"}]}
+        elif endpoint == "/query/picklist":
+            body["query"] = {"field": "symbol"}
+        else:
+            body["query"] = {
+                "axes": {
+                    "rows": [{"field": "symbol"}],
+                    "columns": [],
+                    "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_vol"}],
+                },
+            }
+
+        r = client.post(endpoint, json=body)
+        assert r.status_code == 409
+        payload = r.json()
+        assert payload["code"] == "DATASET_UNAVAILABLE"
+        assert payload["details"]["dataset_id"] == "not_materialized_ds"
+
+    def test_export_post_409_dataset_unavailable_envelope(self, client: TestClient, monkeypatch) -> None:
+        import server.routers.export as export_router
+
+        monkeypatch.setattr(
+            export_router.datasets,
+            "get_schema",
+            lambda dataset_id: {"dataset_id": dataset_id, "fields": [{"name": "symbol"}]},
+        )
+        monkeypatch.setattr(export_router.db_manager, "table_exists", lambda _dataset_id: False)
+        r = client.post("/export", json=_export_body(dataset_id="not_materialized_ds"))
+        assert r.status_code == 409
+        payload = r.json()
+        assert payload["code"] == "DATASET_UNAVAILABLE"
+        assert payload["details"]["dataset_id"] == "not_materialized_ds"
+
 
 class TestValidationErrorEnvelope:
     """422 validation errors wrap Pydantic details in standard envelope."""
@@ -203,6 +254,12 @@ class TestDomainExceptions:
         err = DatasetNotFoundError("ds1")
         assert err.code == "DATASET_NOT_FOUND"
         assert err.status_code == 404
+        assert err.details["dataset_id"] == "ds1"
+
+    def test_dataset_unavailable(self) -> None:
+        err = DatasetUnavailableError("ds1")
+        assert err.code == "DATASET_UNAVAILABLE"
+        assert err.status_code == 409
         assert err.details["dataset_id"] == "ds1"
 
     def test_export_not_found(self) -> None:

--- a/tests/ui/theme.spec.js
+++ b/tests/ui/theme.spec.js
@@ -4,7 +4,7 @@ const { test, expect } = require('@playwright/test');
 async function waitForAppReady(page) {
   await page.goto('/index.html');
   await expect(page.locator('body')).toHaveAttribute('aria-busy', 'false', { timeout: 60000 });
-  await expect(page.locator('#settingsButton')).toBeVisible({ timeout: 20000 });
+  await expect(page.locator('label[for="settingsButton"]')).toBeVisible({ timeout: 20000 });
 }
 
 test.describe('Theme', () => {
@@ -15,14 +15,14 @@ test.describe('Theme', () => {
       getComputedStyle(document.documentElement).getPropertyValue('--huey-medium-background-color').trim()
     );
 
-    const settingsButton = page.locator('#settingsButton');
-    if (!(await settingsButton.isVisible({ timeout: 30000 }).catch(() => false))) {
-      test.skip('Settings button not visible');
+    const settingsTrigger = page.locator('label[for="settingsButton"]');
+    if (!(await settingsTrigger.isVisible({ timeout: 30000 }).catch(() => false))) {
+      test.skip('Settings trigger not visible');
     }
     try {
-      await settingsButton.click({ timeout: 30000 });
+      await settingsTrigger.click({ timeout: 30000 });
     } catch (error) {
-      test.skip('Settings button not clickable');
+      test.skip('Settings trigger not clickable');
     }
     await page.locator('label[for="themeSettingsTab"]').click();
 
@@ -30,7 +30,7 @@ test.describe('Theme', () => {
     if (!(await themeSelect.isVisible({ timeout: 20000 }).catch(() => false))) {
       test.skip('Theme selector not visible');
     }
-    await expect(themeSelect.locator('option').first()).toBeVisible({ timeout: 20000 });
+    await expect(themeSelect).toBeEnabled({ timeout: 20000 });
 
     const options = themeSelect.locator('option');
     const optionCount = await options.count();


### PR DESCRIPTION
## Summary
Handle configured-but-unavailable datasets as deterministic domain errors instead of leaking `500 INTERNAL_ERROR` when DuckDB backing tables are missing.

Closes #148.

## Core #148 changes
- Added `DatasetUnavailableError` (`409`, code `DATASET_UNAVAILABLE`) in `server/errors.py`.
- Added centralized missing-table detection in `server/engine.py`:
  - `is_missing_table_error(exc)` for DuckDB catalog missing-table failures.
  - `execute_sql(..., dataset_id=...)` and `execute_sql_async(..., dataset_id=...)` now map missing-table errors to `DatasetUnavailableError`.
- Query endpoints now pass `dataset_id` into engine execution so mapping is automatic:
  - `/query/tuples`, `/query/cells`, `/query/picklist`.
- Export behavior:
  - Preflight check on submit for configured-but-unmaterialized table (`table_exists`) -> `DATASET_UNAVAILABLE`.
  - Export processing path also maps missing-table failures to explicit failed-job reason.

## Tests
- Added/updated tests to verify missing-table/domain-error behavior:
  - `server/tests/test_engine.py`
  - `server/tests/test_error_contract.py`
- Backend full suite run:
  - `./.venv-server/bin/pytest server/tests -q`
  - Result: `346 passed`

## Additional files included in this branch
Per request, this PR also includes existing working-tree changes present when work started:
- `server/auth.py`
- `server/main.py`
- `server/tests/conftest.py`
- `server/tests/test_datasets_cache.py`
- `tests/ui/theme.spec.js`

## UI test note
- Attempted: `npx playwright test tests/ui/theme.spec.js`
- Result: timed out waiting for configured `webServer` startup (`npx serve src -p 8765`) in this environment.
