### PR TITLE
Standardize auth 401 responses to ErrorResponse envelope; add endpoint auth matrix

### DIFF
--- a/server/auth.py
+++ b/server/auth.py
@@ -2,10 +2,11 @@
 
 import hmac
 
-from fastapi import HTTPException, Security
+from fastapi import Security
 from fastapi.security import APIKeyHeader
 
 from server.config import get_settings
+from server.errors import AuthError
 
 api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
 
@@ -34,7 +35,7 @@ async def require_api_key(api_key: str = Security(api_key_header)) -> str:
     if not settings.auth_enabled:
         return "anonymous"
     if not api_key:
-        raise HTTPException(status_code=401, detail="Missing API key")
+        raise AuthError("Missing API key")
     if not _constant_time_key_check(api_key, settings.api_key_list):
-        raise HTTPException(status_code=401, detail="Invalid API key")
+        raise AuthError("Invalid API key")
     return api_key

--- a/server/errors.py
+++ b/server/errors.py
@@ -180,6 +180,17 @@ class CellsWindowTooLargeError(AppError):
         )
 
 
+class AuthError(AppError):
+    """Raised on missing or invalid API key authentication."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(
+            code="AUTH_ERROR",
+            message=message,
+            status_code=401,
+        )
+
+
 class TooManyConcurrentQueriesError(AppError):
     """Raised when the in-flight query limit and queue depth are exceeded."""
 

--- a/server/tests/test_auth.py
+++ b/server/tests/test_auth.py
@@ -1,26 +1,72 @@
+"""Tests for API key authentication across all protected endpoints."""
+
+import pytest
 from fastapi.testclient import TestClient
 
+VALID_KEY = "test-key-123"
+INVALID_KEY = "wrong-key"
 
-def test_auth_missing_key_returns_401(auth_client: TestClient):
-    r = auth_client.get("/schema", params={"dataset_id": "trades_v1"})
+# (method, path, minimal_body) for every protected endpoint
+_PROTECTED_ENDPOINTS = [
+    ("GET", "/schema", None, {"dataset_id": "trades_v1"}),
+    ("POST", "/query/tuples", {
+        "dataset_id": "trades_v1",
+        "date_range": {"type": "single", "date": "2026-03-01"},
+        "query": {"axes": {"rows": [{"field": "symbol"}], "columns": [], "measures": []}},
+    }, {}),
+    ("POST", "/query/cells", {
+        "dataset_id": "trades_v1",
+        "date_range": {"type": "single", "date": "2026-03-01"},
+        "query": {"axes": {"rows": [{"field": "symbol"}], "columns": [], "measures": [{"field": "volume", "aggregation": "SUM", "alias": "v"}]}},
+    }, {}),
+    ("POST", "/query/picklist", {
+        "dataset_id": "trades_v1",
+        "date_range": {"type": "single", "date": "2026-03-01"},
+        "field": "symbol",
+    }, {}),
+    ("POST", "/export", {
+        "dataset_id": "trades_v1",
+        "date_range": {"type": "single", "date": "2026-03-01"},
+        "query": {
+            "export_type": "pivot_results",
+            "axes": {"rows": [{"field": "symbol"}], "measures": [{"field": "volume", "aggregation": "SUM", "alias": "v"}]},
+            "filters": [],
+            "max_rows": 10,
+            "format": "csv",
+        },
+    }, {}),
+    ("GET", "/export/nonexistent", None, {}),
+    ("GET", "/export/nonexistent/download", None, {}),
+]
+
+
+def _call(client: TestClient, method: str, path: str, body, params: dict, headers: dict):
+    if method == "GET":
+        return client.get(path, params=params, headers=headers)
+    return client.post(path, json=body, headers=headers)
+
+
+def _assert_auth_error_envelope(r) -> None:
     assert r.status_code == 401
+    body = r.json()
+    assert body["code"] == "AUTH_ERROR"
+    assert "message" in body
 
 
-def test_auth_invalid_key_returns_401(auth_client: TestClient):
-    r = auth_client.get(
-        "/schema",
-        params={"dataset_id": "trades_v1"},
-        headers={"X-API-Key": "wrong"},
-    )
-    assert r.status_code == 401
+@pytest.mark.parametrize("method,path,body,params", _PROTECTED_ENDPOINTS)
+def test_missing_key_returns_401_envelope(auth_client: TestClient, method, path, body, params):
+    r = _call(auth_client, method, path, body, params, headers={})
+    _assert_auth_error_envelope(r)
 
 
-def test_auth_valid_key_returns_200(auth_client: TestClient):
-    r = auth_client.get(
-        "/schema",
-        params={"dataset_id": "trades_v1"},
-        headers={"X-API-Key": "test-key-123"},
-    )
+@pytest.mark.parametrize("method,path,body,params", _PROTECTED_ENDPOINTS)
+def test_invalid_key_returns_401_envelope(auth_client: TestClient, method, path, body, params):
+    r = _call(auth_client, method, path, body, params, headers={"X-API-Key": INVALID_KEY})
+    _assert_auth_error_envelope(r)
+
+
+def test_valid_key_schema_returns_200(auth_client: TestClient):
+    r = auth_client.get("/schema", params={"dataset_id": "trades_v1"}, headers={"X-API-Key": VALID_KEY})
     assert r.status_code == 200
 
 

--- a/server/tests/test_error_contract.py
+++ b/server/tests/test_error_contract.py
@@ -171,7 +171,11 @@ class TestErrorResponseSchema:
 
     def test_export_post_409_dataset_unavailable_envelope(self, client: TestClient, monkeypatch) -> None:
         import server.routers.export as export_router
+        from server.config import get_settings
 
+        # table_exists check only fires in sample_table mode
+        monkeypatch.setenv("QUERYSERVICE_EXECUTION_MODE", "sample_table")
+        get_settings.cache_clear()
         monkeypatch.setattr(
             export_router.datasets,
             "get_schema",
@@ -179,6 +183,7 @@ class TestErrorResponseSchema:
         )
         monkeypatch.setattr(export_router.db_manager, "table_exists", lambda _dataset_id: False)
         r = client.post("/export", json=_export_body(dataset_id="not_materialized_ds"))
+        get_settings.cache_clear()
         assert r.status_code == 409
         payload = r.json()
         assert payload["code"] == "DATASET_UNAVAILABLE"
@@ -293,6 +298,32 @@ class TestDomainExceptions:
         assert err.code == "TOO_MANY_EXPORTS"
         assert err.status_code == 429
         assert err.details["max_concurrent"] == 5
+
+
+class TestInternalErrorEnvelope:
+    """Unhandled exceptions return INTERNAL_ERROR without leaking stack traces."""
+
+    def test_unhandled_exception_returns_500_envelope(self, monkeypatch) -> None:
+        import server.routers.query as query_router
+        from server.main import app
+
+        async def boom(*args, **kwargs):
+            raise RuntimeError("unexpected failure")
+
+        monkeypatch.setattr(query_router.db_manager, "execute_sql_async", boom)
+        # raise_server_exceptions=False so we get the HTTP response instead of the re-raised exception
+        no_raise_client = TestClient(app, raise_server_exceptions=False)
+        r = no_raise_client.post("/query/cells", json={
+            "dataset_id": "trades_v1",
+            "date_range": {"type": "single", "date": "2026-03-01"},
+            "query": {"axes": {"rows": [{"field": "symbol"}], "columns": [], "measures": [{"field": "volume", "aggregation": "SUM", "alias": "v"}]}},
+        })
+        assert r.status_code == 500
+        body = r.json()
+        assert body["code"] == "INTERNAL_ERROR"
+        assert "message" in body
+        # No raw exception message or traceback in the response body
+        assert "unexpected failure" not in str(body)
 
 
 class TestHappyPathUnchanged:


### PR DESCRIPTION
## Summary
- `server/auth.py`: raises `AuthError` (new `AppError` subclass) instead of `HTTPException`, so the existing `app_error_handler` wraps it in the standard `ErrorResponse` envelope `{code, message, request_id?}`
- `server/errors.py`: adds `AuthError` with `code="AUTH_ERROR"` and `status_code=401`
- `server/tests/test_auth.py`: rewritten with a parametrized matrix covering all 7 protected endpoints (GET /schema, POST /query/{tuples,cells,picklist}, POST /export, GET /export/{id}, GET /export/{id}/download); each tested for missing key → 401 AUTH_ERROR, invalid key → 401 AUTH_ERROR; health endpoints verified to need no auth

Closes #195, closes #197.

## Test plan
- [ ] 16 auth tests pass
- [ ] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)