### PR TITLE
Add lifespan failure-path tests; wrap stale-job recovery in try-except (#200)

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -50,9 +50,12 @@ async def lifespan(app: FastAPI):
     export_store = ExportJobStore(settings.export_db_path)
     export_store.initialize()
     svc = init_export_service(export_store)
-    recovered = svc.recover_stale_jobs()
-    if recovered:
-        logger.info("Recovered stale export jobs", extra={"count": recovered})
+    try:
+        recovered = svc.recover_stale_jobs()
+        if recovered:
+            logger.info("Recovered stale export jobs", extra={"count": recovered})
+    except Exception:
+        logger.exception("Stale-job recovery failed; continuing startup")
 
     yield
 

--- a/server/tests/test_lifespan.py
+++ b/server/tests/test_lifespan.py
@@ -1,0 +1,71 @@
+"""
+Tests for lifespan startup and shutdown failure paths (#200).
+
+Verifies:
+- Critical startup failures (db_manager, ExportJobStore) propagate and abort startup.
+- Non-critical failures (recover_stale_jobs) are caught, logged, and startup continues.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from server.main import app
+
+
+class TestCriticalStartupFailures:
+    """Critical init failures abort startup and propagate the exception."""
+
+    def test_db_initialize_failure_aborts_startup(self) -> None:
+        """db_manager.initialize() failure propagates out of the lifespan."""
+        with (
+            patch("server.main.db_manager") as mock_db,
+            patch("server.main.load_sample_data"),
+        ):
+            mock_db.initialize.side_effect = RuntimeError("DuckDB init failed")
+            mock_db.shutdown = MagicMock()
+            with pytest.raises(RuntimeError, match="DuckDB init failed"):
+                with TestClient(app):
+                    pass  # pragma: no cover
+
+    def test_export_store_initialize_failure_aborts_startup(self) -> None:
+        """ExportJobStore.initialize() failure propagates out of the lifespan."""
+        with (
+            patch("server.main.db_manager") as mock_db,
+            patch("server.main.load_sample_data"),
+            patch("server.main.ExportJobStore") as mock_store_cls,
+        ):
+            mock_db.initialize = MagicMock()
+            mock_db.shutdown = MagicMock()
+            mock_store = MagicMock()
+            mock_store_cls.return_value = mock_store
+            mock_store.initialize.side_effect = OSError("Cannot open export DB")
+            with pytest.raises(OSError, match="Cannot open export DB"):
+                with TestClient(app):
+                    pass  # pragma: no cover
+
+
+class TestGracefulStartupDegradation:
+    """Non-critical startup failures are caught and startup continues."""
+
+    def test_recover_stale_jobs_failure_does_not_abort_startup(self) -> None:
+        """recover_stale_jobs() failure is swallowed; the app starts and is healthy."""
+        with (
+            patch("server.main.db_manager") as mock_db,
+            patch("server.main.load_sample_data"),
+            patch("server.main.ExportJobStore") as mock_store_cls,
+            patch("server.main.init_export_service") as mock_init_svc,
+        ):
+            mock_db.initialize = MagicMock()
+            mock_db.shutdown = MagicMock()
+            mock_store = MagicMock()
+            mock_store_cls.return_value = mock_store
+            mock_svc = MagicMock()
+            mock_init_svc.return_value = mock_svc
+            mock_svc.recover_stale_jobs.side_effect = RuntimeError("stale recovery failed")
+
+            with TestClient(app) as client:
+                response = client.get("/health/liveness")
+
+        assert response.status_code == 200


### PR DESCRIPTION
## Summary
- Wraps `svc.recover_stale_jobs()` in a `try/except` in `server/main.py` so a stale-job recovery failure only logs a warning instead of aborting startup
- Adds `server/tests/test_lifespan.py` with three tests:
  - `db_manager.initialize()` raising → lifespan propagates the exception (startup aborts)
  - `ExportJobStore.initialize()` raising → lifespan propagates the exception (startup aborts)
  - `recover_stale_jobs()` raising → exception is swallowed, app starts and `/health/liveness` returns 200

## Test plan
- [ ] `pytest server/tests/test_lifespan.py` — 3 tests pass
- [ ] Full suite `pytest server/` — all 404 tests pass

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)