### PR TITLE
Refactor ExportService to use ExportJobStore public API only

### DIFF
--- a/server/export_service.py
+++ b/server/export_service.py
@@ -161,13 +161,7 @@ class ExportService:
 
     def recover_stale_jobs(self) -> int:
         """Mark any active jobs as failed on startup (stale from crash/restart)."""
-        stale: list[ExportJob] = []
-        with self._store._lock:
-            cur = self._store._conn.execute(
-                "SELECT * FROM export_jobs WHERE status IN ('pending', 'processing')",
-            )
-            stale = [self._store._row_to_job(row) for row in cur.fetchall()]
-
+        stale = self._store.find_stale()
         count = 0
         for job in stale:
             self._store.update_status(

--- a/server/export_store.py
+++ b/server/export_store.py
@@ -230,6 +230,14 @@ class ExportJobStore:
             )
             return cur.fetchone()[0]
 
+    def find_stale(self) -> list[ExportJob]:
+        """Return jobs in pending or processing state (presumed stale after restart)."""
+        with self._lock:
+            cur = self._conn.execute(
+                "SELECT * FROM export_jobs WHERE status IN ('pending', 'processing')",
+            )
+            return [self._row_to_job(row) for row in cur.fetchall()]
+
     def find_expired(self, ttl_seconds: int) -> list[ExportJob]:
         """Find jobs older than TTL that haven't been expired yet."""
         cutoff = time.time() - ttl_seconds

--- a/server/tests/test_export_store.py
+++ b/server/tests/test_export_store.py
@@ -170,6 +170,26 @@ class TestFindExpired:
         assert len(expired) == 0
 
 
+class TestFindStale:
+    def test_returns_pending_and_processing(self, store: ExportJobStore) -> None:
+        store.create("exp-pending", "ds1")
+        store.create("exp-proc", "ds1")
+        store.update_status("exp-proc", "processing")
+        store.create("exp-complete", "ds1")
+        store.update_status("exp-complete", "processing")
+        store.update_status("exp-complete", "complete", file_path="/tmp/f.csv")
+
+        stale = store.find_stale()
+        ids = {j.id for j in stale}
+        assert ids == {"exp-pending", "exp-proc"}
+
+    def test_empty_when_no_active(self, store: ExportJobStore) -> None:
+        store.create("exp-1", "ds1")
+        store.update_status("exp-1", "processing")
+        store.update_status("exp-1", "complete", file_path="/tmp/f.csv")
+        assert store.find_stale() == []
+
+
 class TestDelete:
     def test_deletes_existing(self, store: ExportJobStore) -> None:
         store.create("exp-1", "ds1")


### PR DESCRIPTION
## Summary
- Adds `ExportJobStore.find_stale()` — a public method returning jobs in `pending` or `processing` state
- `ExportService.recover_stale_jobs` now calls `self._store.find_stale()` instead of reaching into `_lock`, `_conn`, and `_row_to_job` directly
- Two new tests added to `TestFindStale` in `test_export_store.py`

Closes #196.

## Test plan
- [ ] 36 store + service tests pass
- [ ] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)