### PR TITLE
Dockerfile: add HEALTHCHECK, remove hardcoded UVICORN_WORKERS

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -13,8 +13,18 @@ COPY server/ server/
 
 ENV PYTHONPATH=/app
 ENV PYTHONUNBUFFERED=1
-ENV UVICORN_WORKERS=1
+
+# Persistent storage for export jobs and output files.
+# Mount a volume at /data/exports in production to survive container restarts.
+VOLUME ["/data/exports"]
 
 EXPOSE 8000
 
-CMD ["sh", "-c", "uvicorn server.main:app --host 0.0.0.0 --port 8000 --workers ${UVICORN_WORKERS}"]
+# HEALTHCHECK uses Python's stdlib urllib to avoid requiring curl in the image.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health/ready')" || exit 1
+
+# UVICORN_WORKERS defaults to 1. Override at runtime:
+#   docker run -e UVICORN_WORKERS=4 ...
+# Note: each worker opens its own DuckDB connection; tune accordingly.
+CMD ["sh", "-c", "uvicorn server.main:app --host 0.0.0.0 --port 8000 --workers ${UVICORN_WORKERS:-1}"]


### PR DESCRIPTION
## Summary

Two operational improvements to `server/Dockerfile`.

### HEALTHCHECK added

Docker and Kubernetes won't use the service's `/health/ready` endpoint without a `HEALTHCHECK` instruction (or external config). Now:

```dockerfile
HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health/ready')" || exit 1
```

Uses Python stdlib to avoid requiring `curl` in the slim image.

### UVICORN_WORKERS no longer baked in

```dockerfile
# Before:
ENV UVICORN_WORKERS=1    # baked into image layer

# After:
CMD ["sh", "-c", "uvicorn ... --workers ${UVICORN_WORKERS:-1}"]
```

The shell default `:-1` preserves single-worker behaviour when not set, but the image is no longer opinionated. Override at runtime: `docker run -e UVICORN_WORKERS=4 ...`

### VOLUME declaration

Added `VOLUME ["/data/exports"]` to signal the persistent export path (see #178).

## Test plan

- [x] `docker build` succeeds (no new deps, only Dockerfile changes)
- [x] CI pipeline passes

## Issues

Closes #176