### PR TITLE
Change export default paths from /tmp to /data/exports (ephemeral container fix)

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -20,3 +20,9 @@
 # Authentication
 # QUERYSERVICE_AUTH_ENABLED=false
 # QUERYSERVICE_API_KEYS=key1,key2,key3
+
+# Export storage — must be a persistent volume mount in production containers.
+# Default: /data/exports (mount a volume there).
+# For local dev without Docker you may override to a local path:
+# QUERYSERVICE_EXPORT_OUTPUT_DIR=/tmp/huey-exports
+# QUERYSERVICE_EXPORT_DB_PATH=/tmp/huey-exports/jobs.db

--- a/server/config.py
+++ b/server/config.py
@@ -42,10 +42,13 @@ class Settings(BaseSettings):
     duckdb_enable_object_cache: bool = True
 
     # Export
+    # NOTE: /data/exports must be a persistent volume in production.
+    # In containers, /tmp is ephemeral — pending exports are lost on restart.
+    # Override via QUERYSERVICE_EXPORT_OUTPUT_DIR / QUERYSERVICE_EXPORT_DB_PATH.
     export_ttl_seconds: int = 3600
     export_max_concurrent: int = 5
-    export_output_dir: str = "/tmp/huey-exports"
-    export_db_path: str = "/tmp/huey-exports/jobs.db"
+    export_output_dir: str = "/data/exports"
+    export_db_path: str = "/data/exports/jobs.db"
 
     # Query budgets
     query_timeout_seconds: float = 30.0

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -1,5 +1,6 @@
 """Shared test fixtures for backend tests."""
 
+import os
 from unittest.mock import patch
 
 import pytest
@@ -14,7 +15,24 @@ from server.main import app
 
 
 @pytest.fixture(autouse=True, scope="session")
-def _init_test_db():
+def _tmp_export_dir(tmp_path_factory):
+    """Override export paths to a writable temp directory for the test session.
+
+    Prevents tests from writing to the production default (/data/exports) which
+    may not exist or be writable in CI environments.
+    """
+    export_dir = tmp_path_factory.mktemp("exports")
+    os.environ["QUERYSERVICE_EXPORT_OUTPUT_DIR"] = str(export_dir)
+    os.environ["QUERYSERVICE_EXPORT_DB_PATH"] = str(export_dir / "jobs.db")
+    get_settings.cache_clear()
+    yield
+    os.environ.pop("QUERYSERVICE_EXPORT_OUTPUT_DIR", None)
+    os.environ.pop("QUERYSERVICE_EXPORT_DB_PATH", None)
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _init_test_db(_tmp_export_dir):
     """Initialize DuckDB and export service once for the entire test session."""
     db_manager.initialize()
     settings = get_settings()


### PR DESCRIPTION
## Summary

The export output directory and SQLite job database defaulted to `/tmp/huey-exports`, which is ephemeral in containers. A restart wipes all pending and completed export jobs, causing stale download links to return 404.

## Change

```python
# Before (ephemeral):
export_output_dir: str = "/tmp/huey-exports"
export_db_path: str = "/tmp/huey-exports/jobs.db"

# After (persistent):
export_output_dir: str = "/data/exports"
export_db_path: str = "/data/exports/jobs.db"
```

`/data/exports` should be mounted as a persistent volume in production:

```yaml
# docker-compose.yml
volumes:
  - huey-exports:/data/exports
```

For local development without Docker, override via env vars:
```
QUERYSERVICE_EXPORT_OUTPUT_DIR=/tmp/huey-exports
QUERYSERVICE_EXPORT_DB_PATH=/tmp/huey-exports/jobs.db
```

Instructions are documented in `.env.example`.

## Test plan

- [x] All 33 export store/service tests pass (they use `:memory:` SQLite)
- [x] `ruff check` passes

## Issues

Closes #178

## Notes

- `duckdb_temp_directory` is intentionally left at `/tmp/huey-duckdb-tmp` — this is temporary sort spill space that need not survive restarts
- The `VOLUME` instruction in the Dockerfile is in PR #188