### PR TITLE
Use timing-safe hmac.compare_digest for API key validation

### DIFF
--- a/server/auth.py
+++ b/server/auth.py
@@ -1,11 +1,27 @@
 """Authentication dependency for QueryService."""
 
+import hmac
+
 from fastapi import HTTPException, Security
 from fastapi.security import APIKeyHeader
 
 from server.config import get_settings
 
 api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
+
+
+def _constant_time_key_check(provided: str, valid_keys: list[str]) -> bool:
+    """Compare provided key against all valid keys in constant time.
+
+    Iterates all keys without short-circuiting to prevent timing oracles
+    that could be used to enumerate valid key prefixes.
+    """
+    provided_bytes = provided.encode()
+    matched = False
+    for key in valid_keys:
+        if hmac.compare_digest(key.encode(), provided_bytes):
+            matched = True
+    return matched
 
 
 async def require_api_key(api_key: str = Security(api_key_header)) -> str:
@@ -19,6 +35,6 @@ async def require_api_key(api_key: str = Security(api_key_header)) -> str:
         return "anonymous"
     if not api_key:
         raise HTTPException(status_code=401, detail="Missing API key")
-    if api_key not in settings.api_key_list:
+    if not _constant_time_key_check(api_key, settings.api_key_list):
         raise HTTPException(status_code=401, detail="Invalid API key")
     return api_key


### PR DESCRIPTION
## Summary

Replaces the short-circuit `api_key in settings.api_key_list` comparison with a constant-time check using `hmac.compare_digest`. Python's `in` operator on a list uses `==` which short-circuits on the first differing byte — a timing oracle that allows attackers to enumerate valid API key prefixes by measuring response latency differences.

## Change

```python
# Before (timing-vulnerable):
if api_key not in settings.api_key_list:
    raise HTTPException(...)

# After (timing-safe):
def _constant_time_key_check(provided: str, valid_keys: list[str]) -> bool:
    provided_bytes = provided.encode()
    matched = False
    for key in valid_keys:
        if hmac.compare_digest(key.encode(), provided_bytes):
            matched = True  # no break — iterate all keys
    return matched

if not _constant_time_key_check(api_key, settings.api_key_list):
    raise HTTPException(...)
```

The loop iterates **all** keys without short-circuiting, so response time is constant regardless of which key prefix matches.

## Test plan

- [x] All 4 existing `test_auth.py` tests pass
- [x] `ruff check` passes

## Issues

Closes #181