### PR TITLE
#224 Harden postMessage origin handling and fix ping protocol bug

### DIFF
--- a/docs/postmessage-security.md
+++ b/docs/postmessage-security.md
@@ -1,0 +1,27 @@
+# PostMessage Security Configuration
+
+Huey now validates trusted origins for postMessage requests and responses.
+
+## Trusted Origins
+
+Huey accepts incoming postMessage requests only from trusted origins.
+
+Configure trusted origins via URL query string when embedding Huey:
+
+- `postMessageOrigins=http://app.example.com,https://embed.example.com`
+- `postMessageOrigin=https://app.example.com` (single origin convenience)
+
+Notes:
+- `window.location.origin` is always trusted.
+- `document.referrer` origin is auto-added when available.
+
+## Ready Message Behavior
+
+`PostMessageInterface.sendReadyMessage()` sends to the hosting window only when a trusted target origin can be determined.
+
+If no trusted hosting origin is available, Huey logs a warning and does not send the ready message.
+
+## Session Cloner
+
+Session clone messages are sent using `window.location.origin` as `targetOrigin`.
+Wildcard (`*`) target origins are no longer used.

--- a/src/PostMessageInterface/PostMessageInterface.js
+++ b/src/PostMessageInterface/PostMessageInterface.js
@@ -1,4 +1,6 @@
 class PostMessageInterface {
+
+  static #trustedOrigins = undefined;
     
   constructor(){
     this.#init();
@@ -7,9 +9,139 @@ class PostMessageInterface {
   #init(){
     window.addEventListener('message', this.#messageHandler.bind(this));
   }
+
+  static #normalizeOrigin(origin){
+    if (typeof origin !== 'string' || !origin) {
+      return undefined;
+    }
+    if (origin === 'null') {
+      return undefined;
+    }
+    try {
+      return new URL(origin).origin;
+    }
+    catch (error) {
+      return undefined;
+    }
+  }
+
+  static #parseOriginsParam(value){
+    if (!value || typeof value !== 'string') {
+      return [];
+    }
+    return value
+      .split(',')
+      .map(function(origin){
+        return origin.trim();
+      })
+      .filter(Boolean)
+      .map(PostMessageInterface.#normalizeOrigin)
+      .filter(Boolean);
+  }
+
+  static #getHostingWindowOriginFromReferrer(){
+    var referrer = document.referrer;
+    if (!referrer) {
+      return undefined;
+    }
+    try {
+      return new URL(referrer).origin;
+    }
+    catch (error) {
+      return undefined;
+    }
+  }
+
+  static getTrustedOrigins(){
+    if (PostMessageInterface.#trustedOrigins) {
+      return PostMessageInterface.#trustedOrigins;
+    }
+
+    var trustedOrigins = [window.location.origin];
+    var params = new URLSearchParams(window.location.search);
+
+    var configured = PostMessageInterface.#parseOriginsParam(params.get('postMessageOrigins'));
+    trustedOrigins = trustedOrigins.concat(configured);
+
+    var singleOrigin = PostMessageInterface.#normalizeOrigin(params.get('postMessageOrigin'));
+    if (singleOrigin) {
+      trustedOrigins.push(singleOrigin);
+    }
+
+    var hostingWindowOrigin = PostMessageInterface.#getHostingWindowOriginFromReferrer();
+    if (hostingWindowOrigin) {
+      trustedOrigins.push(hostingWindowOrigin);
+    }
+
+    trustedOrigins = Array.from(new Set(trustedOrigins.filter(Boolean)));
+    PostMessageInterface.#trustedOrigins = trustedOrigins;
+    return trustedOrigins;
+  }
+
+  static isTrustedOrigin(origin){
+    var normalizedOrigin = PostMessageInterface.#normalizeOrigin(origin);
+    if (!normalizedOrigin) {
+      return false;
+    }
+    return PostMessageInterface.getTrustedOrigins().indexOf(normalizedOrigin) !== -1;
+  }
+
+  static getTargetOriginForHostingWindow(){
+    var trustedOrigins = PostMessageInterface.getTrustedOrigins();
+    var referrerOrigin = PostMessageInterface.#getHostingWindowOriginFromReferrer();
+    if (referrerOrigin && trustedOrigins.indexOf(referrerOrigin) !== -1) {
+      return referrerOrigin;
+    }
+
+    for (var i = 0; i < trustedOrigins.length; i++){
+      var origin = trustedOrigins[i];
+      if (origin !== window.location.origin) {
+        return origin;
+      }
+    }
+
+    return undefined;
+  }
+
+  static resetTrustedOriginsForTesting(){
+    PostMessageInterface.#trustedOrigins = undefined;
+  }
+
+  #isValidRequestEnvelope(request){
+    if (!request || typeof request !== 'object') {
+      return false;
+    }
+    if (typeof request.messageType !== 'string' || !request.messageType.length) {
+      return false;
+    }
+    return true;
+  }
   
   async #messageHandler(event){
-    var request = event.data;    
+    var request = event.data;
+
+    if (!PostMessageInterface.isTrustedOrigin(event.origin)) {
+      console.warn('Ignoring postMessage request from untrusted origin:', event.origin);
+      return;
+    }
+
+    if (!event.source || typeof event.source.postMessage !== 'function') {
+      console.warn('Ignoring postMessage request without a valid source window.');
+      return;
+    }
+
+    if (!this.#isValidRequestEnvelope(request)) {
+      event.source.postMessage({
+        messageType: PostMessageProtocol.RESPONSE,
+        status: {
+          code: PostMessageProtocol.STATUS_BAD_REQUEST,
+          message: 'Malformed request envelope.',
+          sent: Date.now()
+        }
+      }, {targetOrigin: event.origin});
+      return;
+    }
+
     var requestType = request.messageType;
     
     var requestId = request.requestId;
@@ -45,7 +177,7 @@ class PostMessageInterface {
     }
 
     response.status.sent = Date.now();
-    event.source.postMessage(response, {targetOrigin: '*'});
+    event.source.postMessage(response, {targetOrigin: event.origin});
     return response;
   }
     
@@ -53,8 +185,7 @@ class PostMessageInterface {
     return {
       error: {
         name: error.name,
-        message: error.message,
-        stack: error.stack
+        message: error.message
       }
     };
   }    
@@ -143,7 +274,7 @@ class PostMessageInterface {
     }
   }
 
-  #handlePingRequest(){
+  #handlePingRequest(request, response){
     response.status.code = PostMessageProtocol.STATUS_OK;
     response.status.message = 'pong';
   }
@@ -177,6 +308,11 @@ class PostMessageInterface {
     }
     
     var hostingWindow = PostMessageInterface.getHostingWindow();
+    var targetOrigin = PostMessageInterface.getTargetOriginForHostingWindow();
+    if (!targetOrigin) {
+      console.warn('Could not determine trusted hosting window origin for ready message. Configure postMessageOrigins or use a trusted referrer origin.');
+      return;
+    }
     
     hostingWindow.postMessage({
       status: {
@@ -187,7 +323,7 @@ class PostMessageInterface {
       body: {
         params: params
       }
-    }, {targetOrigin: '*'});
+    }, {targetOrigin: targetOrigin});
   }
   
 }

--- a/src/SessionCloner/SessionCloner.js
+++ b/src/SessionCloner/SessionCloner.js
@@ -11,6 +11,9 @@ class SessionCloner {
   
   #messageHandler(event){
     var request = event.data;
+    if (!PostMessageInterface.isTrustedOrigin(event.origin)) {
+      return;
+    }
     var requestType = request.messageType;
     
     if (requestType) {
@@ -31,6 +34,7 @@ class SessionCloner {
   }
   
   #copyWindowStateToHueyClone(clonedWindow){
+    var targetOrigin = window.location.origin;
     var datasourceIds = datasourcesUi.getDatasourceIds();
     for (var i = 0; i < datasourceIds.length; i++) {
       var datasourceId = datasourceIds[i];
@@ -43,7 +47,7 @@ class SessionCloner {
           datasourceConfig: originalConfig
         }        
       };
-      clonedWindow.postMessage(request, {targetOrigin: '*'});
+      clonedWindow.postMessage(request, {targetOrigin: targetOrigin});
     }
     var route = Routing.getCurrentRoute();
     if (route) {
@@ -54,7 +58,7 @@ class SessionCloner {
           route: route
         }        
       };
-      clonedWindow.postMessage(request, {targetOrigin: '*'});
+      clonedWindow.postMessage(request, {targetOrigin: targetOrigin});
     }
   }
 

--- a/tests/unit/postmessage-interface.test.js
+++ b/tests/unit/postmessage-interface.test.js
@@ -1,0 +1,155 @@
+const fs = require('fs');
+const path = require('path');
+const { TextEncoder, TextDecoder } = require('util');
+
+if (typeof global.TextEncoder === 'undefined') {
+  global.TextEncoder = TextEncoder;
+}
+if (typeof global.TextDecoder === 'undefined') {
+  global.TextDecoder = TextDecoder;
+}
+
+const { JSDOM } = require('jsdom');
+
+describe('PostMessageInterface security hardening', () => {
+  function createWindow(allowedOrigins) {
+    var queryString = '';
+    if (allowedOrigins) {
+      queryString = '?postMessageOrigins=' + encodeURIComponent(allowedOrigins);
+    }
+    const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+      url: `http://localhost/${queryString}`,
+      runScripts: 'dangerously',
+      pretendToBeVisual: true,
+    });
+
+    const scriptPaths = [
+      'src/PostMessageInterface/PostMessageProtocol.js',
+      'src/PostMessageInterface/PostMessageInterface.js',
+    ];
+
+    scriptPaths.forEach((scriptPath) => {
+      const code = fs.readFileSync(path.resolve(__dirname, '../../', scriptPath), 'utf-8');
+      const scriptElement = dom.window.document.createElement('script');
+      scriptElement.textContent = code;
+      dom.window.document.body.appendChild(scriptElement);
+    });
+
+    dom.window.pageStateManager = {
+      setPageState: jest.fn(),
+    };
+    dom.window.datasourcesUi = {
+      addDatasources: jest.fn(async () => {}),
+    };
+    dom.window.analyzeDatasource = jest.fn();
+    dom.window.DuckDbDataSource = function () {
+      this.getId = () => 'dummy';
+      this.getType = () => 'duckdb';
+    };
+    dom.window.hueyDb = {
+      duckdb: {},
+      instance: {},
+    };
+
+    dom.window.initPostMessageInterface(true);
+
+    return dom.window;
+  }
+
+  test('responds to ping for trusted origin and uses origin as targetOrigin', () => {
+    const window = createWindow('http://trusted.test');
+    const source = { postMessage: jest.fn() };
+
+    const event = new window.MessageEvent('message', {
+      origin: 'http://trusted.test',
+      source,
+      data: {
+        messageType: 'ping',
+        requestId: 'req-1',
+      },
+    });
+
+    window.dispatchEvent(event);
+
+    expect(source.postMessage).toHaveBeenCalledTimes(1);
+    const [response, options] = source.postMessage.mock.calls[0];
+    expect(response.status.code).toBe('Ok');
+    expect(response.status.message).toBe('pong');
+    expect(options).toEqual({ targetOrigin: 'http://trusted.test' });
+  });
+
+  test('ignores messages from untrusted origin', () => {
+    const window = createWindow('http://trusted.test');
+    const source = { postMessage: jest.fn() };
+
+    const event = new window.MessageEvent('message', {
+      origin: 'http://evil.test',
+      source,
+      data: {
+        messageType: 'ping',
+        requestId: 'req-2',
+      },
+    });
+
+    window.dispatchEvent(event);
+
+    expect(source.postMessage).not.toHaveBeenCalled();
+  });
+
+  test('returns bad request for malformed envelope without messageType', () => {
+    const window = createWindow('http://trusted.test');
+    const source = { postMessage: jest.fn() };
+
+    const event = new window.MessageEvent('message', {
+      origin: 'http://trusted.test',
+      source,
+      data: {
+        requestId: 'req-3',
+      },
+    });
+
+    window.dispatchEvent(event);
+
+    expect(source.postMessage).toHaveBeenCalledTimes(1);
+    const [response, options] = source.postMessage.mock.calls[0];
+    expect(response.status.code).toBe('Bad Request');
+    expect(response.status.message).toBe('Malformed request envelope.');
+    expect(options).toEqual({ targetOrigin: 'http://trusted.test' });
+  });
+
+  test('bad request response omits stack details', async () => {
+    const window = createWindow('http://trusted.test');
+    const source = { postMessage: jest.fn() };
+
+    const event = new window.MessageEvent('message', {
+      origin: 'http://trusted.test',
+      source,
+      data: {
+        messageType: 'createDatasource',
+        requestId: 'req-4',
+        body: null,
+      },
+    });
+
+    window.dispatchEvent(event);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(source.postMessage).toHaveBeenCalledTimes(1);
+    const [response] = source.postMessage.mock.calls[0];
+    expect(response.status.code).toBe('Bad Request');
+    expect(response.body.error.stack).toBeUndefined();
+  });
+
+  test('sendReadyMessage uses trusted target origin and never wildcard', () => {
+    const window = createWindow('http://trusted.test');
+    const opener = { postMessage: jest.fn() };
+    window.opener = opener;
+
+    window.postMessageInterface.sendReadyMessage();
+
+    expect(opener.postMessage).toHaveBeenCalledTimes(1);
+    const [, options] = opener.postMessage.mock.calls[0];
+    expect(options.targetOrigin).toBe('http://trusted.test');
+    expect(options.targetOrigin).not.toBe('*');
+  });
+});


### PR DESCRIPTION
## Summary
Implements #224 by hardening postMessage origin handling, removing wildcard target origins, and fixing the ping handler defect.

## What changed
- Updated `src/PostMessageInterface/PostMessageInterface.js`
  - Added trusted origin allowlist validation for incoming messages
  - Added malformed request envelope validation with structured `Bad Request` response
  - Replaced response `targetOrigin: '*'` with request `event.origin`
  - Fixed ping handler signature/logic (`#handlePingRequest(request, response)`)
  - Removed stack data from error response body
  - Hardened ready-message target origin resolution (`postMessageOrigins` / `postMessageOrigin` / referrer)
- Updated `src/SessionCloner/SessionCloner.js`
  - Validates incoming message origin
  - Replaced wildcard `targetOrigin` with `window.location.origin` for clone messages
- Added unit tests in `tests/unit/postmessage-interface.test.js`
  - Trusted origin ping flow
  - Untrusted origin rejection
  - Malformed envelope response
  - No stack leakage in bad request body
  - Non-wildcard target origin for ready message
- Added docs in `docs/postmessage-security.md`

## Validation
- `npm run test:unit -- --runInBand` (pass: 38/38)
- `npm run test:ui` (pass: 6, skipped: 5; unchanged baseline)

Fixes #224