### PR TITLE
Skip table_exists check for parquet_partitioned mode in POST /export

### DIFF
--- a/server/routers/export.py
+++ b/server/routers/export.py
@@ -43,7 +43,8 @@ async def post_export(
         request.state.request_id = rid
     if datasets.get_schema(body.dataset_id) is None:
         raise DatasetNotFoundError(body.dataset_id)
-    if not db_manager.table_exists(body.dataset_id):
+    settings = get_settings()
+    if settings.execution_mode == "sample_table" and not db_manager.table_exists(body.dataset_id):
         raise DatasetUnavailableError(body.dataset_id)
     validate_export_query_fields(body.query, datasets.get_schema_field_names(body.dataset_id))
 

--- a/server/tests/test_export_api.py
+++ b/server/tests/test_export_api.py
@@ -200,6 +200,32 @@ class TestExportErrors:
         r = client.post("/export", json=_valid_body(dataset_id="nonexistent"))
         assert r.status_code == 404
 
+    def test_dataset_unavailable_in_sample_table_mode(self, client: TestClient, monkeypatch) -> None:
+        """In sample_table mode, missing DuckDB table returns 409 DATASET_UNAVAILABLE."""
+        from server.engine import db_manager
+        monkeypatch.setenv("QUERYSERVICE_EXECUTION_MODE", "sample_table")
+        from server.config import get_settings
+        get_settings.cache_clear()
+        monkeypatch.setattr(db_manager, "table_exists", lambda _: False)
+        r = client.post("/export", json=_valid_body())
+        get_settings.cache_clear()
+        assert r.status_code == 409
+        assert r.json()["code"] == "DATASET_UNAVAILABLE"
+
+    def test_dataset_available_in_parquet_partitioned_mode(self, client: TestClient, monkeypatch) -> None:
+        """In parquet_partitioned mode, no DuckDB table check is performed at submission time."""
+        from server.engine import db_manager
+        monkeypatch.setenv("QUERYSERVICE_EXECUTION_MODE", "parquet_partitioned")
+        from server.config import get_settings
+        get_settings.cache_clear()
+        # Ensure table_exists would return False — should not matter in parquet_partitioned mode.
+        monkeypatch.setattr(db_manager, "table_exists", lambda _: False)
+        r = client.post("/export", json=_valid_body())
+        get_settings.cache_clear()
+        # Job is accepted (200) even though no local table exists.
+        assert r.status_code == 200
+        assert r.json()["status"] == "pending"
+
     def test_get_export_not_found(self, client: TestClient) -> None:
         r = client.get("/export/exp-nonexistent")
         assert r.status_code == 404


### PR DESCRIPTION
## Summary
- In `parquet_partitioned` mode no local DuckDB table is used, so `db_manager.table_exists()` returned false for valid S3-backed datasets, causing spurious 409 `DATASET_UNAVAILABLE` responses
- The precheck is now gated on `execution_mode == "sample_table"` only; partitioned-mode errors surface at execution time via `DatasetUnavailableError` / `is_missing_table_error`
- Two new tests added to `TestExportErrors`:
  - `test_dataset_unavailable_in_sample_table_mode` — 409 when table missing in sample_table mode
  - `test_dataset_available_in_parquet_partitioned_mode` — 200 accepted even without a local table in partitioned mode

Closes #192.

## Test plan
- [ ] `TestExportErrors` — all 8 tests pass
- [ ] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)