### PR TITLE
#223 Align remote payload mapping with QueryService contract

### DIFF
--- a/src/DataSet/CellSet.js
+++ b/src/DataSet/CellSet.js
@@ -361,35 +361,18 @@ class CellSet extends DataSetComponent {
 
   #buildRemoteCellsQuery(tuplesToQuery, tuplesFields, cellsAxisItemsToFetch){
     var queryModel = this.getQueryModel();
-    var rowsAxis = queryModel.getRowsAxis().getItems();
-    var columnsAxis = queryModel.getColumnsAxis().getItems();
-    var filterAxis = queryModel.getFiltersAxis().getItems();
-    var filters = filterAxis.filter(function(item) { return item.filter; }).map(function(item) {
-      return { field: item.columnName, operator: 'in', values: (item.filter && item.filter.values) ? item.filter.values : [] };
-    });
     var rowCount = 0, colCount = 0;
     var tupleSets = this.#tupleSets;
     if (tupleSets[0]) rowCount = Math.max(1, tupleSets[0].getTupleCountSync() || 0);
     if (tupleSets[1]) colCount = Math.max(1, tupleSets[1].getTupleCountSync() || 0);
-    var axes = {
-      rows: rowsAxis.map(function(item) { return { field: item.columnName, derivation: item.derivation || null }; }),
-      columns: columnsAxis.map(function(item) { return { field: item.columnName, derivation: item.derivation || null }; }),
-      measures: (cellsAxisItemsToFetch || []).map(function(item) {
-        return { field: item.columnName, aggregation: item.aggregator || 'sum', alias: item.columnName };
-      })
-    };
-    return {
-      rows: { start_index: 0, count: rowCount },
-      columns: { start_index: 0, count: colCount },
-      axes: axes,
-      filters: filters
-    };
+    return RemoteQueryAdapter.createRemoteCellsQuery(queryModel, rowCount, colCount, cellsAxisItemsToFetch);
   }
 
-  #remoteCellsResponseToResultSet(apiResponse, cellsAxisItemsToFetch, columnCount){
+  #remoteCellsResponseToResultSet(apiResponse, cellsAxisItemsToFetch, columnCount, measureAliases){
     var cells = apiResponse.cells || [];
     var colCount = columnCount || 1;
     var items = cellsAxisItemsToFetch || [];
+    var aliases = measureAliases || [];
     // Use same key as pivot: getSqlForQueryAxisItem (e.g. "sum(volume)") so cell.values[sqlExpression] finds the value
     var fields = [{ name: CellSet.#cellIndexColumnName }].concat(items.map(function(item) {
       return { name: QueryAxisItem.getSqlForQueryAxisItem(item, CellSet.datasetRelationName) };
@@ -401,10 +384,10 @@ class CellSet extends DataSetComponent {
       var row = {};
       row[CellSet.#cellIndexColumnName] = (c.row_index || 0) * colCount + (c.column_index || 0);
       var vals = c.values || {};
-      items.forEach(function(item) {
+      items.forEach(function(item, index) {
         var sqlExpression = QueryAxisItem.getSqlForQueryAxisItem(item, CellSet.datasetRelationName);
-        // API returns values keyed by alias (we send alias: item.columnName), so read by columnName
-        row[sqlExpression] = vals[item.columnName];
+        var alias = aliases[index] || item.columnName;
+        row[sqlExpression] = vals[alias];
       });
       return row;
     };
@@ -423,10 +406,11 @@ class CellSet extends DataSetComponent {
     if (isRemote && datasource.getManagedConnection().fetchCells) {
       var query = this.#buildRemoteCellsQuery(tuplesToQuery, tuplesFields, cellsAxisItemsToFetch);
       var colCount = query.columns && query.columns.count ? query.columns.count : 1;
-      var dateRange = { type: 'single', date: new Date().toISOString().slice(0, 10) };
+      var measureAliases = query.axes && query.axes.measures ? query.axes.measures.map(function(measure) { return measure.alias; }) : [];
+      var dateRange = RemoteQueryAdapter.getDateRange(queryModel);
       var connection = await this.getManagedConnection();
       var apiResponse = await connection.fetchCells(dateRange, query);
-      var resultSet = this.#remoteCellsResponseToResultSet(apiResponse, cellsAxisItemsToFetch, colCount);
+      var resultSet = this.#remoteCellsResponseToResultSet(apiResponse, cellsAxisItemsToFetch, colCount, measureAliases);
       return resultSet;
     }
 

--- a/src/DataSet/TupleSet.js
+++ b/src/DataSet/TupleSet.js
@@ -225,33 +225,7 @@ class TupleSet extends DataSetComponent {
 
   #buildRemoteTuplesQuery(limit, offset){
     var queryModel = this.getQueryModel();
-    var axisId = this.#queryAxisId;
-    var queryAxis = queryModel.getQueryAxis(axisId);
-    var items = queryAxis.getItems();
-    if (!items.length) return null;
-    var fields = items.map(function(item) {
-      return {
-        field: item.columnName,
-        derivation: item.derivation || null,
-        sort: 'asc',
-        include_totals: item.includeTotals !== false
-      };
-    });
-    var filterAxis = queryModel.getFiltersAxis();
-    var filterItems = filterAxis.getItems();
-    var filters = filterItems.filter(function(item) { return item.filter; }).map(function(item) {
-      return {
-        field: item.columnName,
-        operator: 'in',
-        values: (item.filter && item.filter.values) ? item.filter.values : []
-      };
-    });
-    return {
-      axis: axisId,
-      fields: fields,
-      filters: filters,
-      paging: { limit: limit, offset: offset }
-    };
+    return RemoteQueryAdapter.createRemoteTuplesQuery(queryModel, this.#queryAxisId, limit, offset);
   }
 
   #remoteResponseToResultSet(apiResponse, axisItems, includeCountAll){
@@ -296,7 +270,7 @@ class TupleSet extends DataSetComponent {
     if (isRemote && datasource.getManagedConnection().fetchTuples) {
       var query = this.#buildRemoteTuplesQuery(limit, offset);
       if (!query) return 0;
-      var dateRange = { type: 'single', date: new Date().toISOString().slice(0, 10) };
+      var dateRange = RemoteQueryAdapter.getDateRange(queryModel);
       var connection = await this.getManagedConnection();
       var apiResponse;
       try {

--- a/src/DataSource/remote/RemoteQueryAdapter.js
+++ b/src/DataSource/remote/RemoteQueryAdapter.js
@@ -1,0 +1,238 @@
+(function () {
+  var FILTER_OPERATOR_BY_TYPE = {
+    in: 'INCLUDE',
+    notin: 'EXCLUDE',
+    like: 'LIKE',
+    between: 'BETWEEN'
+  };
+
+  var AGGREGATION_BY_NAME = {
+    sum: 'SUM',
+    count: 'COUNT',
+    avg: 'AVG',
+    min: 'MIN',
+    max: 'MAX'
+  };
+
+  function createTodayDateRange() {
+    return { type: 'single', date: new Date().toISOString().slice(0, 10) };
+  }
+
+  function getDateRange(queryModel) {
+    if (queryModel && typeof queryModel.getDateRange === 'function') {
+      var queryModelDateRange = queryModel.getDateRange();
+      if (queryModelDateRange && typeof queryModelDateRange === 'object' && queryModelDateRange.type) {
+        return queryModelDateRange;
+      }
+    }
+    return createTodayDateRange();
+  }
+
+  function getRemoteFieldForAxisItem(axisItem, context) {
+    if (!axisItem || typeof axisItem.columnName !== 'string' || !axisItem.columnName.length) {
+      throw new Error('Remote datasource requires a valid columnName for ' + context + '.');
+    }
+    if (axisItem.derivation) {
+      throw new Error('Remote datasource does not support derivation "' + axisItem.derivation + '" in ' + context + '.');
+    }
+    return axisItem.columnName;
+  }
+
+  function normalizeLiteralToValue(literal) {
+    if (literal === null || literal === undefined) {
+      return literal;
+    }
+    if (literal === 'NULL') {
+      return null;
+    }
+    if (typeof literal !== 'string') {
+      return literal;
+    }
+    if (literal.length >= 2 && literal[0] === '\'' && literal[literal.length - 1] === '\'') {
+      return literal.slice(1, -1).replace(/''/g, '\'');
+    }
+    return literal;
+  }
+
+  function extractFilterEntryValue(entry, key) {
+    if (entry && Object.prototype.hasOwnProperty.call(entry, 'value')) {
+      return entry.value;
+    }
+    if (entry && Object.prototype.hasOwnProperty.call(entry, 'literal')) {
+      return normalizeLiteralToValue(entry.literal);
+    }
+    return key;
+  }
+
+  function getEnabledFilterEntries(values) {
+    if (!values || typeof values !== 'object' || values instanceof Array) {
+      return [];
+    }
+    return Object.keys(values)
+      .map(function (key) {
+        return { key: key, entry: values[key] };
+      })
+      .filter(function (item) {
+        return item.entry && item.entry.enabled !== false;
+      });
+  }
+
+  function getRemoteOperator(filterType, field) {
+    var normalizedFilterType = String(filterType || '').toLowerCase();
+    var operator = FILTER_OPERATOR_BY_TYPE[normalizedFilterType];
+    if (!operator) {
+      throw new Error('Remote datasource does not support filter type "' + normalizedFilterType + '" for field "' + field + '".');
+    }
+    return operator;
+  }
+
+  function toRemoteFilter(filterAxisItem, context) {
+    if (!filterAxisItem || !filterAxisItem.filter) {
+      return null;
+    }
+    var field = getRemoteFieldForAxisItem(filterAxisItem, context + ' filters');
+    var filter = filterAxisItem.filter;
+    var operator = getRemoteOperator(filter.filterType, field);
+    var valuesEntries = getEnabledFilterEntries(filter.values);
+
+    if (!valuesEntries.length) {
+      return null;
+    }
+
+    var values;
+    if (operator === 'BETWEEN') {
+      if (valuesEntries.length !== 1) {
+        throw new Error('Remote datasource supports exactly one BETWEEN range per field. Field: "' + field + '".');
+      }
+      var rangeStart = valuesEntries[0];
+      var toValues = filter.toValues || {};
+      var rangeEnd = toValues[rangeStart.key];
+      if (!rangeEnd || rangeEnd.enabled === false) {
+        throw new Error('Remote datasource requires a matching range end value for BETWEEN filter. Field: "' + field + '".');
+      }
+      values = [
+        extractFilterEntryValue(rangeStart.entry, rangeStart.key),
+        extractFilterEntryValue(rangeEnd, rangeStart.key)
+      ];
+    }
+    else if (operator === 'LIKE') {
+      if (valuesEntries.length !== 1) {
+        throw new Error('Remote datasource supports exactly one LIKE pattern per field. Field: "' + field + '".');
+      }
+      var likeEntry = valuesEntries[0];
+      values = [extractFilterEntryValue(likeEntry.entry, likeEntry.key)];
+    }
+    else {
+      values = valuesEntries.map(function (item) {
+        return extractFilterEntryValue(item.entry, item.key);
+      });
+    }
+
+    return {
+      field: field,
+      operator: operator,
+      values: values
+    };
+  }
+
+  function toRemoteFilters(filterAxisItems, context) {
+    return (filterAxisItems || [])
+      .filter(function (item) {
+        return item && item.filter;
+      })
+      .map(function (item) {
+        return toRemoteFilter(item, context || 'query');
+      })
+      .filter(function (item) {
+        return item !== null;
+      });
+  }
+
+  function getRemoteAggregation(axisItem) {
+    var aggregationName = String(axisItem.aggregator || 'sum').toLowerCase();
+    var aggregation = AGGREGATION_BY_NAME[aggregationName];
+    if (!aggregation) {
+      throw new Error('Remote datasource does not support aggregator "' + aggregationName + '" for field "' + axisItem.columnName + '".');
+    }
+    return aggregation;
+  }
+
+  function getMeasureAlias(axisItem, index) {
+    var aggregationName = String(axisItem.aggregator || 'sum').toLowerCase();
+    var alias = aggregationName + '_' + axisItem.columnName;
+    if (index !== undefined) {
+      alias += '_' + index;
+    }
+    return alias.replace(/[^a-zA-Z0-9_]/g, '_');
+  }
+
+  function createRemoteTuplesQuery(queryModel, axisId, limit, offset) {
+    var queryAxis = queryModel.getQueryAxis(axisId);
+    var axisItems = queryAxis.getItems();
+    if (!axisItems.length) {
+      return null;
+    }
+
+    var fields = axisItems.map(function (item) {
+      return {
+        field: getRemoteFieldForAxisItem(item, 'tuples'),
+        sort: 'ASC',
+        include_totals: item.includeTotals !== false
+      };
+    });
+
+    var filters = toRemoteFilters(queryModel.getFiltersAxis().getItems(), 'tuples');
+
+    return {
+      axis: axisId,
+      fields: fields,
+      filters: filters,
+      paging: { limit: limit, offset: offset }
+    };
+  }
+
+  function createRemoteCellsQuery(queryModel, rowCount, colCount, cellsAxisItemsToFetch) {
+    var rowsAxisItems = queryModel.getRowsAxis().getItems();
+    var columnsAxisItems = queryModel.getColumnsAxis().getItems();
+    var filters = toRemoteFilters(queryModel.getFiltersAxis().getItems(), 'cells');
+
+    return {
+      rows: { start_index: 0, count: Math.max(1, rowCount || 0) },
+      columns: { start_index: 0, count: Math.max(1, colCount || 0) },
+      axes: {
+        rows: rowsAxisItems.map(function (item) {
+          return { field: getRemoteFieldForAxisItem(item, 'cells rows') };
+        }),
+        columns: columnsAxisItems.map(function (item) {
+          return { field: getRemoteFieldForAxisItem(item, 'cells columns') };
+        }),
+        measures: (cellsAxisItemsToFetch || []).map(function (item, index) {
+          var field = getRemoteFieldForAxisItem(item, 'cells measures');
+          return {
+            field: field,
+            aggregation: getRemoteAggregation(item),
+            alias: getMeasureAlias(item, index)
+          };
+        })
+      },
+      filters: filters
+    };
+  }
+
+  function createRemotePicklistQuery(queryAxisItem, filterAxisItems, search, limit, offset) {
+    return {
+      field: getRemoteFieldForAxisItem(queryAxisItem, 'picklist'),
+      search: search || undefined,
+      filters: toRemoteFilters(filterAxisItems, 'picklist'),
+      paging: { limit: limit, offset: offset }
+    };
+  }
+
+  window.RemoteQueryAdapter = {
+    getDateRange: getDateRange,
+    toRemoteFilters: toRemoteFilters,
+    createRemoteTuplesQuery: createRemoteTuplesQuery,
+    createRemoteCellsQuery: createRemoteCellsQuery,
+    createRemotePicklistQuery: createRemotePicklistQuery
+  };
+})();

--- a/src/FilterUi/FilterUi.js
+++ b/src/FilterUi/FilterUi.js
@@ -1159,35 +1159,40 @@ class FilterDialog {
 
     if (isRemote && datasource.getManagedConnection().fetchPicklist) {
       var search = this.#getSearch();
-      var query = {
-        field: this.#queryAxisItem.columnName,
-        search: search && search.value ? search.value : undefined,
-        filters: this.#getOtherFilterAxisItems(true).filter(function(item) { return item.filter; }).map(function(item) {
-          return { field: item.columnName, operator: 'in', values: (item.filter && item.filter.values) ? Object.keys(item.filter.values) : [] };
-        }),
-        paging: { limit: limit, offset: offset }
-      };
-      var dateRange = { type: 'single', date: new Date().toISOString().slice(0, 10) };
-      var connection = datasource.getManagedConnection();
-      var timeMessage = `Executing filter dialog picklist query.`;
-      console.time(timeMessage);
-      var apiResponse = await connection.fetchPicklist(dateRange, query);
-      console.timeEnd(timeMessage);
-      var totalCount = apiResponse.total_count != null ? apiResponse.total_count : (apiResponse.values || []).length;
-      var values = apiResponse.values || [];
-      var fields = (offset === 0 ? [{ name: FilterDialog.#numRowsColumnName }] : []).concat([{ name: 'value', type: { typeId: 0 } }, { name: 'label', type: { typeId: 0 } }]);
-      var resultSet = {
-        numRows: values.length,
-        schema: { fields: fields },
-        get: function(i) {
-          var v = values[i];
-          var row = { value: v ? v.value : null, label: v ? (v.label != null ? v.label : v.value) : null };
-          if (offset === 0 && i === 0) row[FilterDialog.#numRowsColumnName] = totalCount;
-          return row;
-        }
-      };
-      this.#setBusy(false);
-      return resultSet;
+      try {
+        var query = RemoteQueryAdapter.createRemotePicklistQuery(
+          this.#queryAxisItem,
+          this.#getOtherFilterAxisItems(true),
+          search && search.value ? search.value : undefined,
+          limit,
+          offset
+        );
+        var dateRange = RemoteQueryAdapter.getDateRange(this.#queryModel);
+        var connection = datasource.getManagedConnection();
+        var timeMessage = `Executing filter dialog picklist query.`;
+        console.time(timeMessage);
+        var apiResponse = await connection.fetchPicklist(dateRange, query);
+        console.timeEnd(timeMessage);
+        var totalCount = apiResponse.total_count != null ? apiResponse.total_count : (apiResponse.values || []).length;
+        var values = apiResponse.values || [];
+        var fields = (offset === 0 ? [{ name: FilterDialog.#numRowsColumnName }] : []).concat([{ name: 'value', type: { typeId: 0 } }, { name: 'label', type: { typeId: 0 } }]);
+        var resultSet = {
+          numRows: values.length,
+          schema: { fields: fields },
+          get: function(i) {
+            var v = values[i];
+            var row = { value: v ? v.value : null, label: v ? (v.label != null ? v.label : v.value) : null };
+            if (offset === 0 && i === 0) row[FilterDialog.#numRowsColumnName] = totalCount;
+            return row;
+          }
+        };
+        this.#setBusy(false);
+        return resultSet;
+      }
+      catch (error) {
+        this.#setBusy(false);
+        throw error;
+      }
     }
 
     var sql = this.#getSqlSelectStatementForPickList(offset, limit);

--- a/src/index.html
+++ b/src/index.html
@@ -2397,6 +2397,7 @@
     <script onload="resourceLoaded(this)" src="DataSource/duckdb/DuckDbDataSource.js"></script>
     <script onload="resourceLoaded(this)" src="DataSource/remote/RemoteDatasourceConfig.js"></script>
     <script onload="resourceLoaded(this)" src="DataSource/remote/RemoteDatasource.js"></script>
+    <script onload="resourceLoaded(this)" src="DataSource/remote/RemoteQueryAdapter.js"></script>
 
     <script onload="resourceLoaded(this)" src="DataSet/SqlQueryGenerator.js"></script>
     <script onload="resourceLoaded(this)" src="DataSet/DataSetComponent.js"></script>

--- a/tests/unit/remote-query-adapter.test.js
+++ b/tests/unit/remote-query-adapter.test.js
@@ -1,0 +1,126 @@
+const { loadScripts } = require('./setup');
+
+describe('RemoteQueryAdapter', () => {
+  let window;
+  let RemoteQueryAdapter;
+  let FilterDialog;
+
+  beforeAll(() => {
+    window = loadScripts();
+    ({ RemoteQueryAdapter, FilterDialog } = window);
+  });
+
+  function makeFilterAxisItem(columnName, filter) {
+    return {
+      columnName,
+      filter,
+    };
+  }
+
+  test('maps include filter to INCLUDE with enabled values only', () => {
+    const filters = RemoteQueryAdapter.toRemoteFilters([
+      makeFilterAxisItem('symbol', {
+        filterType: FilterDialog.filterTypes.INCLUDE,
+        values: {
+          AAPL: { value: 'AAPL', enabled: true },
+          GOOG: { value: 'GOOG', enabled: false },
+        },
+      }),
+    ], 'test');
+
+    expect(filters).toEqual([
+      {
+        field: 'symbol',
+        operator: 'INCLUDE',
+        values: ['AAPL'],
+      },
+    ]);
+  });
+
+  test('maps notin filter to EXCLUDE', () => {
+    const filters = RemoteQueryAdapter.toRemoteFilters([
+      makeFilterAxisItem('symbol', {
+        filterType: FilterDialog.filterTypes.EXCLUDE,
+        values: {
+          TSLA: { value: 'TSLA', enabled: true },
+        },
+      }),
+    ], 'test');
+
+    expect(filters[0].operator).toBe('EXCLUDE');
+    expect(filters[0].values).toEqual(['TSLA']);
+  });
+
+  test('maps between filter to two values', () => {
+    const filters = RemoteQueryAdapter.toRemoteFilters([
+      makeFilterAxisItem('date', {
+        filterType: FilterDialog.filterTypes.BETWEEN,
+        values: {
+          start: { value: '2026-01-01', enabled: true },
+        },
+        toValues: {
+          start: { value: '2026-01-31', enabled: true },
+        },
+      }),
+    ], 'test');
+
+    expect(filters).toEqual([
+      {
+        field: 'date',
+        operator: 'BETWEEN',
+        values: ['2026-01-01', '2026-01-31'],
+      },
+    ]);
+  });
+
+  test('throws on unsupported filter type', () => {
+    expect(() => {
+      RemoteQueryAdapter.toRemoteFilters([
+        makeFilterAxisItem('symbol', {
+          filterType: FilterDialog.filterTypes.NOTLIKE,
+          values: {
+            a: { value: 'A%', enabled: true },
+          },
+        }),
+      ], 'test');
+    }).toThrow('does not support filter type');
+  });
+
+  test('builds cells query with uppercase aggregation names', () => {
+    const queryModel = {
+      getRowsAxis: () => ({ getItems: () => [{ columnName: 'symbol' }] }),
+      getColumnsAxis: () => ({ getItems: () => [{ columnName: 'exchange' }] }),
+      getFiltersAxis: () => ({ getItems: () => [] }),
+    };
+
+    const query = RemoteQueryAdapter.createRemoteCellsQuery(queryModel, 10, 5, [
+      { columnName: 'volume', aggregator: 'sum' },
+      { columnName: 'volume', aggregator: 'avg' },
+    ]);
+
+    expect(query.axes.measures[0].aggregation).toBe('SUM');
+    expect(query.axes.measures[1].aggregation).toBe('AVG');
+    expect(query.axes.measures[0].alias).not.toBe(query.axes.measures[1].alias);
+  });
+
+  test('throws for unsupported cell aggregator', () => {
+    const queryModel = {
+      getRowsAxis: () => ({ getItems: () => [] }),
+      getColumnsAxis: () => ({ getItems: () => [] }),
+      getFiltersAxis: () => ({ getItems: () => [] }),
+    };
+
+    expect(() => {
+      RemoteQueryAdapter.createRemoteCellsQuery(queryModel, 1, 1, [
+        { columnName: 'volume', aggregator: 'distinct count' },
+      ]);
+    }).toThrow('does not support aggregator');
+  });
+
+  test('falls back to single-date range when query model has no date range', () => {
+    const dateRange = RemoteQueryAdapter.getDateRange({});
+    expect(dateRange.type).toBe('single');
+    expect(typeof dateRange.date).toBe('string');
+    expect(dateRange.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});

--- a/tests/unit/setup.js
+++ b/tests/unit/setup.js
@@ -17,6 +17,7 @@ const scriptOrder = [
   'src/util/event/EventEmitter.js',
   'src/util/event/EventBuffer.js',
   'src/util/sql/SQLHelper.js',
+  'src/DataSource/remote/RemoteQueryAdapter.js',
   'src/Internationalization/Internationalization.js',
   'src/AttributeUi/AttributeUi.js',
   'src/FilterUi/FilterUi.js',
@@ -102,6 +103,7 @@ function loadScripts() {
     'QueryAxisItem',
     'FilterDialog',
     'AttributeUi',
+    'RemoteQueryAdapter',
   ];
   globalNames.forEach((name) => {
     if (typeof dom.window[name] === 'undefined') {


### PR DESCRIPTION
## Summary\nImplements #223 by introducing a single frontend adapter for remote payload mapping and wiring all remote callsites through it.\n\n## What changed\n- Added \n  - Centralizes date range resolution\n  - Converts filter model to QueryService operators/values\n  - Converts cells aggregations to API-supported values\n  - Validates unsupported remote semantics with clear errors\n- Updated remote callsites to use adapter\n  - \n  - \n  - \n- Added script loading for adapter in \n- Added unit tests for adapter behavior\n  - \n  - updated  bootstrap\n\n## Validation\n- 
> test:unit
> jest tests/unit --runInBand (pass: 33/33)\n- 
> test:ui
> playwright test


Running 11 tests using 1 worker

  ✓   1 [chromium] › tests/ui/error-handling.spec.js:10:3 › Error handling › renders error dialog for thrown errors (4.8s)
  -   2 [chromium] › tests/ui/export.spec.js:36:3 › Export › open export dialog and trigger export workflow
  -   3 [chromium] › tests/ui/filters.spec.js:39:3 › Filters › apply include filter to symbol and update pivot
  ✓   4 [chromium] › tests/ui/remote-mode.spec.js:14:3 › Remote mode UI › Huey app loads and shows main UI (4.4s)
  ✓   5 [chromium] › tests/ui/remote-mode.spec.js:22:3 › Remote mode UI › toolbar renders core actions (3.5s)
  ✓   6 [chromium] › tests/ui/remote-mode.spec.js:30:3 › Remote mode UI › sidebar tabs for datasources and attributes are available (3.9s)
  ✓   7 [chromium] › tests/ui/theme.spec.js:11:3 › Theme › toggle theme updates CSS variables (4.8s)
  ✓   8 [chromium] › tests/ui/upload-and-pivot.spec.js:55:3 › Upload and Pivot Table › upload CSV and verify datasource appears (4.2s)
  -   9 [chromium] › tests/ui/upload-and-pivot.spec.js:61:3 › Upload and Pivot Table › add rows and cells using attribute toggles and render pivot
  -  10 [chromium] › tests/ui/upload-and-pivot.spec.js:68:3 › Upload and Pivot Table › add measure to cells axis and verify numeric values appear
  -  11 [chromium] › tests/ui/upload-and-pivot.spec.js:75:3 › Upload and Pivot Table › verify row and column counts in status bar

  5 skipped
  6 passed (50.9s) (pass: 6, skipped: 5; unchanged baseline)\n\nFixes #223