### PR TITLE
Decouple limiter from server.main into server/rate_limit

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -17,7 +17,7 @@ ensure_supported_python()
 from fastapi import FastAPI
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
-from slowapi import Limiter, _rate_limit_exceeded_handler
+from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 from starlette.requests import Request
@@ -32,18 +32,12 @@ from server.export_store import ExportJobStore
 from server.logging_config import setup_logging
 from server.middleware import AccessLogMiddleware, CorrelationIdMiddleware
 from server.query_budget import get_query_budget
-from server.rate_limit import get_real_ip
+from server.rate_limit import limiter
 from server.request_context import get_request_id
 
 settings = get_settings()
 setup_logging(settings.log_level, settings.log_format)
 logger = logging.getLogger("query_service")
-
-limiter = Limiter(
-    key_func=get_real_ip,
-    enabled=settings.rate_limit_enabled,
-    headers_enabled=True,
-)
 
 
 @asynccontextmanager

--- a/server/rate_limit.py
+++ b/server/rate_limit.py
@@ -31,4 +31,4 @@ def _make_limiter() -> Limiter:
     )
 
 
-limiter = _make_limiter()
+limiter = _make_limiter()  # module-level singleton

--- a/server/rate_limit.py
+++ b/server/rate_limit.py
@@ -1,6 +1,9 @@
 """Rate limiting helpers for QueryService."""
 
+from slowapi import Limiter
 from starlette.requests import Request
+
+from server.config import get_settings
 
 
 def get_real_ip(request: Request) -> str:
@@ -17,3 +20,15 @@ def get_real_ip(request: Request) -> str:
         return real_ip.strip()
     client = request.client
     return client.host if client else "unknown"
+
+
+def _make_limiter() -> Limiter:
+    settings = get_settings()
+    return Limiter(
+        key_func=get_real_ip,
+        enabled=settings.rate_limit_enabled,
+        headers_enabled=True,
+    )
+
+
+limiter = _make_limiter()

--- a/server/routers/export.py
+++ b/server/routers/export.py
@@ -17,7 +17,7 @@ from server.config import get_settings
 from server.engine import db_manager
 from server.errors import DatasetNotFoundError, DatasetUnavailableError
 from server.export_service import get_export_service
-from server.main import limiter
+from server.rate_limit import limiter
 from server.models import ExportRequest, ExportResponse, ExportStatusResponse
 from server.query_builder import validate_export_query_fields
 from server.request_context import set_request_id

--- a/server/routers/export.py
+++ b/server/routers/export.py
@@ -17,9 +17,9 @@ from server.config import get_settings
 from server.engine import db_manager
 from server.errors import DatasetNotFoundError, DatasetUnavailableError
 from server.export_service import get_export_service
-from server.rate_limit import limiter
 from server.models import ExportRequest, ExportResponse, ExportStatusResponse
 from server.query_builder import validate_export_query_fields
+from server.rate_limit import limiter
 from server.request_context import set_request_id
 
 logger = logging.getLogger("query_service.export")

--- a/server/routers/query.py
+++ b/server/routers/query.py
@@ -13,7 +13,7 @@ from server.cache import build_cache_key, get_query_cache
 from server.config import get_settings
 from server.engine import db_manager
 from server.errors import CellsWindowTooLargeError, DatasetNotFoundError
-from server.main import limiter
+from server.rate_limit import limiter
 from server.models import (
     CellsResponse,
     PagingResponse,

--- a/server/routers/query.py
+++ b/server/routers/query.py
@@ -13,7 +13,6 @@ from server.cache import build_cache_key, get_query_cache
 from server.config import get_settings
 from server.engine import db_manager
 from server.errors import CellsWindowTooLargeError, DatasetNotFoundError
-from server.rate_limit import limiter
 from server.models import (
     CellsResponse,
     PagingResponse,
@@ -33,6 +32,7 @@ from server.query_builder import (
     build_tuples_count_sql,
     build_tuples_sql,
 )
+from server.rate_limit import limiter
 from server.request_context import set_request_id
 
 logger = logging.getLogger("query_service.query")


### PR DESCRIPTION
## Summary
- Moves `Limiter` construction into `server/rate_limit.py` (alongside `get_real_ip`)
- Both `server/routers/query.py` and `server/routers/export.py` now import `limiter` from `server.rate_limit` instead of `server.main`, eliminating the circular import hazard
- `server/main.py` imports `limiter` the same way; the inline `Limiter(…)` construction and now-unused `slowapi.Limiter` import are removed

Closes #193.

## Test plan
- [ ] `test_rate_limiting.py` — rate headers and 429 responses still work
- [ ] `test_query_budget.py` — budget enforcement unaffected
- [ ] Lint clean (no unused imports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)