### PR TITLE
Add flexible source-driven S3 dataset support

### DIFF
--- a/docs/huey-large-scale-olap-tech-spec.md
+++ b/docs/huey-large-scale-olap-tech-spec.md
@@ -1,3 +1,4 @@
+
 ## Huey Large-Scale OLAP – Technical Specification
 
 This specification defines how Huey will integrate with a server-side query service to support large S3-backed parquet datasets (50 GB per day, multi-year history).

--- a/docs/server/api-reference.md
+++ b/docs/server/api-reference.md
@@ -38,6 +38,11 @@ Interactive OpenAPI:
 - Single day: `{"type": "single", "date": "YYYY-MM-DD"}`
 - Inclusive range: `{"type": "range", "start": "YYYY-MM-DD", "end": "YYYY-MM-DD"}`
 
+`date_range` behavior by dataset:
+
+- If dataset source defines a time filter column, `date_range` is applied to that column.
+- If dataset source has no time filter, `date_range` is accepted but ignored.
+
 ### Common error envelope
 
 ```json

--- a/docs/server/configuration-reference.md
+++ b/docs/server/configuration-reference.md
@@ -97,3 +97,35 @@ Example: `QUERYSERVICE_PORT=8000` maps to `port` setting.
 - Empty strings for optional path/string settings are normalized to `None`.
 - `QUERYSERVICE_CORS_ORIGINS` accepts either CSV (`https://a,https://b`) or JSON array (`["https://a","https://b"]`).
 - Settings are cached in-process; test code may clear cache with `get_settings.cache_clear()` when mutating environment at runtime.
+
+## Dataset `source` Configuration (YAML)
+
+Datasets may define a per-dataset physical source block in `datasets.yaml` to override the legacy
+`<dataset_id>/date=YYYY-MM-DD/*.parquet` convention:
+
+```yaml
+datasets:
+  - dataset_id: nyc_taxi_yellow
+    source:
+      kind: parquet_scan
+      uris:
+        - s3://nyc-tlc/trip data/yellow_tripdata_*.parquet
+      read_options:
+        hive_partitioning: false   # true | false | auto
+        union_by_name: true
+        filename: false
+      time_filter:
+        column: tpep_pickup_datetime
+        type: timestamp            # date | timestamp | string
+      max_files: 5000
+    fields:
+      - name: VendorID
+        type: int64
+        is_dimension: true
+```
+
+Behavior:
+
+- If `source` is omitted, QueryService uses legacy partition behavior in `parquet_partitioned` mode.
+- If `source.time_filter` is omitted, the API still accepts `date_range` but does not apply a time predicate.
+- `read_options.hive_partitioning` supports non-Hive, single-Hive, or multi-Hive layouts.

--- a/server/datasets.py
+++ b/server/datasets.py
@@ -9,12 +9,14 @@ import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import yaml
+from pydantic import BaseModel, Field, ValidationError, field_validator
 
 from server.config import get_settings
 from server.engine import DuckDBManager
+from server.errors import DatasetConfigError
 from server.utils import quote_identifier
 
 logger = logging.getLogger("query_service.datasets")
@@ -24,6 +26,60 @@ logger = logging.getLogger("query_service.datasets")
 class _SchemaCacheEntry:
     schema: dict[str, Any] | None
     loaded_at: float
+
+
+class DatasetSourceReadOptions(BaseModel):
+    """Typed options for DuckDB read_parquet()."""
+
+    hive_partitioning: Literal["auto"] | bool = "auto"
+    union_by_name: bool = False
+    filename: bool = False
+    hive_types: dict[str, str] | None = None
+
+
+class DatasetPartitionKey(BaseModel):
+    """Optional metadata about partition keys in the physical source."""
+
+    name: str
+    role: Literal["date", "business_date", "none"] = "none"
+    type: str | None = None
+
+
+class DatasetTimeFilter(BaseModel):
+    """Optional time filter mapping from API date_range to a source column."""
+
+    column: str
+    type: Literal["date", "timestamp", "string"] = "date"
+
+
+class DatasetSourceConfig(BaseModel):
+    """Per-dataset physical source definition for parquet_scan relation planning."""
+
+    kind: Literal["parquet_scan"] = "parquet_scan"
+    uris: str | list[str]
+    read_options: DatasetSourceReadOptions = Field(default_factory=DatasetSourceReadOptions)
+    partitions: list[DatasetPartitionKey] = Field(default_factory=list)
+    time_filter: DatasetTimeFilter | None = None
+    max_files: int | None = Field(default=None, ge=1)
+
+    @field_validator("uris")
+    @classmethod
+    def _validate_uris(cls, value: str | list[str]) -> str | list[str]:
+        if isinstance(value, str):
+            if value.strip() == "":
+                raise ValueError("source.uris must not be empty")
+            return value
+        if not value:
+            raise ValueError("source.uris must include at least one path")
+        cleaned = [u for u in value if isinstance(u, str) and u.strip()]
+        if not cleaned:
+            raise ValueError("source.uris must include at least one non-empty path")
+        return cleaned
+
+    def normalized_uris(self) -> list[str]:
+        if isinstance(self.uris, str):
+            return [self.uris]
+        return list(self.uris)
 
 
 def _default_config_path() -> Path:
@@ -63,6 +119,8 @@ class _DatasetSchemaCache:
         self._lock = threading.RLock()
         self._schemas: dict[str, _SchemaCacheEntry] = {}
         self._schema_fields: dict[str, set[str]] = {}
+        self._dataset_entries: dict[str, dict[str, Any] | None] = {}
+        self._dataset_sources: dict[str, DatasetSourceConfig | None] = {}
         self._partition_metadata: dict[str, Any] = {}
         self._config_path: str | None = None
         self._config_mtime: float | None = None
@@ -98,6 +156,8 @@ class _DatasetSchemaCache:
             self._config_mtime = mtime
             self._schemas.clear()
             self._schema_fields.clear()
+            self._dataset_entries.clear()
+            self._dataset_sources.clear()
             self._partition_metadata.clear()
             self._counters["refresh_count"] += 1
             logger.info(
@@ -120,11 +180,40 @@ class _DatasetSchemaCache:
             if isinstance(f, dict) and "name" in f
         }
 
-    def _store_schema_locked(self, dataset_id: str, schema: dict[str, Any] | None) -> None:
+    @staticmethod
+    def _parse_dataset_source(dataset_id: str, dataset_entry: dict[str, Any] | None) -> DatasetSourceConfig | None:
+        if not dataset_entry:
+            return None
+        source_value = dataset_entry.get("source")
+        if source_value is None:
+            return None
+        if not isinstance(source_value, dict):
+            raise DatasetConfigError(
+                dataset_id,
+                "Dataset source must be an object",
+                {"field": "source"},
+            )
+        try:
+            return DatasetSourceConfig.model_validate(source_value)
+        except ValidationError as exc:
+            raise DatasetConfigError(
+                dataset_id,
+                "Dataset source validation failed",
+                {"field": "source", "errors": exc.errors()},
+            ) from exc
+
+    def _store_schema_locked(
+        self,
+        dataset_id: str,
+        schema: dict[str, Any] | None,
+        dataset_entry: dict[str, Any] | None = None,
+    ) -> None:
         loaded_at = time.monotonic()
         field_names = self._extract_field_names(schema)
         self._schemas[dataset_id] = _SchemaCacheEntry(schema=schema, loaded_at=loaded_at)
         self._schema_fields[dataset_id] = field_names
+        self._dataset_entries[dataset_id] = dataset_entry
+        self._dataset_sources[dataset_id] = self._parse_dataset_source(dataset_id, dataset_entry)
 
     def get_schema(self, dataset_id: str) -> dict[str, Any] | None:
         """
@@ -149,9 +238,11 @@ class _DatasetSchemaCache:
 
         # YAML parsing can be expensive; do it outside the lock.
         schema = None
+        dataset_entry = None
         config = load_datasets_config()
         for ds in config.get("datasets", []):
             if isinstance(ds, dict) and ds.get("dataset_id") == dataset_id:
+                dataset_entry = ds
                 schema = {"dataset_id": dataset_id, "fields": ds.get("fields", [])}
                 break
 
@@ -173,7 +264,7 @@ class _DatasetSchemaCache:
             if entry and self._is_expired(entry.loaded_at):
                 self._counters["refresh_count"] += 1
             self._counters["cache_miss"] += 1
-            self._store_schema_locked(dataset_id, schema)
+            self._store_schema_locked(dataset_id, schema, dataset_entry)
             logger.info(
                 "dataset schema cached",
                 extra={
@@ -196,6 +287,19 @@ class _DatasetSchemaCache:
                 return set()
             return set(fields)
 
+    def get_dataset_entry(self, dataset_id: str) -> dict[str, Any] | None:
+        """Return raw dataset entry from config for a dataset_id."""
+        self.get_schema(dataset_id)
+        with self._lock:
+            entry = self._dataset_entries.get(dataset_id)
+            return dict(entry) if entry else None
+
+    def get_dataset_source(self, dataset_id: str) -> DatasetSourceConfig | None:
+        """Return parsed source metadata for a dataset, if present."""
+        self.get_schema(dataset_id)
+        with self._lock:
+            return self._dataset_sources.get(dataset_id)
+
     def set_partition_metadata(self, dataset_id: str, metadata: Any) -> None:
         """Store per-dataset partition metadata (e.g., shard descriptors) for partition-native execution."""
         with self._lock:
@@ -216,6 +320,8 @@ class _DatasetSchemaCache:
         with self._lock:
             self._schemas.clear()
             self._schema_fields.clear()
+            self._dataset_entries.clear()
+            self._dataset_sources.clear()
             self._partition_metadata.clear()
             self._counters = {"cache_hit": 0, "cache_miss": 0, "refresh_count": 0}
             self._config_path = None
@@ -241,6 +347,16 @@ def get_schema(dataset_id: str) -> dict[str, Any] | None:
 def get_schema_field_names(dataset_id: str) -> set[str]:
     """Return the set of field names defined in the schema for a dataset."""
     return _schema_cache.get_schema_field_names(dataset_id)
+
+
+def get_dataset_entry(dataset_id: str) -> dict[str, Any] | None:
+    """Return the raw dataset config entry for a dataset_id."""
+    return _schema_cache.get_dataset_entry(dataset_id)
+
+
+def get_dataset_source(dataset_id: str) -> DatasetSourceConfig | None:
+    """Return parsed per-dataset source metadata, if configured."""
+    return _schema_cache.get_dataset_source(dataset_id)
 
 
 def get_partition_metadata(dataset_id: str) -> Any:

--- a/server/datasets_config/datasets.yaml
+++ b/server/datasets_config/datasets.yaml
@@ -69,3 +69,55 @@ datasets:
       - name: merkle_root
         type: string
         is_dimension: true
+
+  - dataset_id: "nyc_taxi_yellow"
+    source:
+      kind: parquet_scan
+      uris:
+        - "s3://nyc-tlc/trip data/yellow_tripdata_*.parquet"
+      read_options:
+        hive_partitioning: false
+        union_by_name: true
+    fields:
+      - name: VendorID
+        type: int64
+        is_dimension: true
+      - name: tpep_pickup_datetime
+        type: string
+        is_dimension: true
+      - name: tpep_dropoff_datetime
+        type: string
+        is_dimension: true
+      - name: passenger_count
+        type: int64
+        is_measure: true
+      - name: trip_distance
+        type: float64
+        is_measure: true
+      - name: RatecodeID
+        type: int64
+        is_dimension: true
+      - name: payment_type
+        type: int64
+        is_dimension: true
+      - name: PULocationID
+        type: int64
+        is_dimension: true
+      - name: DOLocationID
+        type: int64
+        is_dimension: true
+      - name: fare_amount
+        type: float64
+        is_measure: true
+      - name: tip_amount
+        type: float64
+        is_measure: true
+      - name: tolls_amount
+        type: float64
+        is_measure: true
+      - name: congestion_surcharge
+        type: float64
+        is_measure: true
+      - name: total_amount
+        type: float64
+        is_measure: true

--- a/server/errors.py
+++ b/server/errors.py
@@ -73,6 +73,21 @@ class DatasetUnavailableError(AppError):
         )
 
 
+class DatasetConfigError(AppError):
+    """Raised when a dataset entry is invalid or missing required source settings."""
+
+    def __init__(self, dataset_id: str, message: str, details: dict[str, Any] | None = None) -> None:
+        payload = {"dataset_id": dataset_id}
+        if details:
+            payload.update(details)
+        super().__init__(
+            code="DATASET_CONFIG_ERROR",
+            message=message,
+            status_code=500,
+            details=payload,
+        )
+
+
 class ExportNotFoundError(AppError):
     """Raised when an export job ID does not exist in the job store."""
 

--- a/server/query_builder.py
+++ b/server/query_builder.py
@@ -20,7 +20,7 @@ from server.models import (
     TupleFilter,
     TuplesQueryBody,
 )
-from server.relation_builder import build_base_relation
+from server.relation_builder import build_base_relation, required_relation_columns
 from server.utils import quote_identifier as _quote
 
 
@@ -163,7 +163,7 @@ def build_tuples_sql(
     required_columns = {f.field for f in fields}
     if query.filters:
         required_columns.update(f.field for f in query.filters)
-    required_columns.add("date")
+    required_columns.update(required_relation_columns(dataset_id))
 
     base = build_base_relation(dataset_id, date_range, required_columns)
     params: list[Any] = list(base.params)
@@ -172,7 +172,7 @@ def build_tuples_sql(
     select_clause = ", ".join(select_cols)
     where_parts = []
 
-    if not base.handles_date:
+    if not base.handles_date and base.requires_time_filter:
         date_clause = _build_date_clause(date_range, params)
         if date_clause:
             where_parts.append(date_clause)
@@ -219,7 +219,7 @@ def build_tuples_count_sql(
     required_columns = {f.field for f in fields}
     if query.filters:
         required_columns.update(f.field for f in query.filters)
-    required_columns.add("date")
+    required_columns.update(required_relation_columns(dataset_id))
 
     base = build_base_relation(dataset_id, date_range, required_columns)
     params: list[Any] = list(base.params)
@@ -227,7 +227,7 @@ def build_tuples_count_sql(
     group_expr = ", ".join(select_cols)
     where_parts = []
 
-    if not base.handles_date:
+    if not base.handles_date and base.requires_time_filter:
         date_clause = _build_date_clause(date_range, params)
         if date_clause:
             where_parts.append(date_clause)
@@ -274,7 +274,7 @@ def build_cells_sql(
     required_columns.update(m.field for m in measures)
     if query.filters:
         required_columns.update(f.field for f in query.filters)
-    required_columns.add("date")
+    required_columns.update(required_relation_columns(dataset_id))
 
     base = build_base_relation(dataset_id, date_range, required_columns)
     params: list[Any] = list(base.params)
@@ -284,7 +284,7 @@ def build_cells_sql(
     select_clause = ", ".join(select_parts)
 
     where_parts: list[str] = []
-    if not base.handles_date:
+    if not base.handles_date and base.requires_time_filter:
         date_clause = _build_date_clause(date_range, params)
         if date_clause:
             where_parts.append(date_clause)
@@ -382,7 +382,8 @@ def build_picklist_sql(
         return f"SELECT 1 FROM {_quote(dataset_id)} WHERE FALSE", []
 
     col = _quote(field)
-    required_columns = {field, "date"}
+    required_columns = {field}
+    required_columns.update(required_relation_columns(dataset_id))
     if query.filters:
         required_columns.update(f.field for f in query.filters)
 
@@ -391,7 +392,7 @@ def build_picklist_sql(
     table = base.from_sql
     where_parts = []
 
-    if not base.handles_date:
+    if not base.handles_date and base.requires_time_filter:
         date_clause = _build_date_clause(date_range, params)
         if date_clause:
             where_parts.append(date_clause)
@@ -430,7 +431,8 @@ def build_picklist_count_sql(
         return "SELECT 0", []
 
     col = _quote(field)
-    required_columns = {field, "date"}
+    required_columns = {field}
+    required_columns.update(required_relation_columns(dataset_id))
     if query.filters:
         required_columns.update(f.field for f in query.filters)
 
@@ -439,7 +441,7 @@ def build_picklist_count_sql(
     table = base.from_sql
     where_parts = []
 
-    if not base.handles_date:
+    if not base.handles_date and base.requires_time_filter:
         date_clause = _build_date_clause(date_range, params)
         if date_clause:
             where_parts.append(date_clause)
@@ -492,7 +494,7 @@ def build_export_sql(
     required_columns.update(m.field for m in measures)
     if query.filters:
         required_columns.update(f.field for f in query.filters)
-    required_columns.add("date")
+    required_columns.update(required_relation_columns(dataset_id))
 
     base = build_base_relation(dataset_id, date_range, required_columns)
     params: list[Any] = list(base.params)
@@ -508,7 +510,7 @@ def build_export_sql(
         headers = dim_headers + agg_headers
 
     where_parts = []
-    if not base.handles_date:
+    if not base.handles_date and base.requires_time_filter:
         date_clause = _build_date_clause(date_range, params)
         if date_clause:
             where_parts.append(date_clause)

--- a/server/relation_builder.py
+++ b/server/relation_builder.py
@@ -13,8 +13,8 @@ from pathlib import Path
 import re
 from typing import Any, Iterable
 
-from server.config import get_settings
 from server import datasets
+from server.config import get_settings
 from server.errors import DatasetConfigError, PartitionConfigError, PartitionNotFoundError
 from server.models import DateRange, DateRangeRange, DateRangeSingle
 from server.s3 import build_partition_path

--- a/server/relation_builder.py
+++ b/server/relation_builder.py
@@ -7,10 +7,10 @@ falls back to the seeded sample tables.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from datetime import date, timedelta
 from pathlib import Path
-import re
 from typing import Any, Iterable
 
 from server import datasets

--- a/server/relation_builder.py
+++ b/server/relation_builder.py
@@ -10,13 +10,17 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import date, timedelta
 from pathlib import Path
+import re
 from typing import Any, Iterable
 
 from server.config import get_settings
-from server.errors import PartitionConfigError, PartitionNotFoundError
+from server import datasets
+from server.errors import DatasetConfigError, PartitionConfigError, PartitionNotFoundError
 from server.models import DateRange, DateRangeRange, DateRangeSingle
 from server.s3 import build_partition_path
 from server.utils import quote_identifier
+
+_HIVE_TYPE_TOKEN = re.compile(r"^[A-Z0-9_ ()]+$")
 
 
 @dataclass
@@ -27,6 +31,7 @@ class BaseRelation:
     from_sql: str
     params: list[Any]
     handles_date: bool
+    requires_time_filter: bool = True
 
 
 def _dates_for_range(date_range: DateRange) -> list[str]:
@@ -52,7 +57,100 @@ def _ensure_columns(required_columns: Iterable[str]) -> list[str]:
     return cols
 
 
-def _build_parquet_partition_relation(
+def _time_filter_sql(
+    column: str,
+    filter_type: str,
+    date_range: DateRange,
+    params: list[Any],
+) -> str:
+    quoted_col = quote_identifier(column)
+    expr = quoted_col
+    if filter_type in {"timestamp", "string"}:
+        expr = f"CAST({quoted_col} AS DATE)"
+    if isinstance(date_range, DateRangeSingle):
+        params.append(date_range.date)
+        return f"{expr} = ?"
+    if isinstance(date_range, DateRangeRange):
+        params.extend([date_range.start, date_range.end])
+        return f"{expr} BETWEEN ? AND ?"
+    return ""
+
+
+def _read_options_sql(dataset_id: str, source: datasets.DatasetSourceConfig) -> str:
+    opts = source.read_options
+    parts: list[str] = []
+    if isinstance(opts.hive_partitioning, bool):
+        parts.append(f"hive_partitioning = {'true' if opts.hive_partitioning else 'false'}")
+    if opts.union_by_name:
+        parts.append("union_by_name = true")
+    if opts.filename:
+        parts.append("filename = true")
+    if opts.hive_types:
+        entries: list[str] = []
+        for key, type_name in opts.hive_types.items():
+            normalized_type = type_name.strip().upper()
+            if not _HIVE_TYPE_TOKEN.match(normalized_type):
+                raise DatasetConfigError(
+                    dataset_id,
+                    "Invalid hive type token in source.read_options.hive_types",
+                    {"column": key, "type": type_name},
+                )
+            entries.append(f"'{key}': {normalized_type}")
+        parts.append(f"hive_types = {{{', '.join(entries)}}}")
+    return f", {', '.join(parts)}" if parts else ""
+
+
+def _build_parquet_source_relation(
+    dataset_id: str,
+    date_range: DateRange,
+    required_columns: Iterable[str],
+    source: datasets.DatasetSourceConfig,
+) -> BaseRelation:
+    uris = source.normalized_uris()
+    if source.max_files is not None and len(uris) > source.max_files:
+        raise DatasetConfigError(
+            dataset_id,
+            "Source URI count exceeds configured max_files",
+            {"max_files": source.max_files, "uri_count": len(uris)},
+        )
+    if not uris:
+        raise DatasetConfigError(dataset_id, "Dataset source requires at least one URI")
+
+    if len(uris) == 1:
+        source_expr = f"read_parquet(?{_read_options_sql(dataset_id, source)})"
+    else:
+        placeholders = ", ".join("?" for _ in uris)
+        source_expr = f"read_parquet([{placeholders}]{_read_options_sql(dataset_id, source)})"
+
+    params: list[Any] = list(uris)
+    cols = _ensure_columns(required_columns)
+    projected = ", ".join(quote_identifier(c) for c in cols) if cols else "*"
+    where_parts: list[str] = []
+    handles_date = False
+    requires_time_filter = False
+    if source.time_filter is not None:
+        handles_date = True
+        requires_time_filter = True
+        where_parts.append(
+            _time_filter_sql(
+                source.time_filter.column,
+                source.time_filter.type,
+                date_range,
+                params,
+            )
+        )
+    where_clause = f" WHERE {' AND '.join(where_parts)}" if where_parts else ""
+    cte_sql = f"WITH base AS (SELECT {projected} FROM {source_expr}{where_clause})"
+    return BaseRelation(
+        cte_sql=cte_sql,
+        from_sql="base",
+        params=params,
+        handles_date=handles_date,
+        requires_time_filter=requires_time_filter,
+    )
+
+
+def _build_legacy_partition_relation(
     dataset_id: str,
     date_range: DateRange,
     required_columns: Iterable[str],
@@ -105,6 +203,19 @@ def _build_parquet_partition_relation(
     return BaseRelation(cte_sql=cte_sql, from_sql="base", params=params, handles_date=True)
 
 
+def required_relation_columns(dataset_id: str) -> set[str]:
+    """Return implicit columns required by base-relation planning (e.g., time filters)."""
+    settings = get_settings()
+    if settings.execution_mode != "parquet_partitioned":
+        return {"date"}
+    source = datasets.get_dataset_source(dataset_id)
+    if source is None:
+        return {"date"}
+    if source.time_filter is None:
+        return set()
+    return {source.time_filter.column}
+
+
 def build_base_relation(
     dataset_id: str,
     date_range: DateRange,
@@ -118,7 +229,16 @@ def build_base_relation(
     """
     settings = get_settings()
     if settings.execution_mode == "parquet_partitioned":
-        return _build_parquet_partition_relation(dataset_id, date_range, required_columns)
+        source = datasets.get_dataset_source(dataset_id)
+        if source is not None:
+            return _build_parquet_source_relation(dataset_id, date_range, required_columns, source)
+        return _build_legacy_partition_relation(dataset_id, date_range, required_columns)
 
     quoted = quote_identifier(dataset_id)
-    return BaseRelation(cte_sql=None, from_sql=quoted, params=[], handles_date=False)
+    return BaseRelation(
+        cte_sql=None,
+        from_sql=quoted,
+        params=[],
+        handles_date=False,
+        requires_time_filter=True,
+    )

--- a/server/routers/query.py
+++ b/server/routers/query.py
@@ -47,6 +47,19 @@ def _apply_client_request_id(body, request: Request) -> None:
         request.state.request_id = rid
 
 
+def _time_filter_metadata(dataset_id: str) -> tuple[bool, str | None]:
+    """Describe whether date_range is actively applied for dataset execution."""
+    settings = get_settings()
+    if settings.execution_mode != "parquet_partitioned":
+        return True, "date"
+    source = datasets.get_dataset_source(dataset_id)
+    if source is None:
+        return True, "date"
+    if source.time_filter is None:
+        return False, None
+    return True, source.time_filter.column
+
+
 @router.post("/tuples", response_model=TuplesResponse)
 @limiter.limit(lambda: get_settings().rate_limit_query)
 async def post_query_tuples(body: QueryTuplesRequest, request: Request, response: Response, _api_key: str = Depends(require_api_key)) -> TuplesResponse:
@@ -132,6 +145,7 @@ async def post_query_tuples(body: QueryTuplesRequest, request: Request, response
 
     duration_ms = result.get("duration_ms", 0.0)
     resp_body = result["response"]
+    time_filter_applied, time_filter_column = _time_filter_metadata(body.dataset_id)
     logger.info(
         "tuples query executed",
         extra={
@@ -144,6 +158,8 @@ async def post_query_tuples(body: QueryTuplesRequest, request: Request, response
             "cache_source": cache_source,
             "queue_wait_ms": round(queue_wait_ms, 2),
             "execution_ms": round(execution_ms, 2),
+            "time_filter_applied": time_filter_applied,
+            "time_filter_column": time_filter_column,
         },
     )
 
@@ -250,6 +266,7 @@ async def post_query_cells(body: QueryCellsRequest, request: Request, response: 
         result = await _budgeted_execute()
 
     duration_ms = result.get("duration_ms", 0.0)
+    time_filter_applied, time_filter_column = _time_filter_metadata(body.dataset_id)
 
     logger.info(
         "cells query executed",
@@ -262,6 +279,8 @@ async def post_query_cells(body: QueryCellsRequest, request: Request, response: 
             "cache_source": cache_source,
             "queue_wait_ms": round(queue_wait_ms, 2),
             "execution_ms": round(execution_ms, 2),
+            "time_filter_applied": time_filter_applied,
+            "time_filter_column": time_filter_column,
         },
     )
 
@@ -353,6 +372,7 @@ async def post_query_picklist(body: QueryPicklistRequest, request: Request, resp
 
     duration_ms = result.get("duration_ms", 0.0)
     resp_body = result["response"]
+    time_filter_applied, time_filter_column = _time_filter_metadata(body.dataset_id)
     logger.info(
         "picklist query executed",
         extra={
@@ -365,6 +385,8 @@ async def post_query_picklist(body: QueryPicklistRequest, request: Request, resp
             "cache_source": cache_source,
             "queue_wait_ms": round(queue_wait_ms, 2),
             "execution_ms": round(execution_ms, 2),
+            "time_filter_applied": time_filter_applied,
+            "time_filter_column": time_filter_column,
         },
     )
 

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -57,6 +57,9 @@ def _init_test_db(_tmp_export_dir):
 def _disable_auth(monkeypatch):
     """Disable authentication by default for tests."""
     monkeypatch.setenv("QUERYSERVICE_AUTH_ENABLED", "false")
+    monkeypatch.setenv("QUERYSERVICE_EXECUTION_MODE", "sample_table")
+    monkeypatch.delenv("QUERYSERVICE_S3_BUCKET", raising=False)
+    monkeypatch.delenv("QUERYSERVICE_PARTITION_BASE_PATH", raising=False)
     get_settings.cache_clear()
     yield
     get_settings.cache_clear()

--- a/server/tests/test_datasets.py
+++ b/server/tests/test_datasets.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from server import datasets
+from server.errors import DatasetConfigError
 
 
 def test_load_datasets_config_missing_file(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -60,4 +61,67 @@ def test_get_schema_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
         )
         assert datasets.get_schema("missing") is None
     finally:
+        Path(path).unlink()
+
+
+def test_get_dataset_source_parsed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """source block is parsed into typed metadata for relation planning."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        f.write("""
+datasets:
+  - dataset_id: ds_source
+    source:
+      kind: parquet_scan
+      uris:
+        - s3://bucket/path/*.parquet
+      read_options:
+        hive_partitioning: false
+        union_by_name: true
+    fields:
+      - name: symbol
+        type: string
+        is_dimension: true
+""")
+        path = f.name
+    try:
+        monkeypatch.setattr(
+            "server.datasets.get_settings",
+            lambda: type("S", (), {"datasets_config_path": path})(),
+        )
+        datasets.reset_cache()
+        source = datasets.get_dataset_source("ds_source")
+        assert source is not None
+        assert source.kind == "parquet_scan"
+        assert source.normalized_uris() == ["s3://bucket/path/*.parquet"]
+        assert source.read_options.union_by_name is True
+    finally:
+        datasets.reset_cache()
+        Path(path).unlink()
+
+
+def test_invalid_dataset_source_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """invalid source config fails deterministically with DatasetConfigError."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        f.write("""
+datasets:
+  - dataset_id: bad_source
+    source:
+      kind: parquet_scan
+      uris: []
+    fields:
+      - name: symbol
+        type: string
+        is_dimension: true
+""")
+        path = f.name
+    try:
+        monkeypatch.setattr(
+            "server.datasets.get_settings",
+            lambda: type("S", (), {"datasets_config_path": path})(),
+        )
+        datasets.reset_cache()
+        with pytest.raises(DatasetConfigError):
+            datasets.get_dataset_source("bad_source")
+    finally:
+        datasets.reset_cache()
         Path(path).unlink()

--- a/server/tests/test_query_builder.py
+++ b/server/tests/test_query_builder.py
@@ -22,6 +22,7 @@ from server.query_builder import (
     build_tuples_count_sql,
     build_tuples_sql,
 )
+from server.relation_builder import BaseRelation
 
 SCHEMA_FIELDS = {"date", "symbol", "volume"}
 DR_SINGLE = DateRangeSingle(type="single", date="2026-03-01")
@@ -125,6 +126,23 @@ class TestBuildTuplesSql:
         assert '"date"' in sql
         assert '"symbol"' in sql
         assert "COUNT(*) OVER()" in sql
+
+    def test_date_clause_skipped_when_relation_disables_time_filter(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        query = TuplesQueryBody(fields=[TupleFieldSpec(field="symbol")])
+
+        def _fake_base_relation(_dataset_id, _date_range, _required_columns):
+            return BaseRelation(
+                cte_sql="WITH base AS (SELECT \"symbol\" FROM read_parquet(?))",
+                from_sql="base",
+                params=["s3://bucket/data/*.parquet"],
+                handles_date=False,
+                requires_time_filter=False,
+            )
+
+        monkeypatch.setattr("server.query_builder.build_base_relation", _fake_base_relation)
+        sql, params = build_tuples_sql("any_ds", query, DR_SINGLE, SCHEMA_FIELDS)
+        assert '"date" =' not in sql
+        assert params == ["s3://bucket/data/*.parquet"]
 
 
 class TestBuildTuplesCountSql:

--- a/server/tests/test_relation_builder.py
+++ b/server/tests/test_relation_builder.py
@@ -1,12 +1,13 @@
-"""Tests for base relation builder (partition-aware)."""
+"""Tests for base relation builder (partition-aware and source-driven)."""
 
 from pathlib import Path
 
 import pytest
 
+from server import datasets
 from server.errors import PartitionNotFoundError
 from server.models import DateRangeRange, DateRangeSingle
-from server.relation_builder import BaseRelation, build_base_relation
+from server.relation_builder import BaseRelation, build_base_relation, required_relation_columns
 
 
 class DummySettings:
@@ -68,3 +69,99 @@ def test_partition_mode_missing_partition(monkeypatch, tmp_path: Path) -> None:
             DateRangeRange(type="range", start="2026-03-01", end="2026-03-02"),
             ["symbol", "date"],
         )
+
+
+def test_partition_mode_source_without_time_filter(monkeypatch, tmp_path: Path) -> None:
+    config = tmp_path / "datasets.yaml"
+    config.write_text(
+        """
+datasets:
+  - dataset_id: ds_no_time
+    source:
+      kind: parquet_scan
+      uris:
+        - s3://bucket/raw/*.parquet
+      read_options:
+        hive_partitioning: auto
+    fields:
+      - name: symbol
+        type: string
+        is_dimension: true
+""",
+        encoding="utf-8",
+    )
+
+    settings = DummySettings(
+        execution_mode="parquet_partitioned",
+        partition_base_path=None,
+        s3_bucket="legacy-bucket",
+    )
+    monkeypatch.setattr("server.relation_builder.get_settings", lambda: settings)
+    monkeypatch.setattr(
+        "server.datasets.get_settings",
+        lambda: DummySettings(datasets_config_path=str(config), schema_cache_ttl_seconds=0),
+    )
+    datasets.reset_cache()
+
+    rel = build_base_relation(
+        "ds_no_time",
+        DateRangeSingle(type="single", date="2026-03-01"),
+        ["symbol"],
+    )
+    assert "read_parquet(?)" in (rel.cte_sql or "")
+    assert 'WHERE "date"' not in (rel.cte_sql or "")
+    assert rel.params == ["s3://bucket/raw/*.parquet"]
+    assert rel.handles_date is False
+    assert rel.requires_time_filter is False
+    assert required_relation_columns("ds_no_time") == set()
+
+
+def test_partition_mode_source_with_time_filter(monkeypatch, tmp_path: Path) -> None:
+    config = tmp_path / "datasets.yaml"
+    config.write_text(
+        """
+datasets:
+  - dataset_id: ds_time
+    source:
+      kind: parquet_scan
+      uris:
+        - s3://bucket/trips/*.parquet
+      time_filter:
+        column: tpep_pickup_datetime
+        type: timestamp
+      read_options:
+        hive_partitioning: false
+    fields:
+      - name: tpep_pickup_datetime
+        type: string
+        is_dimension: true
+      - name: symbol
+        type: string
+        is_dimension: true
+""",
+        encoding="utf-8",
+    )
+
+    settings = DummySettings(
+        execution_mode="parquet_partitioned",
+        partition_base_path=None,
+        s3_bucket="legacy-bucket",
+    )
+    monkeypatch.setattr("server.relation_builder.get_settings", lambda: settings)
+    monkeypatch.setattr(
+        "server.datasets.get_settings",
+        lambda: DummySettings(datasets_config_path=str(config), schema_cache_ttl_seconds=0),
+    )
+    datasets.reset_cache()
+
+    rel = build_base_relation(
+        "ds_time",
+        DateRangeRange(type="range", start="2026-03-01", end="2026-03-02"),
+        ["symbol"],
+    )
+    cte = rel.cte_sql or ""
+    assert "CAST(\"tpep_pickup_datetime\" AS DATE) BETWEEN ? AND ?" in cte
+    assert rel.params[-2:] == ["2026-03-01", "2026-03-02"]
+    assert rel.handles_date is True
+    assert rel.requires_time_filter is True
+    assert required_relation_columns("ds_time") == {"tpep_pickup_datetime"}

--- a/server/tests/test_s3.py
+++ b/server/tests/test_s3.py
@@ -27,7 +27,11 @@ def test_sample_partition_read_local(tmp_path: Path) -> None:
     assert count == 1
 
 
-def test_sample_partition_read_if_configured_no_bucket() -> None:
+def test_sample_partition_read_if_configured_no_bucket(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "server.s3.get_settings",
+        lambda: type("S", (), {"s3_bucket": None, "s3_region": None})(),
+    )
     result = s3.sample_partition_read_if_configured("ds", "2026-01-01")
     assert result is None
 


### PR DESCRIPTION
## Summary
- add typed per-dataset `source` metadata parsing/validation for `datasets.yaml` (including read options, optional time filter, and guardrails)
- refactor parquet relation planning to support arbitrary URI/glob layouts with legacy fallback compatibility
- decouple query builders from hard-coded `date` assumptions and add query observability for time-filter application
- add NYC Taxi source config example, update backend docs, and extend unit/integration tests

## Test plan
- [x] `./.venv-ci/bin/pytest server/tests -q`

## Issues
Closes #212
Closes #213
Closes #214
Closes #215
Closes #216
Closes #217
Closes #218
Closes #219
Closes #220
Closes #221

Made with [Cursor](https://cursor.com)