### PR TITLE
Fix #271: read remote cell values by positional keys with alias fallback

### DIFF
--- a/src/DataSet/CellSet.js
+++ b/src/DataSet/CellSet.js
@@ -388,6 +388,7 @@ export class CellSet extends DataSetComponent {
     var cells = apiResponse.cells || [];
     var colCount = columnCount || 1;
     var items = cellsAxisItemsToFetch || [];
+    var aliases = measureAliases || [];
     var offset = measureValueOffset != null ? measureValueOffset : 0;
     // Backend returns cell.values keyed by column index ("0", "1", ...): row dims, then column dims, then measures.
     var fields = [{ name: CellSet.#cellIndexColumnName }].concat(items.map(function(item) {
@@ -407,7 +408,8 @@ export class CellSet extends DataSetComponent {
       items.forEach(function(item, index) {
         var sqlExpression = QueryAxisItem.getSqlForQueryAxisItem(item, CellSet.datasetRelationName);
         var key = String(offset + index);
-        row[sqlExpression] = vals[key];
+        var alias = aliases[index] || item.columnName;
+        row[sqlExpression] = vals[key] !== undefined ? vals[key] : vals[alias];
       });
       return row;
     };
@@ -430,10 +432,11 @@ export class CellSet extends DataSetComponent {
       var rowDimCount = (axes.rows && axes.rows.length) || 0;
       var colDimCount = (axes.columns && axes.columns.length) || 0;
       var measureValueOffset = rowDimCount + colDimCount;
+      var measureAliases = query.axes && query.axes.measures ? query.axes.measures.map(function(measure) { return measure.alias; }) : [];
       var dateRange = RemoteQueryAdapter.getDateRange(queryModel);
       var connection = datasource.getManagedConnection();
       var apiResponse = await connection.fetchCells(dateRange, query);
-      var resultSet = this.#remoteCellsResponseToResultSet(apiResponse, cellsAxisItemsToFetch, colCount, null, measureValueOffset);
+      var resultSet = this.#remoteCellsResponseToResultSet(apiResponse, cellsAxisItemsToFetch, colCount, measureAliases, measureValueOffset);
       return resultSet;
     }
 

--- a/src/DataSet/CellSet.js
+++ b/src/DataSet/CellSet.js
@@ -409,7 +409,7 @@ export class CellSet extends DataSetComponent {
       var vals = c.values || {};
       items.forEach(function(item, index) {
         var sqlExpression = QueryAxisItem.getSqlForQueryAxisItem(item, CellSet.datasetRelationName);
-        var alias = aliases[index] || item.columnName;
+        var alias = aliases[index];
         var keyedByPosition = vals[String(offset + index)];
         var keyedByMeasureIndex = vals[String(index)];
         row[sqlExpression] = keyedByPosition !== undefined ? keyedByPosition : (


### PR DESCRIPTION
## Summary
- keep positional cell value lookup (offset + index) for QueryService payloads
- pass measure aliases into remote cell mapping and fall back to alias lookup when positional key is absent

## Why
/query/cells responses are primarily keyed by positional indexes. Using aliases alone can return undefined values in remote mode. This change keeps existing positional behavior and adds alias compatibility fallback.

Closes #271

## Validation
- Could not run unit tests in isolated worktree (vitest not installed there; node_modules missing).
