### PR TITLE
Enforce Literal type for execution_mode; document shutdown_drain_seconds

### DIFF
--- a/docs/server/configuration-reference.md
+++ b/docs/server/configuration-reference.md
@@ -39,6 +39,7 @@ Example: `QUERYSERVICE_PORT=8000` maps to `port` setting.
 | `QUERYSERVICE_QUERY_TIMEOUT_SECONDS` | `30.0` | float | Query timeout budget setting |
 | `QUERYSERVICE_MAX_CONCURRENT_QUERIES` | `8` | int | Concurrent query budget setting |
 | `QUERYSERVICE_MAX_QUERY_QUEUE_DEPTH` | `32` | int or empty | Queue depth budget setting |
+| `QUERYSERVICE_SHUTDOWN_DRAIN_SECONDS` | `10.0` | float | Max seconds to wait for in-flight queries on graceful shutdown |
 | `QUERYSERVICE_TUPLES_DEFAULT_LIMIT` | `200` | int | Default tuples page size |
 | `QUERYSERVICE_PICKLIST_DEFAULT_LIMIT` | `100` | int | Default picklist page size |
 | `QUERYSERVICE_MAX_CELLS_PER_RESPONSE` | `10000` | int | Max cells payload bound |

--- a/server/config.py
+++ b/server/config.py
@@ -6,6 +6,7 @@ Loads settings from environment variables and optional config file.
 
 import json
 from functools import lru_cache
+from typing import Literal
 
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -87,7 +88,7 @@ class Settings(BaseSettings):
     cache_sqlite_path: str | None = None
     cache_sqlite_max_bytes: int = 256 * 1024 * 1024
     # Query execution
-    execution_mode: str = "sample_table"  # "sample_table" | "parquet_partitioned"
+    execution_mode: Literal["sample_table", "parquet_partitioned"] = "sample_table"
     partition_base_path: str | None = None
 
     @property

--- a/server/relation_builder.py
+++ b/server/relation_builder.py
@@ -117,8 +117,7 @@ def build_base_relation(
     - parquet_partitioned: reads partitioned parquet paths with projection pushdown
     """
     settings = get_settings()
-    mode = getattr(settings, "execution_mode", "sample_table")
-    if mode == "parquet_partitioned":
+    if settings.execution_mode == "parquet_partitioned":
         return _build_parquet_partition_relation(dataset_id, date_range, required_columns)
 
     quoted = quote_identifier(dataset_id)

--- a/server/tests/test_config.py
+++ b/server/tests/test_config.py
@@ -52,3 +52,13 @@ def test_cors_origins_parse_csv() -> None:
 def test_cors_origins_parse_json_array() -> None:
     s = Settings(cors_origins='["https://app.example.com","https://admin.example.com"]')
     assert s.cors_origins == ["https://app.example.com", "https://admin.example.com"]
+
+
+def test_execution_mode_valid_values() -> None:
+    assert Settings(execution_mode="sample_table").execution_mode == "sample_table"
+    assert Settings(execution_mode="parquet_partitioned").execution_mode == "parquet_partitioned"
+
+
+def test_execution_mode_invalid_raises() -> None:
+    with pytest.raises(ValidationError):
+        Settings(execution_mode="unknown_mode")


### PR DESCRIPTION
## Summary
- **#202**: `execution_mode` in `Settings` changed from `str` to `Literal["sample_table", "parquet_partitioned"]`; pydantic now rejects unknown values at startup. Silent `getattr` fallback removed from `relation_builder.py`. Two new config tests added.
- **#203**: `QUERYSERVICE_SHUTDOWN_DRAIN_SECONDS` added to `docs/server/configuration-reference.md` (was introduced in #179 but not documented). `server/README.md` already had no conflict markers.

Closes #202, closes #203.

## Test plan
- [ ] 9 config tests pass
- [ ] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)