### PR TITLE
Add graceful shutdown drain for in-flight queries

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -51,6 +51,7 @@ class Settings(BaseSettings):
     query_timeout_seconds: float = 30.0
     max_concurrent_queries: int = 8
     max_query_queue_depth: int | None = 32
+    shutdown_drain_seconds: float = 10.0  # Max wait for in-flight queries on shutdown
 
     # Endpoint defaults
     tuples_default_limit: int = 200

--- a/server/main.py
+++ b/server/main.py
@@ -5,6 +5,7 @@ FastAPI application with health endpoints, config loader, and structured logging
 """
 # ruff: noqa: E402
 
+import asyncio
 import logging
 from contextlib import asynccontextmanager
 
@@ -30,6 +31,7 @@ from server.export_service import init_export_service
 from server.export_store import ExportJobStore
 from server.logging_config import setup_logging
 from server.middleware import AccessLogMiddleware, CorrelationIdMiddleware
+from server.query_budget import get_query_budget
 from server.rate_limit import get_real_ip
 from server.request_context import get_request_id
 
@@ -60,9 +62,23 @@ async def lifespan(app: FastAPI):
 
     yield
 
+    drain_seconds = settings.shutdown_drain_seconds
+    logger.info("QueryService draining in-flight queries", extra={"drain_seconds": drain_seconds})
+    budget = get_query_budget()
+    deadline = asyncio.get_event_loop().time() + drain_seconds
+    while budget.active_count > 0:
+        remaining = deadline - asyncio.get_event_loop().time()
+        if remaining <= 0:
+            logger.warning(
+                "Shutdown drain timeout — forcing close with active queries",
+                extra={"active_queries": budget.active_count},
+            )
+            break
+        await asyncio.sleep(0.1)
+
     export_store.close()
     db_manager.shutdown()
-    logger.info("QueryService shutting down")
+    logger.info("QueryService shutdown complete")
 
 
 app = FastAPI(

--- a/server/query_budget.py
+++ b/server/query_budget.py
@@ -61,6 +61,11 @@ class QueryBudget:
                 self._active = max(0, self._active - 1)
             self._semaphore.release()
 
+    @property
+    def active_count(self) -> int:
+        """Return the current number of in-flight queries holding a semaphore slot."""
+        return self._active
+
     async def run_with_budget(
         self,
         request: Request,


### PR DESCRIPTION
## Summary
- Adds `shutdown_drain_seconds` setting (default 10 s) to `Settings`
- Polls `QueryBudget.active_count` in the lifespan shutdown loop, waiting until all in-flight queries finish or the deadline is hit
- Logs a warning if shutdown is forced with active queries remaining
- Adds `active_count` property to `QueryBudget`

Closes #179.

## Test plan
- [ ] Existing `test_query_budget.py` tests pass (no new shutdown-specific tests needed; the behaviour is exercised by the integration path)
- [ ] `test_query_timeout_response` — 504 still returned for tiny timeout
- [ ] `test_queue_depth_rejects_overflow` — 429 still returned when queue is full
- [ ] Lint and mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)