### PR TITLE
Add comprehensive QueryService backend documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@ Or, __Try Huey now__ with some [sample reports](https://github.com/rpbouman/huey
 
 (Note: this is a live demo that allows you to runvHuey without even downloading it. Even though it's available online, it's still a static webapp: any data you load into it is safe, and stays on your local client.)
 
+## Backend / Server Docs
+
+This repository includes the QueryService backend in `server/`.
+
+Start here for complete backend documentation:
+
+- [Backend documentation index](docs/server/README.md)
+- [API reference](docs/server/api-reference.md)
+- [Configuration reference](docs/server/configuration-reference.md)
+
 ![image](https://github.com/user-attachments/assets/f9d49b89-f29e-49b4-accf-64545b3e4c62)
 
 ## Key features

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,12 @@ services:
       dockerfile: server/Dockerfile
     ports:
       - "8002:8000"
+    volumes:
+      - ./server/datasets_config/datasets.yaml:/app/server/datasets_config/datasets.yaml:ro
     environment:
       UVICORN_WORKERS: "1"
-      QUERYSERVICE_SEED_SAMPLE_DATA: "true"
+      QUERYSERVICE_SEED_SAMPLE_DATA: "false"
+      QUERYSERVICE_EXECUTION_MODE: "parquet_partitioned"
+      QUERYSERVICE_S3_BUCKET: "aws-public-blockchain"
+      QUERYSERVICE_S3_REGION: "us-east-2"
     restart: unless-stopped

--- a/docs/server/README.md
+++ b/docs/server/README.md
@@ -1,0 +1,304 @@
+# QueryService Backend Documentation
+
+This documentation set covers the Huey backend service (`server/`), called **QueryService**. It is the API layer used by the frontend (or other clients) to fetch schema metadata, run OLAP-style queries, and generate exports.
+
+## Documentation Map
+
+- [API Reference](./api-reference.md)
+- [Configuration Reference](./configuration-reference.md)
+- [Troubleshooting and FAQ](./troubleshooting.md)
+- [Architecture Walkthrough](../../server/docs/architecture.md)
+
+## 1. Overview and Description
+
+QueryService is a Python FastAPI service that runs analytical SQL against DuckDB and exposes HTTP endpoints for:
+
+- Dataset schema discovery (`/schema`)
+- Distinct tuples, picklists, and aggregated cells (`/query/*`)
+- Async export jobs (`/export*`) with durable job state in SQLite
+- Health probes (`/health/*`)
+
+In the Huey architecture, this service is the backend execution layer behind the frontend query UI.
+
+## 2. Purpose and Use Cases
+
+Primary problems this service solves:
+
+- Centralized query execution over configured datasets
+- Safe, schema-aware SQL generation for frontend-driven analytics
+- Async export generation for large result sets
+- Standardized machine-readable error responses for integration
+
+Typical users:
+
+- Frontend/client engineers integrating analytics calls
+- Backend/integration engineers consuming APIs from other services
+- Ops/SRE teams deploying and operating the service
+
+Typical workflows:
+
+1. Discover dataset schema with `GET /schema`.
+2. Build interactive queries with `POST /query/tuples`, `POST /query/cells`, `POST /query/picklist`.
+3. Trigger async export with `POST /export`, poll with `GET /export/{export_id}`, then download.
+
+## 3. Installation and Setup
+
+### Prerequisites
+
+- Python `3.11+` (enforced at runtime)
+- `pip`
+- Optional: Docker
+- Optional for S3 partition execution: AWS credentials + network access to S3
+
+### Local setup
+
+From repo root:
+
+```bash
+python3 -m venv .venv-server
+./.venv-server/bin/pip install -r server/requirements.txt
+```
+
+Dataset configuration defaults to [`server/datasets_config/datasets.yaml`](../../server/datasets_config/datasets.yaml). Override via `QUERYSERVICE_DATASETS_CONFIG_PATH`.
+
+Environment variables are loaded from `.env` in the working directory (optional).
+
+For all environment variables and defaults, see [Configuration Reference](./configuration-reference.md).
+
+### Local development vs production
+
+- Local dev defaults to in-memory DuckDB when `QUERYSERVICE_DATA_DIR` is unset.
+- Production should set explicit persistent paths for:
+  - `QUERYSERVICE_DATA_DIR` (if you need persistent DuckDB database file)
+  - `QUERYSERVICE_EXPORT_OUTPUT_DIR`
+  - `QUERYSERVICE_EXPORT_DB_PATH`
+
+## 4. Running the Server
+
+### Development
+
+From repo root:
+
+```bash
+./.venv-server/bin/uvicorn server.main:app --host 0.0.0.0 --port 8000
+```
+
+Or:
+
+```bash
+PYTHONPATH=. ./.venv-server/bin/python -m server.main
+```
+
+### Production
+
+Container option:
+
+```bash
+docker build -f server/Dockerfile -t query-service .
+docker run -p 8000:8000 \
+  -e UVICORN_WORKERS=1 \
+  query-service
+```
+
+Non-container option (example process manager pattern):
+
+```bash
+PYTHONPATH=. ./.venv-server/bin/uvicorn server.main:app --host 0.0.0.0 --port 8000 --workers 1
+```
+
+### Network and ports
+
+- Default bind host: `0.0.0.0`
+- Default port: `8000`
+- CORS is controlled by `QUERYSERVICE_CORS_ORIGINS`
+
+## 5. Usage and Integration Guide
+
+### Authentication model
+
+- Auth is disabled by default (`QUERYSERVICE_AUTH_ENABLED=false`)
+- When enabled, clients must send `X-API-Key`
+- Health endpoints remain accessible without API key
+
+### Request conventions
+
+- Query/export requests use an envelope with `dataset_id`, `date_range`, and `query`
+- `date_range` supports:
+  - `{"type": "single", "date": "YYYY-MM-DD"}`
+  - `{"type": "range", "start": "YYYY-MM-DD", "end": "YYYY-MM-DD"}`
+- Date parsing is strict (real calendar dates only)
+
+### Error handling conventions
+
+Domain + validation errors use this envelope:
+
+```json
+{
+  "code": "DATASET_NOT_FOUND",
+  "message": "Dataset not found: trades_v1",
+  "request_id": "...",
+  "details": {"dataset_id": "trades_v1"}
+}
+```
+
+Important API error codes:
+
+- `DATASET_NOT_FOUND` (`404`)
+- `DATASET_UNAVAILABLE` (`409`)
+- `EXPORT_NOT_FOUND` (`404`)
+- `EXPORT_NOT_READY` (`409`)
+- `EXPORT_FILE_NOT_FOUND` (`404`)
+- `TOO_MANY_EXPORTS` (`429`)
+- `VALIDATION_ERROR` (`422`)
+- `INTERNAL_ERROR` (`500`)
+
+Notes:
+
+- Auth failures return `401` using FastAPI `HTTPException` shape (`{"detail": ...}`)
+- If rate limiting is enabled, `429` responses include `Retry-After`
+
+## 6. API Documentation
+
+See [API Reference](./api-reference.md) for full endpoint-by-endpoint request/response schemas, status codes, and examples.
+
+Built-in interactive docs:
+
+- `/docs` (Swagger UI)
+- `/redoc`
+- `/openapi.json`
+
+## 7. Examples and Recipes
+
+### Recipe: start service + run a schema/query/export flow
+
+Start service:
+
+```bash
+./.venv-server/bin/uvicorn server.main:app --host 0.0.0.0 --port 8000
+```
+
+Check schema:
+
+```bash
+curl 'http://localhost:8000/schema?dataset_id=trades_v1'
+```
+
+Run tuples query:
+
+```bash
+curl -X POST 'http://localhost:8000/query/tuples' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "dataset_id": "trades_v1",
+    "date_range": {"type": "single", "date": "2026-03-01"},
+    "query": {"fields": [{"field": "symbol", "sort": "ASC"}], "paging": {"limit": 10, "offset": 0}}
+  }'
+```
+
+Create export (default format is parquet):
+
+```bash
+curl -X POST 'http://localhost:8000/export' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "dataset_id": "trades_v1",
+    "date_range": {"type": "single", "date": "2026-03-01"},
+    "query": {
+      "axes": {
+        "rows": [{"field": "symbol"}],
+        "measures": [{"field": "volume", "aggregation": "SUM", "alias": "total_volume"}]
+      },
+      "max_rows": 1000
+    }
+  }'
+```
+
+Poll + download:
+
+```bash
+curl 'http://localhost:8000/export/<export_id>'
+curl -OJ 'http://localhost:8000/export/<export_id>/download'
+```
+
+### Example environment profiles
+
+Local:
+
+```env
+QUERYSERVICE_LOG_LEVEL=INFO
+QUERYSERVICE_LOG_FORMAT=text
+QUERYSERVICE_SEED_SAMPLE_DATA=true
+```
+
+Staging:
+
+```env
+QUERYSERVICE_LOG_FORMAT=json
+QUERYSERVICE_AUTH_ENABLED=true
+QUERYSERVICE_API_KEYS=staging-key-1,staging-key-2
+QUERYSERVICE_RATE_LIMIT_ENABLED=true
+QUERYSERVICE_DATA_DIR=/var/lib/queryservice/query.duckdb
+QUERYSERVICE_EXPORT_OUTPUT_DIR=/var/lib/queryservice/exports
+QUERYSERVICE_EXPORT_DB_PATH=/var/lib/queryservice/exports/jobs.db
+```
+
+Production baseline:
+
+```env
+QUERYSERVICE_LOG_FORMAT=json
+QUERYSERVICE_AUTH_ENABLED=true
+QUERYSERVICE_RATE_LIMIT_ENABLED=true
+QUERYSERVICE_DUCKDB_THREADS=4
+QUERYSERVICE_DUCKDB_MEMORY_LIMIT=8GB
+QUERYSERVICE_DUCKDB_TEMP_DIRECTORY=/tmp/huey-duckdb-tmp
+QUERYSERVICE_EXPORT_OUTPUT_DIR=/srv/queryservice/exports
+QUERYSERVICE_EXPORT_DB_PATH=/srv/queryservice/exports/jobs.db
+```
+
+## 8. Operational Considerations
+
+### Logging and monitoring
+
+- JSON/text logging controlled by `QUERYSERVICE_LOG_FORMAT`
+- Access logs include method/path/status/duration
+- Query logs include endpoint-level timing and row counts
+- Correlation IDs are supported through `X-Request-ID`
+
+### Health checks
+
+- `GET /health/liveness`: process is up
+- `GET /health/readiness`: backend ready (DuckDB health check)
+
+### Scaling and performance
+
+- DuckDB tuning settings:
+  - `QUERYSERVICE_DUCKDB_THREADS`
+  - `QUERYSERVICE_DUCKDB_MEMORY_LIMIT`
+  - `QUERYSERVICE_DUCKDB_TEMP_DIRECTORY`
+  - `QUERYSERVICE_DUCKDB_ENABLE_OBJECT_CACHE`
+- Keep total execution threads aligned with available CPU when using multiple workers
+- Export capacity is bounded by `QUERYSERVICE_EXPORT_MAX_CONCURRENT`
+
+### Backup/restore and retention
+
+- Export job metadata is in SQLite (`QUERYSERVICE_EXPORT_DB_PATH`)
+- Export artifacts are files in `QUERYSERVICE_EXPORT_OUTPUT_DIR`
+- Completed/failed exports are marked expired and cleaned up after `QUERYSERVICE_EXPORT_TTL_SECONDS`
+- If retention/compliance is strict, run external backup/retention controls on these paths
+
+### Migrations
+
+- No dedicated schema migration framework is currently used for the export SQLite DB
+- Validate compatibility before manual DB schema changes
+
+## 9. Security and Compliance
+
+- API keys are configured via env (`QUERYSERVICE_API_KEYS`) when auth is enabled
+- CORS is explicitly configured via `QUERYSERVICE_CORS_ORIGINS`
+- TLS termination is expected to be handled by ingress/proxy (not built into app)
+- Do not commit secrets to repo; provide via runtime environment/secret manager
+- Review dataset content classification before enabling exports in regulated environments
+
+## 10. Troubleshooting and FAQ
+
+See [Troubleshooting and FAQ](./troubleshooting.md) for common failures and debugging commands.

--- a/docs/server/api-reference.md
+++ b/docs/server/api-reference.md
@@ -1,0 +1,394 @@
+# QueryService API Reference
+
+Base URL examples:
+
+- Local: `http://localhost:8000`
+- Containerized (mapped): `http://<host>:8000`
+
+Interactive OpenAPI:
+
+- `/docs`
+- `/redoc`
+- `/openapi.json`
+
+## Conventions
+
+### Authentication
+
+- Protected endpoints require `X-API-Key` only when `QUERYSERVICE_AUTH_ENABLED=true`.
+- Health endpoints do not require API key.
+
+### Correlation IDs
+
+- `X-Request-ID` is accepted and echoed in response headers.
+- Error envelopes usually include `request_id` when available.
+
+### Shared request envelope (query/export)
+
+```json
+{
+  "dataset_id": "trades_v1",
+  "date_range": {"type": "single", "date": "2026-03-01"},
+  "query": {}
+}
+```
+
+`date_range` schema:
+
+- Single day: `{"type": "single", "date": "YYYY-MM-DD"}`
+- Inclusive range: `{"type": "range", "start": "YYYY-MM-DD", "end": "YYYY-MM-DD"}`
+
+### Common error envelope
+
+```json
+{
+  "code": "DATASET_NOT_FOUND",
+  "message": "Dataset not found: trades_v1",
+  "request_id": "trace-123",
+  "details": {"dataset_id": "trades_v1"}
+}
+```
+
+## Endpoints
+
+## `GET /health/liveness`
+
+Process liveness probe.
+
+Authentication: not required.
+
+Response `200`:
+
+```json
+{"status": "ok"}
+```
+
+## `GET /health/readiness`
+
+Readiness probe (checks DuckDB health).
+
+Authentication: not required.
+
+Responses:
+
+- `200`:
+
+```json
+{"status": "ok"}
+```
+
+- `503`:
+
+```json
+{"status": "unavailable"}
+```
+
+## `GET /schema`
+
+Returns schema metadata for a configured dataset.
+
+Authentication: conditional API key.
+
+Query parameters:
+
+- `dataset_id` (required, string)
+
+Example:
+
+```bash
+curl 'http://localhost:8000/schema?dataset_id=trades_v1'
+```
+
+Success `200` example:
+
+```json
+{
+  "dataset_id": "trades_v1",
+  "fields": [
+    {"name": "date", "type": "date", "is_dimension": true},
+    {"name": "symbol", "type": "string", "is_dimension": true},
+    {"name": "volume", "type": "int64", "is_measure": true}
+  ]
+}
+```
+
+Error statuses:
+
+- `404` `DATASET_NOT_FOUND`
+- `401` auth failure when auth enabled
+
+## `POST /query/tuples`
+
+Returns distinct tuple values for selected fields.
+
+Authentication: conditional API key.
+
+Request body fields:
+
+- `dataset_id` (string, required)
+- `date_range` (required)
+- `query.fields` (array of objects):
+  - `field` (string, required)
+  - `sort` (`ASC` or `DESC`, optional)
+  - `derivation` (optional)
+  - `include_totals` (optional)
+- `query.filters` (optional):
+  - `field` (string)
+  - `operator` (`INCLUDE`, `EXCLUDE`, `LIKE`, `BETWEEN`)
+  - `values` (array)
+- `query.paging` (optional):
+  - `limit` (`1..10000`, default from config)
+  - `offset` (`>=0`)
+
+Request example:
+
+```json
+{
+  "dataset_id": "trades_v1",
+  "date_range": {"type": "single", "date": "2026-03-01"},
+  "query": {
+    "fields": [{"field": "symbol", "sort": "ASC"}],
+    "filters": [{"field": "symbol", "operator": "INCLUDE", "values": ["AAPL", "GOOG"]}],
+    "paging": {"limit": 10, "offset": 0}
+  }
+}
+```
+
+Success `200` example:
+
+```json
+{
+  "total_count": 2,
+  "items": [{"values": ["AAPL"]}, {"values": ["GOOG"]}],
+  "paging": {"limit": 10, "offset": 0, "returned": 2}
+}
+```
+
+Error statuses:
+
+- `404` `DATASET_NOT_FOUND`
+- `409` `DATASET_UNAVAILABLE`
+- `422` `VALIDATION_ERROR`
+- `401` auth failure when auth enabled
+- `429` if rate limiting enabled and exceeded
+
+## `POST /query/cells`
+
+Returns aggregated cells grouped by row/column axes.
+
+Authentication: conditional API key.
+
+Request body fields:
+
+- `dataset_id` (string, required)
+- `date_range` (required)
+- `query.axes.rows` (array of `{ "field": string }`)
+- `query.axes.columns` (array of `{ "field": string }`)
+- `query.axes.measures` (array):
+  - `field` (string)
+  - `aggregation` (`SUM`, `COUNT`, `AVG`, `MIN`, `MAX`)
+  - `alias` (string, optional)
+- `query.rows` and `query.columns` windows (optional):
+  - `start_index` (`>=0`)
+  - `count` (`>=1`)
+- `query.filters` (optional)
+
+Request example:
+
+```json
+{
+  "dataset_id": "trades_v1",
+  "date_range": {"type": "single", "date": "2026-03-01"},
+  "query": {
+    "rows": {"start_index": 0, "count": 10},
+    "axes": {
+      "rows": [{"field": "symbol"}],
+      "columns": [],
+      "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}]
+    }
+  }
+}
+```
+
+Success `200` example:
+
+```json
+{
+  "cells": [
+    {"row_index": 0, "values": {"0": "AAPL", "1": 1500}},
+    {"row_index": 1, "values": {"0": "GOOG", "1": 2200}}
+  ]
+}
+```
+
+Error statuses:
+
+- `400` `CELLS_WINDOW_TOO_LARGE`
+- `404` `DATASET_NOT_FOUND`
+- `409` `DATASET_UNAVAILABLE`
+- `422` `VALIDATION_ERROR`
+- `401` auth failure when auth enabled
+- `429` if rate limiting enabled and exceeded
+
+## `POST /query/picklist`
+
+Returns distinct values for one field, typically used for filter UIs.
+
+Authentication: conditional API key.
+
+Request body fields:
+
+- `dataset_id` (string, required)
+- `date_range` (required)
+- `query.field` (string)
+- `query.search` (string, optional; `*` is translated to SQL `%` wildcard)
+- `query.filters` (optional)
+- `query.paging` (optional)
+
+Request example:
+
+```json
+{
+  "dataset_id": "trades_v1",
+  "date_range": {"type": "range", "start": "2026-03-01", "end": "2026-03-02"},
+  "query": {
+    "field": "symbol",
+    "search": "A*",
+    "paging": {"limit": 10, "offset": 0}
+  }
+}
+```
+
+Success `200` example:
+
+```json
+{
+  "total_count": 2,
+  "values": [{"value": "AAPL", "label": "AAPL"}, {"value": "AMZN", "label": "AMZN"}],
+  "paging": {"limit": 10, "offset": 0, "returned": 2}
+}
+```
+
+Error statuses:
+
+- `404` `DATASET_NOT_FOUND`
+- `409` `DATASET_UNAVAILABLE`
+- `422` `VALIDATION_ERROR`
+- `401` auth failure when auth enabled
+- `429` if rate limiting enabled and exceeded
+
+## `POST /export`
+
+Submits async export job and returns job id immediately.
+
+Authentication: conditional API key.
+
+Request body fields:
+
+- `dataset_id` (string, required)
+- `date_range` (required)
+- `query.axes` (optional; rows/columns/measures)
+- `query.filters` (optional)
+- `query.max_rows` (`1..100000`, default `10000`)
+- `query.format` (`parquet` or `csv`, default `parquet`)
+
+Request example:
+
+```json
+{
+  "dataset_id": "trades_v1",
+  "date_range": {"type": "single", "date": "2026-03-01"},
+  "query": {
+    "axes": {
+      "rows": [{"field": "symbol"}],
+      "measures": [{"field": "volume", "aggregation": "SUM", "alias": "total_volume"}]
+    },
+    "max_rows": 1000,
+    "format": "parquet"
+  }
+}
+```
+
+Success `200` example:
+
+```json
+{"export_id": "exp-1234abcd", "status": "pending"}
+```
+
+Error statuses:
+
+- `404` `DATASET_NOT_FOUND`
+- `409` `DATASET_UNAVAILABLE`
+- `429` `TOO_MANY_EXPORTS`
+- `422` `VALIDATION_ERROR`
+- `401` auth failure when auth enabled
+- `429` if rate limiting enabled and exceeded
+
+## `GET /export/{export_id}`
+
+Returns export job status.
+
+Authentication: conditional API key.
+
+Path parameters:
+
+- `export_id` (string)
+
+Success `200` example:
+
+```json
+{
+  "export_id": "exp-1234abcd",
+  "status": "complete",
+  "download_url": "/export/exp-1234abcd/download"
+}
+```
+
+Other statuses include `pending`, `processing`, `failed`, `expired`.
+
+Error statuses:
+
+- `404` `EXPORT_NOT_FOUND`
+- `401` auth failure when auth enabled
+
+## `GET /export/{export_id}/download`
+
+Downloads completed export artifact.
+
+Authentication: conditional API key.
+
+Path parameters:
+
+- `export_id` (string)
+
+Success `200`:
+
+- For parquet export: binary file, `Content-Disposition: attachment; filename="<id>.parquet"`
+- For csv export: text/csv, `Content-Disposition: attachment; filename="<id>.csv"`
+
+Error statuses:
+
+- `404` `EXPORT_NOT_FOUND`
+- `409` `EXPORT_NOT_READY`
+- `404` `EXPORT_FILE_NOT_FOUND`
+- `401` auth failure when auth enabled
+
+## Pagination, Filtering, and Sorting Summary
+
+- Pagination:
+  - `query.paging.limit` and `query.paging.offset` on tuples/picklist
+  - Defaults: `tuples_default_limit`, `picklist_default_limit`
+- Filtering operators:
+  - `INCLUDE`, `EXCLUDE`, `LIKE`, `BETWEEN`
+- Sorting:
+  - `query.fields[].sort` on tuples (`ASC`/`DESC`)
+- Cells windows:
+  - `query.rows`/`query.columns` with `start_index` and `count`
+  - Limited by `max_axis_cardinality` and `max_cells_per_response`
+
+## Rate Limits and Throttling
+
+- Disabled by default (`QUERYSERVICE_RATE_LIMIT_ENABLED=false`)
+- Query endpoints use `QUERYSERVICE_RATE_LIMIT_QUERY`
+- Export submission uses `QUERYSERVICE_RATE_LIMIT_EXPORT`
+- Exceeded limits return `429`; clients should honor `Retry-After`

--- a/docs/server/configuration-reference.md
+++ b/docs/server/configuration-reference.md
@@ -1,0 +1,98 @@
+# QueryService Configuration Reference
+
+All application settings are read from environment variables prefixed with `QUERYSERVICE_`.
+
+Example: `QUERYSERVICE_PORT=8000` maps to `port` setting.
+
+## Core Server
+
+| Variable | Default | Type | Purpose |
+|---|---:|---|---|
+| `QUERYSERVICE_HOST` | `0.0.0.0` | string | Bind host |
+| `QUERYSERVICE_PORT` | `8000` | int | Bind port |
+| `QUERYSERVICE_LOG_LEVEL` | `INFO` | string | Log level |
+| `QUERYSERVICE_LOG_FORMAT` | `text` | `text` \| `json` | Log output format |
+| `QUERYSERVICE_CORS_ORIGINS` | `[]` | CSV or JSON array | Allowed browser origins |
+
+## Dataset and Seeding
+
+| Variable | Default | Type | Purpose |
+|---|---:|---|---|
+| `QUERYSERVICE_DATASETS_CONFIG_PATH` | bundled `server/datasets_config/datasets.yaml` | string | Override datasets YAML path |
+| `QUERYSERVICE_SEED_SAMPLE_DATA` | `false` | bool | Seed sample data tables at startup |
+| `QUERYSERVICE_SCHEMA_CACHE_TTL_SECONDS` | `300` | float or empty | Dataset schema cache TTL (`0`/empty disables TTL refresh) |
+
+## DuckDB Runtime
+
+| Variable | Default | Type | Purpose |
+|---|---:|---|---|
+| `QUERYSERVICE_DATA_DIR` | unset | string | DuckDB DB file path; unset uses in-memory |
+| `QUERYSERVICE_DUCKDB_THREADS` | auto (`min(4, cpu/workers)`) | int | DuckDB execution threads |
+| `QUERYSERVICE_DUCKDB_MEMORY_LIMIT` | unset | string | DuckDB memory limit (example `8GB`) |
+| `QUERYSERVICE_DUCKDB_TEMP_DIRECTORY` | `/tmp/huey-duckdb-tmp` | string | Spill directory |
+| `QUERYSERVICE_DUCKDB_ENABLE_OBJECT_CACHE` | `true` | bool | DuckDB object cache toggle |
+
+## Query and Response Limits
+
+| Variable | Default | Type | Purpose |
+|---|---:|---|---|
+| `QUERYSERVICE_QUERY_TIMEOUT_SECONDS` | `30.0` | float | Query timeout budget setting |
+| `QUERYSERVICE_MAX_CONCURRENT_QUERIES` | `8` | int | Concurrent query budget setting |
+| `QUERYSERVICE_MAX_QUERY_QUEUE_DEPTH` | `32` | int or empty | Queue depth budget setting |
+| `QUERYSERVICE_TUPLES_DEFAULT_LIMIT` | `200` | int | Default tuples page size |
+| `QUERYSERVICE_PICKLIST_DEFAULT_LIMIT` | `100` | int | Default picklist page size |
+| `QUERYSERVICE_MAX_CELLS_PER_RESPONSE` | `10000` | int | Max cells payload bound |
+| `QUERYSERVICE_MAX_AXIS_CARDINALITY` | `5000` | int | Max axis cardinality/window |
+
+## Authentication and Rate Limiting
+
+| Variable | Default | Type | Purpose |
+|---|---:|---|---|
+| `QUERYSERVICE_AUTH_ENABLED` | `false` | bool | Require `X-API-Key` on protected endpoints |
+| `QUERYSERVICE_API_KEYS` | unset | CSV string | Allowed API keys |
+| `QUERYSERVICE_RATE_LIMIT_ENABLED` | `false` | bool | Enable slowapi rate limiting |
+| `QUERYSERVICE_RATE_LIMIT_QUERY` | `100/minute` | string | Query endpoint limit policy |
+| `QUERYSERVICE_RATE_LIMIT_EXPORT` | `10/minute` | string | Export submission limit policy |
+
+## Export Pipeline
+
+| Variable | Default | Type | Purpose |
+|---|---:|---|---|
+| `QUERYSERVICE_EXPORT_TTL_SECONDS` | `3600` | int | Expiration TTL for complete/failed exports |
+| `QUERYSERVICE_EXPORT_MAX_CONCURRENT` | `5` | int | Max active exports (`pending`/`processing`) |
+| `QUERYSERVICE_EXPORT_OUTPUT_DIR` | `/tmp/huey-exports` | string | Export artifact directory |
+| `QUERYSERVICE_EXPORT_DB_PATH` | `/tmp/huey-exports/jobs.db` | string | SQLite job store path |
+
+## Query Result Cache
+
+| Variable | Default | Type | Purpose |
+|---|---:|---|---|
+| `QUERYSERVICE_CACHE_ENABLED` | `false` | bool | Enable query response cache |
+| `QUERYSERVICE_CACHE_TTL_SECONDS` | `120` | int | Cache TTL |
+| `QUERYSERVICE_CACHE_MAX_BYTES` | `67108864` | int | Max in-memory cache budget (bytes) |
+| `QUERYSERVICE_CACHE_MAX_ITEM_BYTES` | `1048576` | int | Max cached item size (bytes) |
+| `QUERYSERVICE_CACHE_ADMISSION_MIN_DURATION_MS` | `0.0` | float | Minimum query duration to cache |
+| `QUERYSERVICE_CACHE_SQLITE_PATH` | unset | string | Optional SQLite-backed cache path |
+| `QUERYSERVICE_CACHE_SQLITE_MAX_BYTES` | `268435456` | int | Max SQLite cache size budget |
+
+## Execution Mode and Partitions
+
+| Variable | Default | Type | Purpose |
+|---|---:|---|---|
+| `QUERYSERVICE_EXECUTION_MODE` | `sample_table` | `sample_table` \| `parquet_partitioned` | Query relation mode |
+| `QUERYSERVICE_PARTITION_BASE_PATH` | unset | string | Local partition root when using partitioned mode |
+| `QUERYSERVICE_S3_BUCKET` | unset | string | S3 bucket for partitioned mode |
+| `QUERYSERVICE_S3_REGION` | unset | string | S3 region |
+
+## Additional Non-Prefixed Environment Variables
+
+| Variable | Default | Purpose |
+|---|---:|---|
+| `UVICORN_WORKERS` | `1` | Worker count used at container start and thread auto-tuning heuristic |
+| `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | unset | AWS credential chain inputs when using S3 |
+
+## Notes
+
+- Empty strings for optional path/string settings are normalized to `None`.
+- `QUERYSERVICE_CORS_ORIGINS` accepts either CSV (`https://a,https://b`) or JSON array (`["https://a","https://b"]`).
+- Settings are cached in-process; test code may clear cache with `get_settings.cache_clear()` when mutating environment at runtime.

--- a/docs/server/troubleshooting.md
+++ b/docs/server/troubleshooting.md
@@ -1,0 +1,78 @@
+# QueryService Troubleshooting and FAQ
+
+## Quick Checks
+
+1. Is the service up?
+
+```bash
+curl -i http://localhost:8000/health/liveness
+curl -i http://localhost:8000/health/readiness
+```
+
+2. Are settings loaded as expected?
+
+- Confirm `.env` location and active shell environment.
+- Confirm `QUERYSERVICE_*` names are exact.
+
+3. Is dataset configuration loaded?
+
+- Verify `QUERYSERVICE_DATASETS_CONFIG_PATH` if overriding defaults.
+- Validate YAML format and dataset IDs.
+
+## Common Issues
+
+| Symptom | Likely cause | Resolution |
+|---|---|---|
+| `404 DATASET_NOT_FOUND` | Unknown `dataset_id` in YAML | Add/fix dataset in datasets config, then retry |
+| `409 DATASET_UNAVAILABLE` | Dataset exists in config but table/data is not available in DuckDB | Materialize/load table for the dataset, or fix execution mode/path config |
+| `422 VALIDATION_ERROR` for dates | Invalid calendar date or format | Use strict `YYYY-MM-DD` real date values |
+| `401` on protected endpoint | Auth enabled and missing/invalid API key | Send `X-API-Key` matching `QUERYSERVICE_API_KEYS` |
+| `429 TOO_MANY_EXPORTS` | Active exports hit configured cap | Wait for active exports to complete/expire or increase `QUERYSERVICE_EXPORT_MAX_CONCURRENT` |
+| Export status stuck at `failed` | Query failed during background export | Inspect logs; validate dataset/table presence and filters |
+| `404 EXPORT_FILE_NOT_FOUND` | Job says complete but artifact file missing | Check `QUERYSERVICE_EXPORT_OUTPUT_DIR` persistence and cleanup policies |
+| `503` readiness | DuckDB connection unhealthy | Check process logs and DuckDB configuration; restart service if needed |
+| CORS browser errors | Origin not allowed | Add origin to `QUERYSERVICE_CORS_ORIGINS` |
+| Slow/heavy queries | Thread/memory/temp settings not tuned | Tune DuckDB settings and response window limits |
+
+## Debugging Commands
+
+Run tests (from repo root):
+
+```bash
+./.venv-server/bin/pytest server/tests -q
+```
+
+Run targeted API contract tests:
+
+```bash
+./.venv-server/bin/pytest server/tests/test_error_contract.py -q
+```
+
+Run export tests:
+
+```bash
+./.venv-server/bin/pytest server/tests/test_export_api.py server/tests/test_export_service.py -q
+```
+
+## FAQ
+
+### Does export default to CSV?
+
+No. The default export format is **parquet** when `query.format` is omitted.
+
+### Why do I get `DATASET_UNAVAILABLE` when schema exists?
+
+Schema metadata and physical table availability are separate checks. A dataset can be configured but not materialized/loaded in DuckDB.
+
+### Are all errors returned in the same envelope?
+
+Domain and validation errors use `{code, message, request_id?, details?}`. Auth failures use FastAPI HTTPException shape (`detail`), and rate-limit responses depend on slowapi handler shape.
+
+### Is data persistent by default?
+
+- DuckDB is in-memory unless `QUERYSERVICE_DATA_DIR` is set.
+- Export jobs/files are persisted if `QUERYSERVICE_EXPORT_DB_PATH` and `QUERYSERVICE_EXPORT_OUTPUT_DIR` point to persistent storage.
+
+### Is there automatic migration for the export SQLite schema?
+
+No migration framework is currently included. Treat schema changes as manual operational changes.

--- a/server/README.md
+++ b/server/README.md
@@ -1,136 +1,37 @@
-# QueryService
+# QueryService (Huey Backend)
 
-Huey OLAP query service backend (Python, FastAPI, DuckDB). Serves health checks and will expose schema and query APIs per the [tech spec](../docs/huey-large-scale-olap-tech-spec.md). See the [architecture guide](./docs/architecture.md) for a deeper walkthrough.
+FastAPI + DuckDB backend for Huey analytics queries and exports.
 
-## Setup
+Primary docs entrypoint:
 
-From the repo root:
+- [Backend Documentation Index](../docs/server/README.md)
+
+Direct references:
+
+- [API Reference](../docs/server/api-reference.md)
+- [Configuration Reference](../docs/server/configuration-reference.md)
+- [Troubleshooting and FAQ](../docs/server/troubleshooting.md)
+- [Architecture Walkthrough](./docs/architecture.md)
+
+## Quick Start
+
+From repo root:
 
 ```bash
-python3 --version  # requires Python 3.11+
 python3 -m venv .venv-server
 ./.venv-server/bin/pip install -r server/requirements.txt
-```
-
-## Run
-
-From the repo root (so `server` is the package):
-
-```bash
 ./.venv-server/bin/uvicorn server.main:app --host 0.0.0.0 --port 8000
 ```
 
-Or:
+Smoke checks:
 
 ```bash
-PYTHONPATH=. ./.venv-server/bin/python -m server.main
+curl http://localhost:8000/health/liveness
+curl 'http://localhost:8000/schema?dataset_id=trades_v1'
 ```
 
-## Health
-
-- `GET /health/liveness` – process is up
-- `GET /health/readiness` – ready for traffic (engine/S3 checks added in later issues)
-
-## API
-
-- `GET /schema` – return schema metadata for a dataset (`dataset_id` query param)
-- `POST /query/tuples` – distinct dimension tuples with paging
-- `POST /query/cells` – aggregated cell values grouped by dimensions/measures
-- `POST /query/picklist` – distinct values for a field with search/paging
-- `POST /export` – submit an export job (background processing)
-- `GET /export/{export_id}` – poll export status/download URL
-- `GET /export/{export_id}/download` – download completed export artifact
-- `GET /health/liveness` – liveness probe
-- `GET /health/readiness` – readiness probe
-
-## Tests
-
-From the repo root:
+Run tests:
 
 ```bash
-PYTHONPATH=. ./.venv-server/bin/python -m pytest server/tests -v
+./.venv-server/bin/pytest server/tests -q
 ```
-
-To include coverage:
-
-```bash
-PYTHONPATH=. ./.venv-server/bin/python -m pytest server/tests --cov=server --cov-report=term-missing
-```
-
-## Docker
-
-From the repo root:
-
-```bash
-docker build -f server/Dockerfile -t query-service .
-docker run -p 8000:8000 -e UVICORN_WORKERS=1 query-service
-```
-
-## Config
-
-Environment variables (prefix `QUERYSERVICE_`):
-
-- `QUERYSERVICE_HOST` (default `0.0.0.0`)
-- `QUERYSERVICE_PORT` (default `8000`)
-- `QUERYSERVICE_LOG_LEVEL` (default `INFO`)
-- `QUERYSERVICE_LOG_FORMAT` (default `text`, set `json` for structured logs)
-- `QUERYSERVICE_CORS_ORIGINS` (default empty; comma-separated list or JSON array)
-- `QUERYSERVICE_DATASETS_CONFIG_PATH` (default bundled `datasets_config/datasets.yaml`)
-- `QUERYSERVICE_SEED_SAMPLE_DATA` (default `false`, set `true` for local demo data seeding)
-- `QUERYSERVICE_DATA_DIR` (default `None`, DuckDB in-memory; set to persist)
-- `QUERYSERVICE_DUCKDB_THREADS` (default auto, conservative: `min(4, CPU/worker)`)
-- `QUERYSERVICE_DUCKDB_MEMORY_LIMIT` (default unset, DuckDB default)
-- `QUERYSERVICE_DUCKDB_TEMP_DIRECTORY` (default `/tmp/huey-duckdb-tmp`)
-- `QUERYSERVICE_DUCKDB_ENABLE_OBJECT_CACHE` (default `true`)
-- `QUERYSERVICE_EXPORT_TTL_SECONDS` (default `3600`)
-- `QUERYSERVICE_EXPORT_MAX_CONCURRENT` (default `5`)
-- `QUERYSERVICE_EXPORT_OUTPUT_DIR` (default `/tmp/huey-exports`)
-- `QUERYSERVICE_EXPORT_DB_PATH` (default `/tmp/huey-exports/jobs.db`)
-- `QUERYSERVICE_S3_BUCKET` (default `None`)
-- `QUERYSERVICE_S3_REGION` (default `None`)
-- `QUERYSERVICE_EXECUTION_MODE` (default `sample_table`; set `parquet_partitioned` to scan partitioned parquet)
-- `QUERYSERVICE_PARTITION_BASE_PATH` (default `None`; local base path for partitioned parquet when not using S3)
-- `QUERYSERVICE_SCHEMA_CACHE_TTL_SECONDS` (default `300`, set `0` to disable TTL refresh)
-- `QUERYSERVICE_CACHE_ENABLED` (default `false`)
-- `QUERYSERVICE_CACHE_TTL_SECONDS` (default `120`)
-- `QUERYSERVICE_CACHE_MAX_BYTES` (default `67108864`)
-- `QUERYSERVICE_CACHE_MAX_ITEM_BYTES` (default `1048576`)
-- `QUERYSERVICE_CACHE_ADMISSION_MIN_DURATION_MS` (default `0.0`)
-- `QUERYSERVICE_CACHE_SQLITE_PATH` (default `None`, enables L2 persistence when set)
-- `QUERYSERVICE_CACHE_SQLITE_MAX_BYTES` (default `268435456`)
-
-Schema metadata is cached in memory and automatically refreshed when the datasets
-config file changes on disk or when the TTL elapses. Use the TTL env var to tune
-refresh cadence for your deployment.
-
-Optional `.env` in the working directory is also loaded.
-
-## Runtime Tuning Profile
-
-QueryService applies DuckDB runtime settings at startup and logs the effective
-values (`threads`, `memory_limit`, `temp_directory`, `enable_object_cache`).
-
-Recommended baseline profiles:
-
-- `dev`:
-  - `UVICORN_WORKERS=1`
-  - `QUERYSERVICE_DUCKDB_THREADS` unset (auto)
-  - `QUERYSERVICE_DUCKDB_MEMORY_LIMIT=2GB`
-- `staging`:
-  - `UVICORN_WORKERS=1`
-  - `QUERYSERVICE_DUCKDB_THREADS=4` (or unset for auto)
-  - `QUERYSERVICE_DUCKDB_MEMORY_LIMIT=8GB`
-- `prod` (large analytical workloads):
-  - Start with `UVICORN_WORKERS=1` to avoid CPU oversubscription.
-  - Scale workers only when needed for mixed/short queries.
-  - If `UVICORN_WORKERS>1`, reduce `QUERYSERVICE_DUCKDB_THREADS` per worker so total threads do not exceed available vCPUs.
-
-Resource sizing baseline:
-
-- CPU: keep total `workers * duckdb_threads <= vCPU count`
-- Memory: reserve headroom for app and OS (`duckdb_memory_limit` set with explicit units, e.g. `8GB`)
-- Disk: place `duckdb_temp_directory` on fast local SSD for spill-heavy queries
-
-## Try Huey with this backend (remote datasource)
-
-See [Try the remote feature](../docs/try-remote-feature.md): start this server, serve Huey, add a remote datasource in the browser console, then explore and run queries.

--- a/server/datasets_config/datasets.yaml
+++ b/server/datasets_config/datasets.yaml
@@ -13,3 +13,59 @@ datasets:
       - name: volume
         type: int64
         is_measure: true
+
+  - dataset_id: "v1.0/btc/blocks"
+    fields:
+      - name: date
+        type: date
+        is_dimension: true
+      - name: number
+        type: int64
+        is_dimension: true
+      - name: hash
+        type: string
+        is_dimension: true
+      - name: previousblockhash
+        type: string
+        is_dimension: true
+      - name: mediantime
+        type: string
+        is_dimension: true
+      - name: timestamp
+        type: string
+        is_dimension: true
+      - name: last_modified
+        type: string
+        is_dimension: true
+      - name: version
+        type: int64
+        is_dimension: true
+      - name: bits
+        type: string
+        is_dimension: true
+      - name: difficulty
+        type: float64
+        is_measure: true
+      - name: chainwork
+        type: string
+        is_dimension: true
+      - name: nonce
+        type: int64
+      - name: size
+        type: int64
+        is_measure: true
+      - name: stripped_size
+        type: int64
+        is_measure: true
+      - name: weight
+        type: int64
+        is_measure: true
+      - name: transaction_count
+        type: int64
+        is_measure: true
+      - name: coinbase_param
+        type: string
+        is_dimension: true
+      - name: merkle_root
+        type: string
+        is_dimension: true

--- a/server/errors.py
+++ b/server/errors.py
@@ -130,6 +130,9 @@ class PartitionNotFoundError(AppError):
             message=f"Partitions not found for dataset {dataset_id}",
             status_code=404,
             details={"dataset_id": dataset_id, "dates": dates},
+        )
+
+
 class QueryTimeoutError(AppError):
     """Raised when a query exceeds the configured timeout budget."""
 
@@ -150,6 +153,18 @@ class QueryCancelledError(AppError):
             code="QUERY_CANCELLED",
             message="Query cancelled because the client disconnected",
             status_code=499,
+        )
+
+
+class CellsWindowTooLargeError(AppError):
+    """Raised when a requested cells window exceeds configured limits."""
+
+    def __init__(self, message: str, details: dict[str, Any]) -> None:
+        super().__init__(
+            code="CELLS_WINDOW_TOO_LARGE",
+            message=message,
+            status_code=400,
+            details=details,
         )
 
 

--- a/server/routers/query.py
+++ b/server/routers/query.py
@@ -125,33 +125,11 @@ async def post_query_tuples(body: QueryTuplesRequest, request: Request, _api_key
         )
         cache_status = meta.cache_status
         cache_source = meta.cache_source
-    start = time.perf_counter()
-    sql, params = build_tuples_sql(body.dataset_id, body.query, body.date_range, schema_fields)
-    rows = await db_manager.execute_sql_async(
-        sql,
-        tuple(params) if params else None,
-        dataset_id=body.dataset_id,
-    )
-    if rows:
-        total_count = int(rows[0][-1])
-        items = [TupleItem(values=list(row[:-1])) for row in rows]
     else:
         result = await _execute()
 
     duration_ms = result.get("duration_ms", 0.0)
     resp_body = result["response"]
-    # Fallback to a lightweight count when page is empty (e.g., offset beyond results)
-    if total_count == 0 and (paging.offset if paging else 0) > 0:
-        count_sql, count_params = build_tuples_count_sql(body.dataset_id, body.query, body.date_range, schema_fields)
-        count_rows = await db_manager.execute_sql_async(
-            count_sql,
-            tuple(count_params) if count_params else None,
-            dataset_id=body.dataset_id,
-        )
-        if count_rows:
-            total_count = int(count_rows[0][0])
-    duration_ms = (time.perf_counter() - start) * 1000
-
     logger.info(
         "tuples query executed",
         extra={
@@ -162,7 +140,6 @@ async def post_query_tuples(body: QueryTuplesRequest, request: Request, _api_key
             "total_count": resp_body["total_count"],
             "cache_status": cache_status,
             "cache_source": cache_source,
-            "row_count": len(rows),
             "queue_wait_ms": round(queue_wait_ms, 2),
             "execution_ms": round(execution_ms, 2),
         },


### PR DESCRIPTION
## Summary
- add a complete backend documentation set for QueryService focused on technical users
- add a full endpoint-level API reference with request/response schemas, status codes, and curl examples
- add a dedicated troubleshooting/FAQ guide and update README navigation entry points

## Files
- docs/server/api-reference.md
- docs/server/troubleshooting.md
- server/README.md
- README.md

## Validation
- Attempted: `./.venv-server/bin/pip install -r server/requirements.txt`
- Result: blocked by offline dependency resolution for `slowapi` in this environment, so runtime test execution could not be completed here

Closes #157
