### PR TITLE
refactor: split god-object modules into focused sub-modules

### DIFF
--- a/src/DataSource/DataSourceExport.js
+++ b/src/DataSource/DataSourceExport.js
@@ -1,0 +1,182 @@
+/**
+ * Export/download utilities extracted from DataSourcesUi.
+ * Contains the datasource export menu, format prompt, and settings builder.
+ */
+
+import { DuckDbDataSource } from './duckdb/DuckDbDataSource.js';
+import { PromptUi } from '../PromptUi/PromptUi.js';
+import { settings } from '../SettingsDialog/SettingsDialog.js';
+
+export const datasourceExportMenuId = 'datasourceExportMenu';
+
+/**
+ * Generate the HTML for the file type selection menu used during export.
+ * @param {string} [fromFileType] - The source file type to optionally filter
+ * @param {boolean} [includeFromFileType=true] - Whether to include the source file type in the menu
+ * @returns {string} HTML string for the menu
+ */
+export function getDownloadMenuHTML(fromFileType, includeFromFileType) {
+  const fileTypes = Object.keys(DuckDbDataSource.fileTypes)
+    .filter((fileType) => {
+      if (fromFileType) {
+        switch (fileType) {
+          case fromFileType:
+            return includeFromFileType !== false;
+        }
+      }
+      return true;
+    });
+  const menuItems = fileTypes.sort().map((fileType) => {
+    const id = `fileType-${fileType}`;
+    return `
+        <li role="menuitem">
+          <input
+            type="radio"
+            name="fileTypes"
+            value="${fileType}"
+            id="${id}"
+          />
+          <label for="${id}">${fileType}</label>
+        </li>
+      `;
+  });
+  const menu = `
+      <menu class="fileTypes" id="${datasourceExportMenuId}">
+        ${menuItems.join('\n')}
+      </menu>
+    `;
+  return menu;
+}
+
+/**
+ * Show a prompt dialog asking the user to select an export file format.
+ * @param {string} [fromFileType] - The source file type
+ * @param {boolean} [includeFromFileType=true] - Whether to include the source type
+ * @returns {Promise<string|undefined>} The selected file type, or undefined if cancelled
+ */
+export async function promptExportDataFormat(fromFileType, includeFromFileType) {
+  const menu = getDownloadMenuHTML(fromFileType, includeFromFileType);
+  const result = await PromptUi.show({
+    title: 'Export Datasource',
+    contents: menu,
+    allowUnsafeHtml: true
+  });
+
+  if (result !== 'accept') {
+    return undefined;
+  }
+  const selectedItemCss = `menu#${datasourceExportMenuId} > li > input[type=radio]:checked`;
+  const selected = document.querySelector(selectedItemCss);
+  if (!selected) {
+    return undefined;
+  }
+  const fileType = selected.value;
+  return fileType;
+}
+
+/**
+ * Build the export settings object for a given target file type.
+ * @param {string} targetFileType - The file type to export to (e.g., 'csv', 'parquet', 'sqlite')
+ * @returns {Object} Export settings object with type flags and merged user settings
+ */
+export function getDatasourceExportSettings(targetFileType) {
+  const fileTypeInfo = DuckDbDataSource.getFileTypeInfo(targetFileType);
+  let exportType = null;
+  let exportDelimited = false;
+  let exportJson = false;
+  let exportParquet = false;
+  let exportSqlite = false;
+  let exportDuckdb = false;
+  let exportXlsx = false;
+
+  switch (targetFileType) {
+    case 'sqlite':
+      exportType = 'exportSqlite';
+      exportSqlite = true;
+      break;
+    case 'duckdb':
+      exportType = 'exportDuckdb';
+      exportDuckdb = true;
+      break;
+    default:
+      switch (fileTypeInfo.duckdb_reader) {
+        case 'read_csv':
+          exportType = 'exportDelimited';
+          exportDelimited = true;
+          break;
+        case 'read_json':
+          exportType = 'exportJson';
+          exportJson = true;
+          break;
+        case 'read_parquet':
+          exportType = 'exportParquet';
+          exportParquet = true;
+          break;
+        case 'read_xlsx':
+          exportType = 'exportXlsx';
+          exportXlsx = true;
+          break;
+      }
+  }
+  const exportSettings = Object.assign(
+    {}, settings.getSettings('exportUi'), {
+    exportDestinationFile: true,
+    exportDestinationClipboard: false,
+    exportType: exportType,
+    exportDelimited: exportDelimited,
+    exportJson: exportJson,
+    exportParquet: exportParquet,
+    exportSqlite: exportSqlite,
+    exportDuckdb: exportDuckdb,
+    exportXlsx: exportXlsx,
+  });
+  return exportSettings;
+}
+
+/**
+ * Get a display caption for a datasource based on its type.
+ * @param {Object} datasource - The datasource object
+ * @returns {string} A human-readable caption
+ */
+export function getCaptionForDatasource(datasource) {
+  const type = datasource.getType();
+  switch (type) {
+    case DuckDbDataSource.types.DUCKDB:
+    case DuckDbDataSource.types.SQLITE:
+    case DuckDbDataSource.types.FILE:
+      return datasource.getFileNameWithoutExtension();
+    case DuckDbDataSource.types.TABLE:
+    case DuckDbDataSource.types.TABLEFUNCTION:
+    case DuckDbDataSource.types.VIEW:
+      return datasource.getObjectName();
+    case 'remote':
+      return `${datasource.getBaseUrl()} — ${datasource.getDatasetId()}`;
+    default:
+      return datasource.getId();
+  }
+}
+
+/**
+ * Sort a datasources object by caption.
+ * @param {Object} datasources - Object keyed by datasource ID
+ * @returns {Object} New object with same keys, sorted by caption
+ */
+export function sortDatasources(datasources) {
+  const datasourceKeys = Object.keys(datasources);
+  datasourceKeys
+    .sort((a, b) => {
+      const datasourceA = getCaptionForDatasource(datasources[a]);
+      const datasourceB = getCaptionForDatasource(datasources[b]);
+      if (datasourceA > datasourceB) {
+        return 1;
+      }
+      else if (datasourceA < datasourceB) {
+        return -1;
+      }
+      return 0;
+    });
+  return datasourceKeys.reduce((sortedDatasources, datasourceKey) => {
+    sortedDatasources[datasourceKey] = datasources[datasourceKey];
+    return sortedDatasources;
+  }, {});
+}

--- a/src/DataSource/DataSourcesUi.js
+++ b/src/DataSource/DataSourcesUi.js
@@ -5,16 +5,22 @@ import { DuckDbDataSource } from './duckdb/DuckDbDataSource.js';
 import { Internationalization } from '../Internationalization/Internationalization.js';
 import { getQuotedIdentifier } from '../util/sql/SQLHelper.js';
 import { showErrorDialog } from '../ErrorDialog/ErrorDialog.js';
-import { PromptUi } from '../PromptUi/PromptUi.js';
 import { ExportUi } from '../ExportUi/ExportDialog.js';
 import { uploadUi, afterUploaded } from '../UploadUi/UploadUi.js';
 import { analyzeDatasource } from '../App/analyzeDatasource.js';
 import { datasourceSettingsDialog } from '../DatasourceSettingsDialog/DatasourceSettingsDialog.js';
 import { getConnection, getDatabase, getDuckDbModule } from './duckdb/database.js';
+import {
+  datasourceExportMenuId,
+  getDownloadMenuHTML as _getDownloadMenuHTML,
+  promptExportDataFormat as _promptExportDataFormat,
+  getDatasourceExportSettings as _getDatasourceExportSettings,
+  getCaptionForDatasource as _getCaptionForDatasource,
+  sortDatasources as _sortDatasources,
+} from './DataSourceExport.js';
 
 export class DataSourcesUi extends EventEmitter {
 
-  static #datasourceExportMenuId = 'datasourceExportMenu';
 
   #id = undefined;
   #datasources = {};
@@ -228,21 +234,7 @@ export class DataSourcesUi extends EventEmitter {
   }
 
   static getCaptionForDatasource(datasource){
-    const type = datasource.getType();
-    switch (type){
-      case DuckDbDataSource.types.DUCKDB:
-      case DuckDbDataSource.types.SQLITE:
-      case DuckDbDataSource.types.FILE:
-        return datasource.getFileNameWithoutExtension();
-      case DuckDbDataSource.types.TABLE:
-      case DuckDbDataSource.types.TABLEFUNCTION:
-      case DuckDbDataSource.types.VIEW:
-        return datasource.getObjectName();
-      case 'remote':
-        return `${datasource.getBaseUrl()} — ${datasource.getDatasetId()}`;
-      default:
-        return datasource.getId();
-    }
+    return _getCaptionForDatasource(datasource);
   }
 
   #renderDatasourceActionButton(config){
@@ -632,110 +624,15 @@ export class DataSourcesUi extends EventEmitter {
   }
   
   static #getDownloadMenuHTML(fromFileType, includeFromFileType){
-    const fileTypes = Object.keys(DuckDbDataSource.fileTypes)
-    .filter((fileType) =>{
-      if (fromFileType) { 
-        switch (fileType){
-          case fromFileType:
-            return includeFromFileType !== false;
-        }
-      }
-      return true;
-    });
-    const menuItems = fileTypes.sort().map((fileType) =>{
-      const id = `fileType-${fileType}`;
-      return `
-        <li role="menuitem">
-          <input 
-            type="radio" 
-            name="fileTypes" 
-            value="${fileType}" 
-            id="${id}"
-          />
-          <label for="${id}">${fileType}</label>
-        </li>
-      `;
-    });
-    const menu = `
-      <menu class="fileTypes" id="${DataSourcesUi.#datasourceExportMenuId}">
-        ${menuItems.join('\n')}
-      </menu>
-    `;
-    return menu;
+    return _getDownloadMenuHTML(fromFileType, includeFromFileType);
   }
-  
-  static async #promptExportDataFormat(fromFileType, includeFromFileType){
-    const menu = DataSourcesUi.#getDownloadMenuHTML(fromFileType, includeFromFileType);
-    const result = await PromptUi.show({
-      title: 'Export Datasource',
-      contents: menu,
-      allowUnsafeHtml: true
-    });
 
-    if (result !== 'accept'){
-      return undefined;
-    }
-    const selectedItemCss = `menu#${DataSourcesUi.#datasourceExportMenuId} > li > input[type=radio]:checked`;
-    const selected = document.querySelector(selectedItemCss);
-    if (!selected) {
-      return undefined;
-    }
-    const fileType = selected.value;
-    return fileType;
+  static async #promptExportDataFormat(fromFileType, includeFromFileType){
+    return _promptExportDataFormat(fromFileType, includeFromFileType);
   }
-  
+
   static #getDatasourceExportSettings(targetFileType){
-    const fileTypeInfo = DuckDbDataSource.getFileTypeInfo(targetFileType);
-    let exportType = null;
-    let exportDelimited = false;
-    let exportJson = false;
-    let exportParquet = false;
-    let exportSqlite = false;
-    let exportDuckdb = false;
-    let exportXlsx = false;
-    
-    switch (targetFileType) {
-      case 'sqlite':
-        exportType = 'exportSqlite';
-        exportSqlite = true;
-        break;
-      case 'duckdb':
-        exportType = 'exportDuckdb';
-        exportDuckdb = true;
-        break;
-      default:
-        switch (fileTypeInfo.duckdb_reader){
-          case 'read_csv':
-            exportType = 'exportDelimited';
-            exportDelimited = true;
-            break;
-          case 'read_json':
-            exportType = 'exportJson';
-            exportJson = true;
-            break;
-          case 'read_parquet':
-            exportType = 'exportParquet';
-            exportParquet = true;
-            break;
-          case 'read_xlsx':
-            exportType = 'exportXlsx';
-            exportXlsx = true;
-            break;
-        }
-    }
-    const exportSettings = Object.assign(
-      {}, settings.getSettings('exportUi'), {
-      exportDestinationFile: true,
-      exportDestinationClipboard: false,
-      exportType: exportType,
-      exportDelimited: exportDelimited,
-      exportJson: exportJson,
-      exportParquet: exportParquet,
-      exportSqlite: exportSqlite,
-      exportDuckdb: exportDuckdb,
-      exportXlsx: exportXlsx,
-    });
-    return exportSettings;
+    return _getDatasourceExportSettings(targetFileType);
   }
   
   async #downloadDatasourceClicked(event) {
@@ -848,24 +745,7 @@ export class DataSourcesUi extends EventEmitter {
   }
   
   static sortDatasources(datasources){
-    const datasourceKeys = Object.keys(datasources);
-    datasourceKeys
-    .sort((a, b) =>{
-      const datasourceA = DataSourcesUi.getCaptionForDatasource( datasources[a] );
-      const datasourceB = DataSourcesUi.getCaptionForDatasource( datasources[b] );
-      if (datasourceA > datasourceB) {
-        return 1;
-      }
-      else
-      if (datasourceA < datasourceB) {
-        return -1;
-      }
-      return 0;
-    });
-    return datasourceKeys.reduce((sortedDatasources, datasourceKey) =>{
-      sortedDatasources[datasourceKey] = datasources[datasourceKey];
-      return sortedDatasources;
-    }, {});
+    return _sortDatasources(datasources);
   }
 
   #addDatasource(datasource) {

--- a/src/DataSource/duckdb/DuckDbDataSource.js
+++ b/src/DataSource/duckdb/DuckDbDataSource.js
@@ -14,98 +14,25 @@ import {
   getComma,
   getIdentifier
 } from '../../util/sql/SQLHelper.js';
+import {
+  datasourceTypes,
+  fileTypeDefinitions,
+  readerArguments,
+  getFileNameParts as _getFileNameParts,
+  getFileTypeInfo as _getFileTypeInfo,
+  getResourceInfoForUrl as _getResourceInfoForUrl,
+  globPathPattern,
+} from './DuckDbDataSourceConfig.js';
 
 export class DuckDbDataSource extends EventEmitter {
   
   static #defaultNumberOfAccessAttempts = 1;
-  static #globPathPattern = /[*?\[\]]/;
+  static #globPathPattern = globPathPattern;
 
-  static types = {
-    "DUCKDB": 'duckdb',
-    "FILE": 'file',
-    "FILES": 'files',
-    "SQLITE": 'sqlite',
-    "SQLQUERY": 'sql',
-    "TABLE": 'table',
-    "TABLEFUNCTION": 'table function',
-    "URL": 'url',
-    "VIEW": 'view'
-  };
-
-  static fileTypes = {
-    "csv": {
-      datasourceType: DuckDbDataSource.types.FILE,
-      duckdb_reader: 'read_csv',
-      duckdb_sniffer: 'sniff_csv',
-      reader_arguments_settings_key: 'csvReader',
-      mimeType: 'text/csv'
-    },
-    "tsv": {
-      datasourceType: DuckDbDataSource.types.FILE,
-      duckdb_reader: 'read_csv',
-      duckdb_sniffer: 'sniff_csv',
-      reader_arguments_settings_key: 'csvReader',
-      mimeType: 'text/tab-separated-values'
-    },
-    "txt": {
-      datasourceType: DuckDbDataSource.types.FILE,
-      duckdb_reader: 'read_csv',
-      duckdb_sniffer: 'sniff_csv',
-      reader_arguments_settings_key: 'csvReader',
-      mimeType: 'text/plain'
-    },
-    "json": {
-      datasourceType: DuckDbDataSource.types.FILE,
-      duckdb_reader: 'read_json_auto',
-      duckdb_extension: 'json',
-      mimeType: 'application/json'
-    },
-    "jsonl": {
-      datasourceType: DuckDbDataSource.types.FILE,
-      duckdb_reader: 'read_json_auto',
-      duckdb_extension: 'json',
-      mimeType: 'application/json'
-    },
-    "parquet": {
-      datasourceType: DuckDbDataSource.types.FILE,
-      duckdb_reader: 'read_parquet',
-      mimeType: 'application/vnd.apache.parquet'
-    },
-    "xlsx": {
-      datasourceType: DuckDbDataSource.types.FILE,
-      duckdb_reader: 'read_xlsx',
-      duckdb_extension: 'excel',
-      //duckdb_extension_repository: 'core_nightly',
-      mimeType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
-    },
-    "duckdb": {
-      datasourceType: DuckDbDataSource.types.DUCKDB,
-      mimeType: 'application/vnd.duckdb'
-    },
-    "sqlite": {
-      datasourceType: DuckDbDataSource.types.SQLITE,
-      duckdb_extension: 'sqlite_scanner',
-      mimeType: 'application/vnd.sqlite3'
-    }
-  };
-
-  static duckdb_reader_arguments = {
-    read_csv: {
-      // https://duckdb.org/docs/data/csv/reading_faulty_csv_files.html#retrieving-faulty-csv-lines
-      //"ignore_errors" : true,
-      "store_rejects" : false
-      //"rejects_scan": 'reject_scans',
-      //"rejects_table": 'reject_errors',
-      //"rejects_limit": 0
-    },
-    sniff_csv: {
-      "sample_size": 20480
-    },
-    read_json_auto: {
-      "ignore_errors": true,
-      "maximum_object_size": 16777216
-    }
-  };
+  // Delegate to shared config (also available via direct import from DuckDbDataSourceConfig.js)
+  static types = datasourceTypes;
+  static fileTypes = fileTypeDefinitions;
+  static duckdb_reader_arguments = readerArguments;
 
   // this is a crutch for reading from url.
   // basically this lets us find out what reader duckdb chose to read the url
@@ -266,90 +193,9 @@ export class DuckDbDataSource extends EventEmitter {
   getCloudUri(){
     return this.#cloudUri;
   }
-  static getFileNameParts(fileName){
-    if (fileName instanceof File) {
-      fileName = fileName.name;
-    }
-
-    const separator = '.';
-    const fileNameParts = fileName.split( separator );
-    if (fileNameParts.length < 2){
-      return undefined;
-    }
-    const extension = fileNameParts.pop();
-    const lowerCaseExtension = extension.toLowerCase();
-    const fileNameWithoutExtension = fileNameParts.join( separator );
-    return {
-      extension: extension,
-      lowerCaseExtension: lowerCaseExtension,
-      fileNameWithoutExtension: fileNameWithoutExtension
-    };
-  }
-
-  static async getResourceInfoForUrl(url, httpMethod, requestHeaders){
-    return new Promise((resolve, reject) =>{
-      try {
-        const xhr = new XMLHttpRequest();
-        xhr.addEventListener("error", (progressEvent) =>{
-          // note: the error event is still an event, not an Error object.
-          // The problem here is that some errors will actually leave some useful information in the status and response,
-          // (e.g, HTTP status in the 400 and 500 ranges)
-          // but there are also errors where the response is useless.
-          // Unfortunately, failure to load doc due to CORS headers is one such case.
-          const status = xhr.status;
-          let message = 'XHR emitted error event.'
-          if (status === 0){
-            message += [
-              '',
-              'The server may not be available, or the request may have failed due to same origin policy / missing CORS header.',
-              'The network tab in your browser\'s development tools may reveal additional information.'
-            ].join(' ')
-            ;
-          }
-          else {
-            message += ` HTTP ${xhr.status} - ${xhr.statusText}`;
-          }
-          const error = new Error(message, {
-            cause: progressEvent
-          });
-          reject(error);
-        });
-
-        xhr.addEventListener("load", () =>{
-          const allResponseHeaders = xhr.getAllResponseHeaders();
-          const headersArray = allResponseHeaders.split('\r\n');
-          const headers = headersArray.reduce((headers, header) =>{
-            const nameValue = header.split(':');
-            let name = nameValue.shift().trim();
-            if (name.length) {
-              name = name.toLowerCase();
-              const value = nameValue.join(':').trim();
-              headers[name] = value;
-            }
-            return headers;
-          }, {});
-          resolve({
-            headers: headers,
-            status: xhr.status,
-            statusText: xhr.statusText,
-            responseType: xhr.responseType,
-            responseText: xhr.responseText
-          });
-        });
-
-        xhr.open(httpMethod || 'GET', url);
-        if (requestHeaders){
-          for (const requestHeader in requestHeaders){
-            xhr.setRequestHeader(requestHeader, requestHeaders[requestHeader]);
-          }
-        }
-        xhr.send();
-      }
-      catch(e){
-        reject(e);
-      }
-    });
-  }
+  // Delegate to extracted utilities (also available via direct import from DuckDbDataSourceConfig.js)
+  static getFileNameParts(fileName){ return _getFileNameParts(fileName); }
+  static async getResourceInfoForUrl(url, httpMethod, requestHeaders){ return _getResourceInfoForUrl(url, httpMethod, requestHeaders); }
 
   // this is a light weight method that should produce the id of a datasource that would be created for the given file.
   // this should not actually instantiate a datasource, merely its identifier.
@@ -358,10 +204,7 @@ export class DuckDbDataSource extends EventEmitter {
     return `${this.types.FILE}:${getQuotedIdentifier(fileName)}`;
   }
 
-  static getFileTypeInfo(fileType){
-    const fileTypeInfo = DuckDbDataSource.fileTypes[fileType];
-    return fileTypeInfo;
-  }
+  static getFileTypeInfo(fileType){ return _getFileTypeInfo(fileType); }
 
   static async createFromUrl(duckdb, instance, url) {
     if (!(typeof url === 'string')){

--- a/src/DataSource/duckdb/DuckDbDataSourceConfig.js
+++ b/src/DataSource/duckdb/DuckDbDataSourceConfig.js
@@ -1,0 +1,206 @@
+/**
+ * Static configuration for DuckDB data source types and file type definitions.
+ * Extracted from DuckDbDataSource to improve modularity.
+ */
+
+/**
+ * Datasource type constants.
+ */
+export const datasourceTypes = {
+  "DUCKDB": 'duckdb',
+  "FILE": 'file',
+  "FILES": 'files',
+  "SQLITE": 'sqlite',
+  "SQLQUERY": 'sql',
+  "TABLE": 'table',
+  "TABLEFUNCTION": 'table function',
+  "URL": 'url',
+  "VIEW": 'view'
+};
+
+/**
+ * Supported file type definitions with their DuckDB readers and MIME types.
+ */
+export const fileTypeDefinitions = {
+  "csv": {
+    datasourceType: datasourceTypes.FILE,
+    duckdb_reader: 'read_csv',
+    duckdb_sniffer: 'sniff_csv',
+    reader_arguments_settings_key: 'csvReader',
+    mimeType: 'text/csv'
+  },
+  "tsv": {
+    datasourceType: datasourceTypes.FILE,
+    duckdb_reader: 'read_csv',
+    duckdb_sniffer: 'sniff_csv',
+    reader_arguments_settings_key: 'csvReader',
+    mimeType: 'text/tab-separated-values'
+  },
+  "txt": {
+    datasourceType: datasourceTypes.FILE,
+    duckdb_reader: 'read_csv',
+    duckdb_sniffer: 'sniff_csv',
+    reader_arguments_settings_key: 'csvReader',
+    mimeType: 'text/plain'
+  },
+  "json": {
+    datasourceType: datasourceTypes.FILE,
+    duckdb_reader: 'read_json_auto',
+    duckdb_extension: 'json',
+    mimeType: 'application/json'
+  },
+  "jsonl": {
+    datasourceType: datasourceTypes.FILE,
+    duckdb_reader: 'read_json_auto',
+    duckdb_extension: 'json',
+    mimeType: 'application/json'
+  },
+  "parquet": {
+    datasourceType: datasourceTypes.FILE,
+    duckdb_reader: 'read_parquet',
+    mimeType: 'application/vnd.apache.parquet'
+  },
+  "xlsx": {
+    datasourceType: datasourceTypes.FILE,
+    duckdb_reader: 'read_xlsx',
+    duckdb_extension: 'excel',
+    //duckdb_extension_repository: 'core_nightly',
+    mimeType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+  },
+  "duckdb": {
+    datasourceType: datasourceTypes.DUCKDB,
+    mimeType: 'application/vnd.duckdb'
+  },
+  "sqlite": {
+    datasourceType: datasourceTypes.SQLITE,
+    duckdb_extension: 'sqlite_scanner',
+    mimeType: 'application/vnd.sqlite3'
+  }
+};
+
+/**
+ * Default reader arguments per DuckDB reader function.
+ */
+export const readerArguments = {
+  read_csv: {
+    // https://duckdb.org/docs/data/csv/reading_faulty_csv_files.html#retrieving-faulty-csv-lines
+    //"ignore_errors" : true,
+    "store_rejects" : false
+    //"rejects_scan": 'reject_scans',
+    //"rejects_table": 'reject_errors',
+    //"rejects_limit": 0
+  },
+  sniff_csv: {
+    "sample_size": 20480
+  },
+  read_json_auto: {
+    "ignore_errors": true,
+    "maximum_object_size": 16777216
+  }
+};
+
+/**
+ * Parse a filename into its extension parts.
+ * @param {string|File} fileName - The filename or File object
+ * @returns {{ extension: string, lowerCaseExtension: string, fileNameWithoutExtension: string } | undefined}
+ */
+export function getFileNameParts(fileName){
+  if (fileName instanceof File) {
+    fileName = fileName.name;
+  }
+
+  const separator = '.';
+  const fileNameParts = fileName.split( separator );
+  if (fileNameParts.length < 2){
+    return undefined;
+  }
+  const extension = fileNameParts.pop();
+  const lowerCaseExtension = extension.toLowerCase();
+  const fileNameWithoutExtension = fileNameParts.join( separator );
+  return {
+    extension: extension,
+    lowerCaseExtension: lowerCaseExtension,
+    fileNameWithoutExtension: fileNameWithoutExtension
+  };
+}
+
+/**
+ * Get the file type info for a given extension.
+ * @param {string} fileType - File extension (e.g., 'csv', 'parquet')
+ * @returns {Object|undefined}
+ */
+export function getFileTypeInfo(fileType){
+  return fileTypeDefinitions[fileType];
+}
+
+/**
+ * Perform an HTTP request (HEAD/GET) to retrieve resource info.
+ * @param {string} url - The URL to query
+ * @param {string} [httpMethod='GET'] - HTTP method
+ * @param {Object} [requestHeaders] - Additional headers
+ * @returns {Promise<{headers: Object, status: number, statusText: string, responseType: string, responseText: string}>}
+ */
+export async function getResourceInfoForUrl(url, httpMethod, requestHeaders){
+  return new Promise((resolve, reject) =>{
+    try {
+      const xhr = new XMLHttpRequest();
+      xhr.addEventListener("error", (progressEvent) =>{
+        const status = xhr.status;
+        let message = 'XHR emitted error event.'
+        if (status === 0){
+          message += [
+            '',
+            'The server may not be available, or the request may have failed due to same origin policy / missing CORS header.',
+            'The network tab in your browser\'s development tools may reveal additional information.'
+          ].join(' ')
+          ;
+        }
+        else {
+          message += ` HTTP ${xhr.status} - ${xhr.statusText}`;
+        }
+        const error = new Error(message, {
+          cause: progressEvent
+        });
+        reject(error);
+      });
+
+      xhr.addEventListener("load", () =>{
+        const allResponseHeaders = xhr.getAllResponseHeaders();
+        const headersArray = allResponseHeaders.split('\r\n');
+        const headers = headersArray.reduce((headers, header) =>{
+          const nameValue = header.split(':');
+          let name = nameValue.shift().trim();
+          if (name.length) {
+            name = name.toLowerCase();
+            const value = nameValue.join(':').trim();
+            headers[name] = value;
+          }
+          return headers;
+        }, {});
+        resolve({
+          headers: headers,
+          status: xhr.status,
+          statusText: xhr.statusText,
+          responseType: xhr.responseType,
+          responseText: xhr.responseText
+        });
+      });
+
+      xhr.open(httpMethod || 'GET', url);
+      if (requestHeaders){
+        for (const requestHeader in requestHeaders){
+          xhr.setRequestHeader(requestHeader, requestHeaders[requestHeader]);
+        }
+      }
+      xhr.send();
+    }
+    catch(e){
+      reject(e);
+    }
+  });
+}
+
+/**
+ * Glob path pattern for detecting wildcard paths.
+ */
+export const globPathPattern = /[*?\[\]]/;

--- a/src/PivotTableUi/PivotTableUi.js
+++ b/src/PivotTableUi/PivotTableUi.js
@@ -12,10 +12,18 @@ import { PivotTableUiHighlighting } from './PivotTableUiHighlighting.js';
 import { showErrorDialog } from '../ErrorDialog/ErrorDialog.js';
 import { copyToClipboard } from '../util/clipboard/clipboard.js';
 import { getDuckDbLiteralForValue, quoteStringLiteral } from '../util/sql/SQLHelper.js';
+import {
+  pivotTableUiDefaults,
+  getTotalsItemsIndices as _getTotalsItemsIndices,
+  isTotalsMember as _isTotalsMember,
+  getDittoMark as _getDittoMark,
+  getHideRepeatingAxisValues as _getHideRepeatingAxisValues,
+  getMaxCellWidth as _getMaxCellWidth,
+} from './PivotTableUiUtils.js';
 
 export class PivotTableUi extends EventEmitter {
 
-  static #templateId = 'pivotTableUiTemplate';
+  static #templateId = pivotTableUiDefaults.templateId;
 
   #id = undefined;
   #queryModel = undefined;
@@ -34,7 +42,7 @@ export class PivotTableUi extends EventEmitter {
   #columnHeaderResizeTimeoutId = undefined;
 
   // the maximum width in ch units
-  static #maximumCellWidth = 30;
+  static #maximumCellWidth = pivotTableUiDefaults.maximumCellWidth;
 
   #lastMetrics = undefined;
 
@@ -577,39 +585,12 @@ export class PivotTableUi extends EventEmitter {
     };
   }
 
-  // get the indices of all totals items.
-  // this is a helper for #isTotalsMember
   static #getTotalsItemsIndices(queryAxisItems){
-    return queryAxisItems && queryAxisItems.length ? queryAxisItems.reduce((acc, curr, index) =>{
-      if (curr.includeTotals) {
-        acc.unshift(index);
-      }
-      return acc;
-    }, []) : undefined;
+    return _getTotalsItemsIndices(queryAxisItems);
   }
-  // if the tuple has a grouping id,
-  // find the most significant bit of the grouping id
-  // find the totals item that corresponds with the MSB of the grouping id
-  // find the index of that totals item
-  // if the index of the current item is equal to or greater than the index of the totals item, then return true
-  // else return false.
 
   static #isTotalsMember(groupingId, totalsItemsIndices, currentItemIndex){
-    if (
-      !groupingId ||
-      !totalsItemsIndices ||
-      !totalsItemsIndices.length ||
-      currentItemIndex === undefined
-    ){
-      return Infinity;
-    }
-
-    let i = BigInt(totalsItemsIndices.length - 1);
-    while (i >= 0n && !(groupingId & (1n << i)))  {
-      i -= 1n;
-    }
-
-    return  (i < 0n) ? Infinity : totalsItemsIndices[i];
+    return _isTotalsMember(groupingId, totalsItemsIndices, currentItemIndex);
   }
 
   #getTupleGroupingId(tuple){
@@ -1792,51 +1773,15 @@ export class PivotTableUi extends EventEmitter {
   }
 
   #getDittoMark(){
-    let dittoMark;
-    let settings = this.#settings;
-    if (settings && typeof settings.getSettings === 'function') {
-      settings = settings.getSettings('pivotSettings');
-    }
-    if (settings){
-      dittoMark = settings.dittoMark;
-    }
-    if ( dittoMark === undefined) {
-      dittoMark = '〃';
-    }
-    return dittoMark;
+    return _getDittoMark(this.#settings);
   }
-  
+
   #getHideRepeatingAxisValues(){
-    let hideRepeatingAxisValues;
-    let settings = this.#settings;
-    if (settings && typeof settings.getSettings === 'function') {
-      settings = settings.getSettings('pivotSettings');
-    }
-    if (settings){
-      hideRepeatingAxisValues = settings.hideRepeatingAxisValues;
-    }
-    if ( hideRepeatingAxisValues === undefined) {
-      hideRepeatingAxisValues = true;
-    }
-    return hideRepeatingAxisValues;
+    return _getHideRepeatingAxisValues(this.#settings);
   }
 
   #getMaxCellWidth(){
-    let maxCellWidth;
-    let settings = this.#settings;
-    if (settings && typeof settings.getSettings === 'function') {
-      settings = settings.getSettings('pivotSettings');
-    }
-    if (settings){
-      maxCellWidth = settings.maxCellWidth;
-    }
-    if (maxCellWidth){
-      maxCellWidth = parseInt(maxCellWidth, 10);
-    }
-    if ( maxCellWidth === undefined || isNaN(maxCellWidth) || maxCellWidth <= 0 ) {
-      maxCellWidth = 30;
-    }
-    return maxCellWidth;
+    return _getMaxCellWidth(this.#settings);
   }
 
   async updatePivotTableUi(){

--- a/src/PivotTableUi/PivotTableUiUtils.js
+++ b/src/PivotTableUi/PivotTableUiUtils.js
@@ -1,0 +1,128 @@
+/**
+ * Pure utility functions extracted from PivotTableUi.
+ * These functions have no dependency on PivotTableUi instance state.
+ */
+
+/**
+ * Default configuration values for PivotTableUi.
+ */
+export const pivotTableUiDefaults = {
+  resizeTimeout: 1000,
+  scrollTimeout: 500,
+  columnHeaderResizeTimeout: 500,
+  maximumCellWidth: 30,
+  defaultDittoMark: '〃',
+  defaultHideRepeatingAxisValues: true,
+  defaultPageSize: 100,
+  templateId: 'pivotTableUiTemplate'
+};
+
+/**
+ * Get the indices of all totals items in a query axis items array.
+ * Items with `includeTotals === true` are collected (in reverse order).
+ * @param {Array} queryAxisItems - Array of query axis items
+ * @returns {number[]|undefined} Array of indices (most significant first), or undefined if none
+ */
+export function getTotalsItemsIndices(queryAxisItems) {
+  return queryAxisItems && queryAxisItems.length
+    ? queryAxisItems.reduce((acc, curr, index) => {
+        if (curr.includeTotals) {
+          acc.unshift(index);
+        }
+        return acc;
+      }, [])
+    : undefined;
+}
+
+/**
+ * Determine whether a tuple member at a given index is a totals member,
+ * based on the grouping ID bitmask and the totals items indices.
+ *
+ * Returns the index of the totals item whose bit is the most significant set bit
+ * in the groupingId, or Infinity if the member is not a totals member.
+ *
+ * @param {BigInt|undefined} groupingId - The GROUPING_ID() value from DuckDB
+ * @param {number[]|undefined} totalsItemsIndices - Indices of items with includeTotals
+ * @param {number|undefined} currentItemIndex - The index of the current item
+ * @returns {number|Infinity}
+ */
+export function isTotalsMember(groupingId, totalsItemsIndices, currentItemIndex) {
+  if (
+    !groupingId ||
+    !totalsItemsIndices ||
+    !totalsItemsIndices.length ||
+    currentItemIndex === undefined
+  ) {
+    return Infinity;
+  }
+
+  let i = BigInt(totalsItemsIndices.length - 1);
+  while (i >= 0n && !(groupingId & (1n << i))) {
+    i -= 1n;
+  }
+
+  return (i < 0n) ? Infinity : totalsItemsIndices[i];
+}
+
+/**
+ * Extract the ditto mark setting from a settings object.
+ * @param {Object} settingsObj - Settings object (may have getSettings method)
+ * @returns {string} The ditto mark character
+ */
+export function getDittoMark(settingsObj) {
+  let dittoMark;
+  let s = settingsObj;
+  if (s && typeof s.getSettings === 'function') {
+    s = s.getSettings('pivotSettings');
+  }
+  if (s) {
+    dittoMark = s.dittoMark;
+  }
+  if (dittoMark === undefined) {
+    dittoMark = pivotTableUiDefaults.defaultDittoMark;
+  }
+  return dittoMark;
+}
+
+/**
+ * Extract the hideRepeatingAxisValues setting from a settings object.
+ * @param {Object} settingsObj - Settings object (may have getSettings method)
+ * @returns {boolean} Whether to hide repeating axis values
+ */
+export function getHideRepeatingAxisValues(settingsObj) {
+  let hideRepeatingAxisValues;
+  let s = settingsObj;
+  if (s && typeof s.getSettings === 'function') {
+    s = s.getSettings('pivotSettings');
+  }
+  if (s) {
+    hideRepeatingAxisValues = s.hideRepeatingAxisValues;
+  }
+  if (hideRepeatingAxisValues === undefined) {
+    hideRepeatingAxisValues = pivotTableUiDefaults.defaultHideRepeatingAxisValues;
+  }
+  return hideRepeatingAxisValues;
+}
+
+/**
+ * Extract the maxCellWidth setting from a settings object.
+ * @param {Object} settingsObj - Settings object (may have getSettings method)
+ * @returns {number} The maximum cell width in ch units
+ */
+export function getMaxCellWidth(settingsObj) {
+  let maxCellWidth;
+  let s = settingsObj;
+  if (s && typeof s.getSettings === 'function') {
+    s = s.getSettings('pivotSettings');
+  }
+  if (s) {
+    maxCellWidth = s.maxCellWidth;
+  }
+  if (maxCellWidth) {
+    maxCellWidth = parseInt(maxCellWidth, 10);
+  }
+  if (maxCellWidth === undefined || isNaN(maxCellWidth) || maxCellWidth <= 0) {
+    maxCellWidth = pivotTableUiDefaults.maximumCellWidth;
+  }
+  return maxCellWidth;
+}

--- a/src/QueryModel/QueryAxis.js
+++ b/src/QueryModel/QueryAxis.js
@@ -1,0 +1,146 @@
+import { QueryAxisItem } from './QueryAxisItem.js';
+
+export class QueryAxis {
+
+  #items = [];
+
+  static getCaptionForQueryAxis(queryAxis){
+    const items = queryAxis.getItems();
+    if (items.length === 0){
+      return '<empty>';
+    }
+    const itemKeys = Object.keys(items);
+    const captions = itemKeys.map((itemKey) =>{
+      const item = items[itemKey];
+      const caption = QueryAxisItem.getCaptionForQueryAxisItem(item);
+      return `"${caption}"`;
+    });
+    return captions.join(', ');
+  }
+
+  getCaption(){
+    return QueryAxis.getCaptionForQueryAxis(this);
+  }
+
+  findItem(config){
+    const columnName = config.columnName || '';
+    const derivation = config.derivation;
+    const aggregator = config.aggregator;
+    let memberExpressionPath = config.memberExpressionPath;
+    if (memberExpressionPath instanceof Array){
+      memberExpressionPath = JSON.stringify(memberExpressionPath);
+    }
+
+    const items = this.#items;
+    const itemIndex = items.findIndex((item) =>{
+      // check column name
+      if ((item.columnName || '') !== columnName){
+        return false;
+      }
+
+      // check member expression path
+      if (memberExpressionPath) {
+        if (!item.memberExpressionPath){
+          return false;
+        }
+        if (memberExpressionPath !== JSON.stringify(item.memberExpressionPath)) {
+          return false;
+        }
+      }
+      else
+      if (item.memberExpressionPath) {
+        return false;
+      }
+
+      // check derivation
+      if (derivation) {
+        if (item.derivation !== derivation) {
+          return false;
+        }
+      }
+      else
+      if (item.derivation){
+        return false;
+      }
+
+      // check aggregator
+      if (aggregator) {
+        if (item.aggregator !== aggregator){
+          return false;
+        }
+      }
+      else
+      if (item.aggregator){
+        return false;
+      }
+
+      // all checks passed
+      return true;
+    });
+
+    if (itemIndex === -1) {
+      return undefined;
+    }
+    const item = items[itemIndex];
+    const copyOfItem = Object.assign({}, item);
+    if (item.filter) {
+      copyOfItem.filter = JSON.parse(JSON.stringify(item.filter));
+    }
+    copyOfItem.index = itemIndex;
+    return copyOfItem;
+  }
+
+  addItem(config){
+    const copyOfConfig = Object.assign({}, config);
+    if (copyOfConfig.index === undefined) {
+      copyOfConfig.index = this.#items.length;
+    }
+    else {
+      if (copyOfConfig.index < 0) {
+        copyOfConfig.index = 0;
+      }
+      else
+      if (copyOfConfig.index > this.#items.length){
+        copyOfConfig.index = this.#items.length;
+      }
+    }
+    delete copyOfConfig['axis'];
+    this.#items.splice(copyOfConfig.index, 0, copyOfConfig);
+    return copyOfConfig;
+  }
+
+  removeItem(config){
+    const item = this.findItem(config);
+    if (!item){
+      return undefined;
+    }
+    this.#items.splice(item.index, 1);
+    return item;
+  }
+
+  clear(){
+    this.#items = [];
+  }
+
+  getItems() {
+    return [].concat(this.#items);
+  }
+
+  syncItemIndices(){
+    this.#items.forEach((item, index) =>{
+      item.index = index;
+    })
+  }
+
+  getTotalsItems(){
+    const totalsItems = this.#items.filter((axisItem) =>{
+      return axisItem.includeTotals === true;
+    });
+    return totalsItems.length ? totalsItems : undefined;
+  }
+
+  setItems(items) {
+    this.#items = items;
+  }
+
+}

--- a/src/QueryModel/QueryAxisItem.js
+++ b/src/QueryModel/QueryAxisItem.js
@@ -1,0 +1,576 @@
+import { AttributeUi } from '../AttributeUi/AttributeUi.js';
+import { FilterDialog } from '../FilterUi/FilterUi.js';
+import { Internationalization } from '../Internationalization/Internationalization.js';
+import {
+  getDataTypeInfo,
+  fallbackFormatter,
+  normalizeSqlOptions,
+  quoteIdentifierWhenRequired,
+  getQualifiedIdentifier,
+  extrapolateColumnExpression,
+  getMemberExpressionType,
+  getArrayElementType,
+  getArrayType,
+  getMapEntryType,
+  getMedianReturnDataTypeForArgumentDataType,
+} from '../util/sql/SQLHelper.js';
+
+// Forward reference — set by QueryModel.js to avoid circular dependency
+let _QueryModel = null;
+export function _setQueryModelRef(ref) { _QueryModel = ref; }
+
+export class QueryAxisItem {
+
+  static createFormatter(axisItem){
+    let dataType = QueryAxisItem.getQueryAxisItemDataType(axisItem);
+    if (axisItem.aggregator) {
+      const aggregatorInfo = AttributeUi.aggregators[axisItem.aggregator];
+      if (aggregatorInfo.createFormatter){
+        return aggregatorInfo.createFormatter(axisItem);
+      }
+      else
+      if (aggregatorInfo.columnType) {
+        dataType = aggregatorInfo.columnType;
+      }
+      else
+      if (aggregatorInfo.preservesColumnType) {
+        // okay, noop
+      }
+      else {
+        //todo.
+      }
+    }
+    else
+    if (axisItem.derivation){
+      const derivationInfo = AttributeUi.getDerivationInfo(axisItem.derivation);
+      if (derivationInfo.createFormatter) {
+        return derivationInfo.createFormatter(axisItem);
+      }
+      else
+      if (derivationInfo.columnType){
+        dataType = derivationInfo.columnType;
+      }
+    }
+
+    if (dataType) {
+      const dataTypeInfo = getDataTypeInfo(dataType);
+      if (dataTypeInfo) {
+        if (dataTypeInfo.createFormatter){
+          return dataTypeInfo.createFormatter();
+        }
+      }
+      else {
+        console.error(`No data type info found for ${dataType}`);
+      }
+    }
+    else{
+      console.warn(`No data type for axisItem "${QueryAxisItem.getCaptionForQueryAxisItem(axisItem)}".`);
+    }
+
+    console.warn(`Using fallback formatter for axisItem ${QueryAxisItem.getCaptionForQueryAxisItem(axisItem)}`);
+    return fallbackFormatter;
+  }
+
+  static createParser(axisItem){
+    if (axisItem.derivation){
+      const derivationInfo = AttributeUi.getDerivationInfo(axisItem.derivation);
+      if (derivationInfo.createParser) {
+        return derivationInfo.createParser(axisItem);
+      }
+    }
+  }
+
+  static createLiteralWriter(axisItem){
+    const dataType = QueryAxisItem.getQueryAxisItemDataType(axisItem);
+    if (!dataType) {
+      // this may happen in case the item has an aggregator like sum() - in these cases we don't know what the datatype of the resulting values will be.
+      // we need to find a better solution for this but for now just bail out - we currently don't need a literalwriter for aggregated values.
+      return null;
+    }
+    const dataTypeInfo = getDataTypeInfo(dataType);
+    let literalWriter;
+    if (typeof dataTypeInfo.createLiteralWriter === 'function') {
+      literalWriter = dataTypeInfo.createLiteralWriter(dataTypeInfo, dataType);
+    }
+    else {
+      return null;
+    }
+    return literalWriter;
+  }
+
+  static getLiteralWriter(axisItem) {
+    let literalWriter = axisItem.literalWriter;
+    if (literalWriter) {
+      return literalWriter;
+    }
+    literalWriter = QueryAxisItem.createLiteralWriter(axisItem);
+    return literalWriter;
+  }
+
+  static getCaptionForQueryAxisItem(axisItem){
+    let caption = axisItem.caption;
+    if (caption){
+      return caption;
+    }
+
+    caption = QueryAxisItem.createCaptionForQueryAxisItem(axisItem);
+
+    if (axisItem.axis === _QueryModel?.AXIS_FILTERS) {
+      let filterItemCaption = `: No filters set.`;
+      const filter = axisItem.filter;
+      if (filter) {
+        const values = filter.values;
+        if (values) {
+          const valueKeys = Object.keys(values);
+          if (valueKeys.length){
+            const valueLabels = [];
+            const toValues = filter.toValues;
+            const toValueKeys = toValues? Object.keys(toValues) : undefined;
+            for (let i = 0; i < valueKeys.length; i++){
+              const valueKey = valueKeys[i];
+              const valueObject = values[valueKey];
+              let valueLabel = valueObject.label;
+              if (toValueKeys && i < toValueKeys.length){
+                const toValueKey = toValueKeys[i];
+                const toValueObject = toValues[toValueKey];
+                valueLabel += ' - ' + toValueObject.label;
+              }
+              valueLabels.push(valueLabel);
+            }
+            filterItemCaption = ` ${filter.filterType} ${valueLabels.join('\n')}`;
+          }
+        }
+      }
+
+      caption = `${caption}${filterItemCaption}`
+    }
+
+    return caption;
+  }
+
+  static createCaptionForQueryAxisItem(axisItem){
+    let caption = axisItem.columnName;
+    if (axisItem.memberExpressionPath) {
+      const path = Object.assign([], axisItem.memberExpressionPath);
+      switch (axisItem.derivation) {
+        case 'elements':
+        case 'element indices':
+          path.pop();
+      }
+      caption = `${caption}.${path.join('.')}`;
+    }
+
+    if (axisItem.derivation) {
+      const translatedDerivation = Internationalization.getText(axisItem.derivation);
+      if (caption) {
+        caption = Internationalization.getText('{1} of {2}', translatedDerivation, caption);
+      }
+      else {
+        caption = translatedDerivation;
+      }
+    }
+    else
+    if (axisItem.aggregator) {
+      const translatedAggregator = Internationalization.getText(axisItem.aggregator);
+      if (caption) {
+        caption = Internationalization.getText('{1} of {2}', translatedAggregator, caption);
+      }
+      else {
+        caption = translatedAggregator;
+      }
+    }
+
+    return caption;
+  }
+
+  static getIdForQueryAxisItem(axisItem){
+    // see issue https://github.com/rpbouman/huey/issues/352
+    // only the sql expression is not enough to identify an Item
+    // some items may have identical SQL, but a different formatter
+    // the caption should be unique but to be on the safe side
+    // we'll take the combination of sql expression and caption
+    // and we'll stylize it as an aliased SQL expression
+    const sqlExpression = QueryAxisItem.getSqlForQueryAxisItem(axisItem);
+    const caption = QueryAxisItem.getCaptionForQueryAxisItem(axisItem);
+    const alias = quoteIdentifierWhenRequired(caption);
+    const id = `${sqlExpression} AS ${alias}`;
+    return id;
+  }
+
+  static getSqlForColumnExpression(item, alias, sqlOptions) {
+    let sqlExpression = [item.columnName];
+
+    if (alias){
+      sqlExpression.unshift(alias);
+    }
+    sqlExpression = getQualifiedIdentifier(sqlExpression, sqlOptions);
+
+    if (item.memberExpressionPath) {
+      sqlExpression = item.memberExpressionPath.reduce((acc, curr) =>{
+        if ( curr.endsWith('()') ) {
+          acc = `${curr.slice(0, -2)}( ${acc} )`;
+        }
+        else {
+          acc += `['${curr}']`;
+        }
+        return acc;
+      }, sqlExpression);
+    }
+    return sqlExpression;
+  }
+
+  static getSqlForAggregatedQueryAxisItem(item, alias, sqlOptions){
+    let columnExpression = item.columnName;
+
+    if (columnExpression === '*') {
+      if (alias) {
+        columnExpression = `${quoteIdentifierWhenRequired(alias)}.*`;
+      }
+    }
+    else
+    if (item.derivation){
+      columnExpression = QueryAxisItem.getSqlForDerivedQueryAxisItem(item, alias, sqlOptions);
+    }
+    else {
+      columnExpression = QueryAxisItem.getSqlForColumnExpression(item, alias, sqlOptions);
+    }
+
+    const aggregator = item.aggregator;
+    const aggregatorInfo = AttributeUi.aggregators[aggregator];
+    const expressionTemplate = aggregatorInfo.expressionTemplate;
+    columnExpression = extrapolateColumnExpression(expressionTemplate, columnExpression);
+    return columnExpression;
+  }
+
+  static getSqlForDerivedQueryAxisItem(item, alias, sqlOptions){
+    let columnExpression = QueryAxisItem.getSqlForColumnExpression(item, alias, sqlOptions);
+
+    const derivation = item.derivation;
+    let derivationInfo;
+    derivationInfo = AttributeUi.getDerivationInfo(derivation);
+    const derivationExpressionTemplate = derivationInfo.expressionTemplate;
+    columnExpression = extrapolateColumnExpression(derivationExpressionTemplate, columnExpression);
+
+    return columnExpression;
+  }
+
+  static getSqlForQueryAxisItem(item, alias, sqlOptions){
+    sqlOptions = normalizeSqlOptions(sqlOptions);
+    let sqlExpression;
+    if (item.aggregator) {
+      sqlExpression = QueryAxisItem.getSqlForAggregatedQueryAxisItem(item, alias, sqlOptions);
+    }
+    else
+    if (item.derivation) {
+      sqlExpression = QueryAxisItem.getSqlForDerivedQueryAxisItem(item, alias, sqlOptions);
+    }
+    else {
+      sqlExpression = QueryAxisItem.getSqlForColumnExpression(item, alias, sqlOptions);
+    }
+    return sqlExpression;
+  }
+
+  static getQueryAxisItemDataType(queryAxisItem){
+    const columnType = queryAxisItem.columnType;
+    let dataType = columnType;
+
+    /*
+      see https://github.com/rpbouman/huey/issues/505
+      If items have a member expression path, then we first need to unwrap that and get the type of the path.
+      Once we have that, we can evaluate type hints like hasElementDataType, hasKeyArrayDataType, preservesColumnType
+    */
+    if (queryAxisItem.memberExpressionPath) {
+      const memberExpressionPath = queryAxisItem.memberExpressionPath;
+      dataType = getMemberExpressionType(columnType, memberExpressionPath);
+      if (memberExpressionPath[memberExpressionPath.length - 1].endsWith('()')){
+        return dataType;
+      }
+    }
+
+    let derivationInfo, derivation = queryAxisItem.derivation;
+    if (derivation) {
+      derivationInfo = AttributeUi.getDerivationInfo(derivation);
+      if (derivationInfo.columnType) {
+        dataType = derivationInfo.columnType;
+      }
+      else
+      if (derivationInfo.hasElementDataType){
+        dataType = getArrayElementType(dataType);
+      }
+      else
+      if (derivationInfo.hasKeyDataType || derivationInfo.hasKeyArrayDataType){
+        dataType = getMemberExpressionType(dataType, 'key');
+        if (derivationInfo.hasKeyArrayDataType){
+          dataType = getArrayType(dataType);
+        }
+      }
+      else
+      if (derivationInfo.hasValueDataType || derivationInfo.hasValueArrayDataType){
+        dataType = getArrayElementType(dataType);
+        dataType = getMemberExpressionType(dataType, 'value');
+        if (derivationInfo.hasValueArrayDataType) {
+          dataType = getArrayType(dataType);
+        }
+      }
+      else
+      if (derivationInfo.hasEntryDataType || derivationInfo.hasEntryArrayDataType){
+        dataType = getMapEntryType(dataType);
+        if (derivationInfo.hasEntryArrayDataType) {
+          dataType = getArrayType(dataType);
+        }
+      }
+      else
+      if (derivation === 'median'){
+        dataType = getArrayElementType(dataType);
+        dataType = getMedianReturnDataTypeForArgumentDataType(dataType);
+      }
+      else
+      if (!derivationInfo.preservesColumnType){
+        console.warn(`Item ${QueryAxisItem.getIdForQueryAxisItem(queryAxisItem)} has derivation "${derivation}" which does not preserve column type and no column type set.`);
+      }
+    }
+
+    let aggregatorInfo, aggregator = queryAxisItem.aggregator;
+    if (aggregator) {
+      aggregatorInfo = AttributeUi.getAggregatorInfo(aggregator);
+      if (aggregatorInfo.columnType) {
+        dataType = aggregatorInfo.columnType;
+      }
+      else
+      if (aggregatorInfo.preservesColumnType){
+        // noop
+      }
+      else
+      if (aggregatorInfo && typeof aggregatorInfo.getReturnDataTypeForArgumentDataType === 'function'){
+        dataType = aggregatorInfo.getReturnDataTypeForArgumentDataType(dataType);
+      }
+      else {
+        dataType = undefined;
+      }
+    }
+
+    return dataType;
+  }
+
+  // includeDisabledItems: if true then return all values, if not true then exclude values that have enabled===false;
+  static #getFilterAxisItemValuesListAsSqlLiterals(queryAxisItem, includeDisabledItems){
+    let sql;
+    const filter = queryAxisItem.filter;
+
+    const values = filter.values;
+    const toValues = filter.toValues;
+
+    let keys = Object.keys(values);
+
+    if (includeDisabledItems !== true) {
+      keys = keys.filter((key) =>{
+        const valueObject = values[key];
+        return valueObject.enabled !== false;
+      });
+    }
+
+    const isRangeFilterType = FilterDialog.isRangeFilterType(filter.filterType);
+    const toValueKeys = isRangeFilterType ? Object.keys(toValues) : undefined;
+    const toValueLiterals = isRangeFilterType ? [] : undefined;
+    const valueLiterals = keys.map((key, index) =>{
+      const entry = values[key];
+      if (isRangeFilterType) {
+        toValueLiterals.push( toValues[toValueKeys[index]].literal );
+      }
+      return entry.literal;
+    });
+    return {
+      valueLiterals: valueLiterals,
+      toValueLiterals: toValueLiterals
+    };
+  }
+
+  static isFilterItemEffective(queryAxisItem){
+    const filter = queryAxisItem.filter;
+    if (!filter) {
+      return undefined;
+    }
+    const literalLists = QueryAxisItem.#getFilterAxisItemValuesListAsSqlLiterals(queryAxisItem);
+    return literalLists.valueLiterals.length !== 0;
+  }
+
+  static getFilterConditionSql(queryAxisItem, alias){
+    if (!QueryAxisItem.isFilterItemEffective(queryAxisItem)) {
+      return undefined;
+    }
+    const filter = queryAxisItem.filter;
+
+    let columnExpression = QueryAxisItem.getSqlForQueryAxisItem(queryAxisItem, alias);
+    let dataType = QueryAxisItem.getQueryAxisItemDataType(queryAxisItem);
+    if (dataType === 'VARCHAR' && filter.caseSensitive === false) {
+      columnExpression = `${columnExpression} COLLATE NOCASE`;
+    }
+
+    let operator = '';
+
+    let nullCondition;
+    const literalLists = QueryAxisItem.#getFilterAxisItemValuesListAsSqlLiterals(queryAxisItem);
+    const indexOfNull = literalLists.valueLiterals.findIndex((value) =>{
+      return value === 'NULL' || value.startsWith('NULL::');
+    });
+
+    if (indexOfNull !== -1) {
+      operator = 'IS';
+      if (FilterDialog.isExclusiveFilterType(filter.filterType)){
+        operator += ' NOT';
+      }
+      literalLists.valueLiterals.splice(indexOfNull, 1);
+      if (FilterDialog.isRangeFilterType(filter.filterType)){
+        literalLists.toValueLiterals.splice(indexOfNull, 1);
+      }
+      nullCondition = `${columnExpression} ${operator} NULL`;
+      operator = '';
+    }
+
+    let sql = '', logicalOperator;
+    let needsParentheses = false;
+    if (literalLists.valueLiterals.length > 0) {
+      switch (filter.filterType) {
+
+        // INCLUDE and EXCLUDE logic
+        case FilterDialog.filterTypes.EXCLUDE:
+          // in case of exclude, keep NULL values unless NULL is also in the valuelist.
+          // https://github.com/rpbouman/huey/issues/90
+          // TODO: if the column happens not to contain any nulls, we can omit this condition
+          if (indexOfNull === -1) {
+            sql = `${columnExpression} IS NULL OR `;
+            needsParentheses = true;
+          }
+          operator += literalLists.valueLiterals.length === 1 ? ' !' : ' NOT';
+          logicalOperator = 'AND';
+        case FilterDialog.filterTypes.INCLUDE:
+          operator += literalLists.valueLiterals.length === 1 ? '=' : ' IN';
+          let values = literalLists.valueLiterals.length === 1 ? literalLists.valueLiterals[0] : `( ${literalLists.valueLiterals.join('\n,')} )`;
+
+          sql += `${columnExpression} ${operator} ${values}`;
+
+          if (indexOfNull !== -1) {
+            if (!logicalOperator) {
+              logicalOperator = 'OR';
+              needsParentheses = true;
+            }
+            sql = `${nullCondition} ${logicalOperator} ${sql}`;
+          }
+          sql = `( ${sql} )`;
+          break;
+
+        // LIKE and NOT LIKE logic
+        case FilterDialog.filterTypes.NOTLIKE:
+          operator = 'NOT ';
+          logicalOperator = 'AND';
+        case FilterDialog.filterTypes.LIKE:
+          let dataType = QueryAxisItem.getQueryAxisItemDataType(queryAxisItem);
+          if (dataType !== 'VARCHAR'){
+            columnExpression = `${columnExpression}::VARCHAR`;
+          }
+          operator += 'LIKE';
+          sql = literalLists.valueLiterals.reduce((acc, curr, currIndex) =>{
+            acc += '\n';
+            if (currIndex) {
+              if (!logicalOperator) {
+                logicalOperator = 'OR';
+                needsParentheses = true;
+              }
+              acc += logicalOperator + ' ';
+            }
+            const value = literalLists.valueLiterals[currIndex];
+            acc += `${columnExpression} ${operator} ${value}`;
+            return acc;
+          }, '');
+
+          if (indexOfNull === -1) {
+            // https://github.com/rpbouman/huey/issues/391
+            // This is essentially the same as
+            // https://github.com/rpbouman/huey/issues/90
+            // but for NOT LIKE
+            if (filter.filterType === FilterDialog.filterTypes.NOTLIKE) {
+              nullCondition = `${columnExpression} IS NULL`;
+              if (literalLists.valueLiterals.length) {
+                sql = `(${sql}) OR ${nullCondition}`;
+                needsParentheses = true;
+              }
+              else {
+                sql = nullCondition;
+              }
+            }
+          }
+          else {
+            if (!logicalOperator) {
+              logicalOperator = 'OR';
+              needsParentheses = true;
+            }
+            sql = `${nullCondition} ${logicalOperator} ${sql}`;
+          }
+          break;
+
+        // BETWEEN and NOT BETWEEN logic
+        case FilterDialog.filterTypes.NOTBETWEEN:
+          operator = 'NOT ';
+          logicalOperator = 'AND';
+        case FilterDialog.filterTypes.BETWEEN:
+          operator += 'BETWEEN';
+          sql = literalLists.valueLiterals.reduce((acc, curr, currIndex) =>{
+            acc += '\n';
+            if (currIndex) {
+              if (!logicalOperator){
+                logicalOperator = 'OR';
+                needsParentheses = true;
+              }
+              acc += logicalOperator + ' ';
+            }
+            const fromValue = literalLists.valueLiterals[currIndex];
+            const toValue = literalLists.toValueLiterals[currIndex];
+            acc += `${columnExpression} ${operator} ${fromValue} AND ${toValue}`;
+            return acc;
+          }, '');
+
+          if (nullCondition) {
+            if (!logicalOperator){
+              logicalOperator = 'OR';
+              needsParentheses = true;
+            }
+            sql = `${nullCondition} ${logicalOperator} ${sql}`
+          }
+          break;
+        case FilterDialog.filterTypes.NOTHASANY:
+        case FilterDialog.filterTypes.NOTHASALL:
+        case FilterDialog.filterTypes.HASANY:
+        case FilterDialog.filterTypes.HASALL:
+          let arrayFunction;
+          switch (filter.filterType){
+            case FilterDialog.filterTypes.HASANY:
+            case FilterDialog.filterTypes.NOTHASANY:
+              arrayFunction = 'list_has_any';
+              break;
+            case FilterDialog.filterTypes.HASALL:
+            case FilterDialog.filterTypes.NOTHASALL:
+              arrayFunction = 'list_has_all';
+              break;
+          }
+          let valueList = literalLists.valueLiterals.reduce((acc, curr, currIndex) =>{
+            const valueLiteral = literalLists.valueLiterals[currIndex];
+            acc.push(valueLiteral);
+            return acc;
+          }, []);
+          valueList = `[ ${valueList.join(',')} ]`;
+          sql = `${arrayFunction}( ${columnExpression}, ${valueList} )`;
+          if (FilterDialog.isExclusiveFilterType(filter.filterType)){
+            sql = `NOT ${sql}`;
+          }
+          break;
+      }
+    }
+    else {
+      sql = nullCondition;
+    }
+    if (needsParentheses) {
+      sql = `( ${sql} )`;
+    }
+    return sql;
+  }
+}

--- a/src/QueryModel/QueryModel.js
+++ b/src/QueryModel/QueryModel.js
@@ -1,19 +1,8 @@
-import { AttributeUi } from '../AttributeUi/AttributeUi.js';
-import { FilterDialog } from '../FilterUi/FilterUi.js';
 import { showErrorDialog } from '../ErrorDialog/ErrorDialog.js';
-import { Internationalization } from '../Internationalization/Internationalization.js';
 import { EventEmitter } from '../util/event/EventEmitter.js';
 import { settings } from '../SettingsDialog/SettingsDialog.js';
 import { datasourcesUi } from '../DataSource/DataSourcesUi.js';
 import { DuckDbDataSource } from '../DataSource/duckdb/DuckDbDataSource.js';
-import {
-  getDataTypeInfo,
-  fallbackFormatter,
-  normalizeSqlOptions,
-  quoteIdentifierWhenRequired,
-  getQualifiedIdentifier,
-  extrapolateColumnExpression,
-} from '../util/sql/SQLHelper.js';
 
 /**
  * @typedef {Object} QueryFilterConfig
@@ -50,706 +39,12 @@ import {
  * @property {Object.<string, {size?: number, unit?: string}>} [sampling]
  */
 
-export class QueryAxisItem {
+import { QueryAxisItem, _setQueryModelRef } from './QueryAxisItem.js';
+import { QueryAxis } from './QueryAxis.js';
 
-  static createFormatter(axisItem){
-    let dataType = QueryAxisItem.getQueryAxisItemDataType(axisItem);
-    if (axisItem.aggregator) {
-      const aggregatorInfo = AttributeUi.aggregators[axisItem.aggregator];
-      if (aggregatorInfo.createFormatter){
-        return aggregatorInfo.createFormatter(axisItem);
-      }
-      else
-      if (aggregatorInfo.columnType) {
-        dataType = aggregatorInfo.columnType;
-      }
-      else
-      if (aggregatorInfo.preservesColumnType) {
-        // okay, noop
-      }
-      else {
-        //todo.
-      }
-    }
-    else
-    if (axisItem.derivation){
-      const derivationInfo = AttributeUi.getDerivationInfo(axisItem.derivation);
-      if (derivationInfo.createFormatter) {
-        return derivationInfo.createFormatter(axisItem);
-      }
-      else
-      if (derivationInfo.columnType){
-        dataType = derivationInfo.columnType;
-      }
-    }
-
-    if (dataType) {
-      const dataTypeInfo = getDataTypeInfo(dataType);
-      if (dataTypeInfo) {
-        if (dataTypeInfo.createFormatter){
-          return dataTypeInfo.createFormatter();
-        }
-      }
-      else {
-        console.error(`No data type info found for ${dataType}`);
-      }
-    }
-    else{
-      console.warn(`No data type for axisItem "${QueryAxisItem.getCaptionForQueryAxisItem(axisItem)}".`);
-    }
-
-    console.warn(`Using fallback formatter for axisItem ${QueryAxisItem.getCaptionForQueryAxisItem(axisItem)}`);
-    return fallbackFormatter;
-  }
-  
-  static createParser(axisItem){
-    if (axisItem.derivation){
-      const derivationInfo = AttributeUi.getDerivationInfo(axisItem.derivation);
-      if (derivationInfo.createParser) {
-        return derivationInfo.createParser(axisItem);
-      }
-    }
-  }
-
-  static createLiteralWriter(axisItem){
-    const dataType = QueryAxisItem.getQueryAxisItemDataType(axisItem);
-    if (!dataType) {
-      // this may happen in case the item has an aggregator like sum() - in these cases we don't know what the datatype of the resulting values will be.
-      // we need to find a better solution for this but for now just bail out - we currently don't need a literalwriter for aggregated values.
-      return null;
-    }
-    const dataTypeInfo = getDataTypeInfo(dataType);
-    let literalWriter;
-    if (typeof dataTypeInfo.createLiteralWriter === 'function') {
-      literalWriter = dataTypeInfo.createLiteralWriter(dataTypeInfo, dataType);
-    }
-    else {
-      return null;
-    }
-    return literalWriter;
-  }
-
-  static getLiteralWriter(axisItem) {
-    let literalWriter = axisItem.literalWriter;
-    if (literalWriter) {
-      return literalWriter;
-    }
-    literalWriter = QueryAxisItem.createLiteralWriter(axisItem);
-    return literalWriter;
-  }
-
-  static getCaptionForQueryAxisItem(axisItem){
-    let caption = axisItem.caption;
-    if (caption){
-      return caption;
-    }
-
-    caption = QueryAxisItem.createCaptionForQueryAxisItem(axisItem);
-
-    if (axisItem.axis === QueryModel.AXIS_FILTERS) {
-      let filterItemCaption = `: No filters set.`;
-      const filter = axisItem.filter;
-      if (filter) {
-        const values = filter.values;
-        if (values) {
-          const valueKeys = Object.keys(values);
-          if (valueKeys.length){
-            const valueLabels = [];
-            const toValues = filter.toValues;
-            const toValueKeys = toValues? Object.keys(toValues) : undefined;
-            for (let i = 0; i < valueKeys.length; i++){
-              const valueKey = valueKeys[i];
-              const valueObject = values[valueKey];
-              let valueLabel = valueObject.label;
-              if (toValueKeys && i < toValueKeys.length){
-                const toValueKey = toValueKeys[i];
-                const toValueObject = toValues[toValueKey];
-                valueLabel += ' - ' + toValueObject.label;
-              }
-              valueLabels.push(valueLabel);
-            }
-            filterItemCaption = ` ${filter.filterType} ${valueLabels.join('\n')}`;
-          }
-        }
-      }
-      
-      caption = `${caption}${filterItemCaption}` 
-    }
-
-    return caption;
-  }
-
-  static createCaptionForQueryAxisItem(axisItem){
-    let caption = axisItem.columnName;
-    if (axisItem.memberExpressionPath) {
-      const path = Object.assign([], axisItem.memberExpressionPath);
-      switch (axisItem.derivation) {
-        case 'elements':
-        case 'element indices':
-          path.pop();
-      }
-      caption = `${caption}.${path.join('.')}`;
-    }
-
-    if (axisItem.derivation) {
-      const translatedDerivation = Internationalization.getText(axisItem.derivation);
-      if (caption) {        
-        caption = Internationalization.getText('{1} of {2}', translatedDerivation, caption);
-      }
-      else {
-        caption = translatedDerivation;
-      }
-    }
-    else 
-    if (axisItem.aggregator) {
-      const translatedAggregator = Internationalization.getText(axisItem.aggregator);
-      if (caption) {
-        caption = Internationalization.getText('{1} of {2}', translatedAggregator, caption);
-      }
-      else {
-        caption = translatedAggregator;
-      }
-    }
-    
-    return caption;
-  }
-
-  static getIdForQueryAxisItem(axisItem){
-    // see issue https://github.com/rpbouman/huey/issues/352
-    // only the sql expression is not enough to identify an Item
-    // some items may have identical SQL, but a different formatter
-    // the caption should be unique but to be on the safe side 
-    // we'll take the combination of sql expression and caption
-    // and we'll stylize it as an aliased SQL expression
-    const sqlExpression = QueryAxisItem.getSqlForQueryAxisItem(axisItem);
-    const caption = QueryAxisItem.getCaptionForQueryAxisItem(axisItem);
-    const alias = quoteIdentifierWhenRequired(caption);
-    const id = `${sqlExpression} AS ${alias}`;
-    return id;
-  }
-
-  static getSqlForColumnExpression(item, alias, sqlOptions) {
-    let sqlExpression = [item.columnName];
-
-    if (alias){
-      sqlExpression.unshift(alias);
-    }
-    sqlExpression = getQualifiedIdentifier(sqlExpression, sqlOptions);
-
-    if (item.memberExpressionPath) {
-      sqlExpression = item.memberExpressionPath.reduce((acc, curr) =>{
-        if ( curr.endsWith('()') ) {
-          acc = `${curr.slice(0, -2)}( ${acc} )`;
-        }
-        else {
-          acc += `['${curr}']`;
-        }
-        return acc;
-      }, sqlExpression);
-    }
-    return sqlExpression;
-  }
-
-  static getSqlForAggregatedQueryAxisItem(item, alias, sqlOptions){
-    let columnExpression = item.columnName;
-
-    if (columnExpression === '*') {
-      if (alias) {
-        columnExpression = `${quoteIdentifierWhenRequired(alias)}.*`;
-      }
-    }
-    else 
-    if (item.derivation){ 
-      columnExpression = QueryAxisItem.getSqlForDerivedQueryAxisItem(item, alias, sqlOptions);
-    }
-    else {
-      columnExpression = QueryAxisItem.getSqlForColumnExpression(item, alias, sqlOptions);
-    }
-
-    const aggregator = item.aggregator;
-    const aggregatorInfo = AttributeUi.aggregators[aggregator];
-    const expressionTemplate = aggregatorInfo.expressionTemplate;
-    columnExpression = extrapolateColumnExpression(expressionTemplate, columnExpression);
-    return columnExpression;
-  }
-
-  static getSqlForDerivedQueryAxisItem(item, alias, sqlOptions){
-    let columnExpression = QueryAxisItem.getSqlForColumnExpression(item, alias, sqlOptions);
-
-    const derivation = item.derivation;
-    let derivationInfo;
-    derivationInfo = AttributeUi.getDerivationInfo(derivation);
-    const derivationExpressionTemplate = derivationInfo.expressionTemplate;
-    columnExpression = extrapolateColumnExpression(derivationExpressionTemplate, columnExpression);
-
-    return columnExpression;
-  }
-
-  static getSqlForQueryAxisItem(item, alias, sqlOptions){
-    sqlOptions = normalizeSqlOptions(sqlOptions);
-    let sqlExpression;
-    if (item.aggregator) {
-      sqlExpression = QueryAxisItem.getSqlForAggregatedQueryAxisItem(item, alias, sqlOptions);
-    }
-    else
-    if (item.derivation) {
-      sqlExpression = QueryAxisItem.getSqlForDerivedQueryAxisItem(item, alias, sqlOptions);
-    }
-    else {
-      sqlExpression = QueryAxisItem.getSqlForColumnExpression(item, alias, sqlOptions);
-    }
-    return sqlExpression;
-  }
-
-  static getQueryAxisItemDataType(queryAxisItem){
-    const columnType = queryAxisItem.columnType;
-    let dataType = columnType;
-
-    /* 
-      see https://github.com/rpbouman/huey/issues/505
-      If items have a member expression path, then we first need to unwrap that and get the type of the path.
-      Once we have that, we can evaluate type hints like hasElementDataType, hasKeyArrayDataType, preservesColumnType
-    */
-    if (queryAxisItem.memberExpressionPath) {
-      const memberExpressionPath = queryAxisItem.memberExpressionPath;
-      dataType = getMemberExpressionType(columnType, memberExpressionPath);
-      if (memberExpressionPath[memberExpressionPath.length - 1].endsWith('()')){
-        return dataType;
-      }
-    }
-
-    let derivationInfo, derivation = queryAxisItem.derivation;
-    if (derivation) {
-      derivationInfo = AttributeUi.getDerivationInfo(derivation);
-      if (derivationInfo.columnType) {
-        dataType = derivationInfo.columnType;
-      }
-      else
-      if (derivationInfo.hasElementDataType){
-        dataType = getArrayElementType(dataType);
-      }
-      else
-      if (derivationInfo.hasKeyDataType || derivationInfo.hasKeyArrayDataType){
-        dataType = getMemberExpressionType(dataType, 'key');
-        if (derivationInfo.hasKeyArrayDataType){
-          dataType = getArrayType(dataType);
-        }
-      }
-      else
-      if (derivationInfo.hasValueDataType || derivationInfo.hasValueArrayDataType){
-        dataType = getArrayElementType(dataType);
-        dataType = getMemberExpressionType(dataType, 'value');
-        if (derivationInfo.hasValueArrayDataType) {
-          dataType = getArrayType(dataType);
-        }
-      }
-      else
-      if (derivationInfo.hasEntryDataType || derivationInfo.hasEntryArrayDataType){
-        dataType = getMapEntryType(dataType);
-        if (derivationInfo.hasEntryArrayDataType) {
-          dataType = getArrayType(dataType);
-        }
-      }
-      else 
-      if (derivation === 'median'){
-        dataType = getArrayElementType(dataType);
-        dataType = getMedianReturnDataTypeForArgumentDataType(dataType);
-      }
-      else
-      if (!derivationInfo.preservesColumnType){
-        console.warn(`Item ${QueryAxisItem.getIdForQueryAxisItem(queryAxisItem)} has derivation "${derivation}" which does not preserve column type and no column type set.`);
-      }
-    }
-
-    let aggregatorInfo, aggregator = queryAxisItem.aggregator;
-    if (aggregator) {
-      aggregatorInfo = AttributeUi.getAggregatorInfo(aggregator);
-      if (aggregatorInfo.columnType) {
-        dataType = aggregatorInfo.columnType;
-      }
-      else 
-      if (aggregatorInfo.preservesColumnType){
-        // noop
-      }
-      else
-      if (aggregatorInfo && typeof aggregatorInfo.getReturnDataTypeForArgumentDataType === 'function'){
-        dataType = aggregatorInfo.getReturnDataTypeForArgumentDataType(dataType);
-      }
-      else {
-        dataType = undefined;
-      }
-    }
-
-    return dataType;
-  }
-
-  // includeDisabledItems: if true then return all values, if not true then exclude values that have enabled===false;
-  static #getFilterAxisItemValuesListAsSqlLiterals(queryAxisItem, includeDisabledItems){
-    let sql;
-    const filter = queryAxisItem.filter;
-
-    const values = filter.values;
-    const toValues = filter.toValues;
-
-    let keys = Object.keys(values);
-    
-    if (includeDisabledItems !== true) {
-      keys = keys.filter((key) =>{
-        const valueObject = values[key];
-        return valueObject.enabled !== false;
-      });
-    }
-    
-    const isRangeFilterType = FilterDialog.isRangeFilterType(filter.filterType);
-    const toValueKeys = isRangeFilterType ? Object.keys(toValues) : undefined;
-    const toValueLiterals = isRangeFilterType ? [] : undefined;
-    const valueLiterals = keys.map((key, index) =>{
-      const entry = values[key];
-      if (isRangeFilterType) {
-        toValueLiterals.push( toValues[toValueKeys[index]].literal );
-      }
-      return entry.literal;
-    });
-    return {
-      valueLiterals: valueLiterals,
-      toValueLiterals: toValueLiterals
-    };
-  }
-
-  static isFilterItemEffective(queryAxisItem){
-    const filter = queryAxisItem.filter;
-    if (!filter) {
-      return undefined;
-    }
-    const literalLists = QueryAxisItem.#getFilterAxisItemValuesListAsSqlLiterals(queryAxisItem);
-    return literalLists.valueLiterals.length !== 0;
-  }
-
-  static getFilterConditionSql(queryAxisItem, alias){
-    if (!QueryAxisItem.isFilterItemEffective(queryAxisItem)) {
-      return undefined;
-    }
-    const filter = queryAxisItem.filter;
-
-    let columnExpression = QueryAxisItem.getSqlForQueryAxisItem(queryAxisItem, alias);
-    let dataType = QueryAxisItem.getQueryAxisItemDataType(queryAxisItem);          
-    if (dataType === 'VARCHAR' && filter.caseSensitive === false) {
-      columnExpression = `${columnExpression} COLLATE NOCASE`;
-    }
-
-    let operator = '';
-
-    let nullCondition;
-    const literalLists = QueryAxisItem.#getFilterAxisItemValuesListAsSqlLiterals(queryAxisItem);
-    const indexOfNull = literalLists.valueLiterals.findIndex((value) =>{
-      return value === 'NULL' || value.startsWith('NULL::');
-    });
-
-    if (indexOfNull !== -1) {
-      operator = 'IS';
-      if (FilterDialog.isExclusiveFilterType(filter.filterType)){
-        operator += ' NOT';
-      }
-      literalLists.valueLiterals.splice(indexOfNull, 1);
-      if (FilterDialog.isRangeFilterType(filter.filterType)){
-        literalLists.toValueLiterals.splice(indexOfNull, 1);
-      }
-      nullCondition = `${columnExpression} ${operator} NULL`;
-      operator = '';
-    }
-
-    let sql = '', logicalOperator;
-    let needsParentheses = false;
-    if (literalLists.valueLiterals.length > 0) {
-      switch (filter.filterType) {
-
-        // INCLUDE and EXCLUDE logic
-        case FilterDialog.filterTypes.EXCLUDE:
-          // in case of exclude, keep NULL values unless NULL is also in the valuelist.
-          // https://github.com/rpbouman/huey/issues/90
-          // TODO: if the column happens not to contain any nulls, we can omit this condition
-          if (indexOfNull === -1) {
-            sql = `${columnExpression} IS NULL OR `;
-            needsParentheses = true;
-          }
-          operator += literalLists.valueLiterals.length === 1 ? ' !' : ' NOT';
-          logicalOperator = 'AND';
-        case FilterDialog.filterTypes.INCLUDE:
-          operator += literalLists.valueLiterals.length === 1 ? '=' : ' IN';
-          let values = literalLists.valueLiterals.length === 1 ? literalLists.valueLiterals[0] : `( ${literalLists.valueLiterals.join('\n,')} )`;
-          
-          sql += `${columnExpression} ${operator} ${values}`;
-
-          if (indexOfNull !== -1) {
-            if (!logicalOperator) {
-              logicalOperator = 'OR';
-              needsParentheses = true;
-            }
-            sql = `${nullCondition} ${logicalOperator} ${sql}`;
-          }
-          sql = `( ${sql} )`;
-          break;
-
-        // LIKE and NOT LIKE logic
-        case FilterDialog.filterTypes.NOTLIKE:
-          operator = 'NOT ';
-          logicalOperator = 'AND';
-        case FilterDialog.filterTypes.LIKE:
-          let dataType = QueryAxisItem.getQueryAxisItemDataType(queryAxisItem);
-          if (dataType !== 'VARCHAR'){
-            columnExpression = `${columnExpression}::VARCHAR`;
-          }
-          operator += 'LIKE';
-          sql = literalLists.valueLiterals.reduce((acc, curr, currIndex) =>{
-            acc += '\n';
-            if (currIndex) {
-              if (!logicalOperator) {
-                logicalOperator = 'OR';
-                needsParentheses = true;
-              }
-              acc += logicalOperator + ' ';
-            }
-            const value = literalLists.valueLiterals[currIndex];
-            acc += `${columnExpression} ${operator} ${value}`;
-            return acc;
-          }, '');
-
-          if (indexOfNull === -1) {
-            // https://github.com/rpbouman/huey/issues/391
-            // This is essentially the same as 
-            // https://github.com/rpbouman/huey/issues/90
-            // but for NOT LIKE
-            if (filter.filterType === FilterDialog.filterTypes.NOTLIKE) {
-              nullCondition = `${columnExpression} IS NULL`;
-              if (literalLists.valueLiterals.length) {
-                sql = `(${sql}) OR ${nullCondition}`;
-                needsParentheses = true;
-              }
-              else {
-                sql = nullCondition;
-              }
-            }
-          }
-          else {
-            if (!logicalOperator) {
-              logicalOperator = 'OR';
-              needsParentheses = true;
-            }
-            sql = `${nullCondition} ${logicalOperator} ${sql}`;
-          }
-          break;
-
-        // BETWEEN and NOT BETWEEN logic
-        case FilterDialog.filterTypes.NOTBETWEEN:
-          operator = 'NOT ';
-          logicalOperator = 'AND';
-        case FilterDialog.filterTypes.BETWEEN:
-          operator += 'BETWEEN';
-          sql = literalLists.valueLiterals.reduce((acc, curr, currIndex) =>{
-            acc += '\n';
-            if (currIndex) {
-              if (!logicalOperator){
-                logicalOperator = 'OR';
-                needsParentheses = true;
-              }
-              acc += logicalOperator + ' ';
-            }
-            const fromValue = literalLists.valueLiterals[currIndex];
-            const toValue = literalLists.toValueLiterals[currIndex];
-            acc += `${columnExpression} ${operator} ${fromValue} AND ${toValue}`;
-            return acc;
-          }, '');
-
-          if (nullCondition) {
-            if (!logicalOperator){
-              logicalOperator = 'OR';
-              needsParentheses = true;
-            }
-            sql = `${nullCondition} ${logicalOperator} ${sql}`
-          }
-          break;        
-        case FilterDialog.filterTypes.NOTHASANY:
-        case FilterDialog.filterTypes.NOTHASALL:
-        case FilterDialog.filterTypes.HASANY:
-        case FilterDialog.filterTypes.HASALL:
-          let arrayFunction;
-          switch (filter.filterType){
-            case FilterDialog.filterTypes.HASANY:
-            case FilterDialog.filterTypes.NOTHASANY:
-              arrayFunction = 'list_has_any';
-              break;
-            case FilterDialog.filterTypes.HASALL:
-            case FilterDialog.filterTypes.NOTHASALL:
-              arrayFunction = 'list_has_all';
-              break;
-          }
-          let valueList = literalLists.valueLiterals.reduce((acc, curr, currIndex) =>{
-            const valueLiteral = literalLists.valueLiterals[currIndex];
-            acc.push(valueLiteral);
-            return acc;
-          }, []);
-          valueList = `[ ${valueList.join(',')} ]`;
-          sql = `${arrayFunction}( ${columnExpression}, ${valueList} )`;
-          if (FilterDialog.isExclusiveFilterType(filter.filterType)){
-            sql = `NOT ${sql}`;
-          }
-          break;
-      }
-    }
-    else {
-      sql = nullCondition;
-    }
-    if (needsParentheses) {
-      sql = `( ${sql} )`;
-    }
-    return sql;
-  }
-}
-
-export class QueryAxis {
-
-  #items = [];
-
-  static getCaptionForQueryAxis(queryAxis){
-    const items = queryAxis.getItems();
-    if (items.length === 0){
-      return '<empty>';
-    }
-    const itemKeys = Object.keys(items);
-    const captions = itemKeys.map((itemKey) =>{
-      const item = items[itemKey];
-      const caption = QueryAxisItem.getCaptionForQueryAxisItem(item);
-      return `"${caption}"`;
-    });
-    return captions.join(', ');
-  }
-
-  getCaption(){
-    return QueryAxis.getCaptionForQueryAxis(this);
-  }
-
-  findItem(config){
-    const columnName = config.columnName || '';
-    const derivation = config.derivation;
-    const aggregator = config.aggregator;
-    let memberExpressionPath = config.memberExpressionPath;
-    if (memberExpressionPath instanceof Array){
-      memberExpressionPath = JSON.stringify(memberExpressionPath);
-    }
-
-    const items = this.#items;
-    const itemIndex = items.findIndex((item) =>{
-      // check column name
-      if ((item.columnName || '') !== columnName){
-        return false;
-      }
-
-      // check member expression path
-      if (memberExpressionPath) {
-        if (!item.memberExpressionPath){
-          return false;
-        }
-        if (memberExpressionPath !== JSON.stringify(item.memberExpressionPath)) {
-          return false;
-        }
-      }
-      else
-      if (item.memberExpressionPath) {
-        return false;
-      }
-
-      // check derivation
-      if (derivation) {
-        if (item.derivation !== derivation) {
-          return false;
-        }
-      }
-      else
-      if (item.derivation){
-        return false;
-      }
-
-      // check aggregator
-      if (aggregator) {
-        if (item.aggregator !== aggregator){
-          return false;
-        }
-      }
-      else
-      if (item.aggregator){
-        return false;
-      }
-
-      // all checks passed
-      return true;
-    });
-
-    if (itemIndex === -1) {
-      return undefined;
-    }
-    const item = items[itemIndex];
-    const copyOfItem = Object.assign({}, item);
-    if (item.filter) {
-      copyOfItem.filter = JSON.parse(JSON.stringify(item.filter));
-    }
-    copyOfItem.index = itemIndex;
-    return copyOfItem;
-  }
-
-  addItem(config){
-    const copyOfConfig = Object.assign({}, config);
-    if (copyOfConfig.index === undefined) {
-      copyOfConfig.index = this.#items.length;
-    }
-    else {
-      if (copyOfConfig.index < 0) {
-        copyOfConfig.index = 0;
-      }
-      else
-      if (copyOfConfig.index > this.#items.length){
-        copyOfConfig.index = this.#items.length;
-      }
-    }
-    delete copyOfConfig['axis'];
-    this.#items.splice(copyOfConfig.index, 0, copyOfConfig);
-    return copyOfConfig;
-  }
-
-  removeItem(config){
-    const item = this.findItem(config);
-    if (!item){
-      return undefined;
-    }
-    this.#items.splice(item.index, 1);
-    return item;
-  }
-
-  clear(){
-    this.#items = [];
-  }
-
-  getItems() {
-    return [].concat(this.#items);
-  }
-  
-  syncItemIndices(){
-    this.#items.forEach((item, index) =>{
-      item.index = index;
-    })
-  }
-
-  getTotalsItems(){
-    const totalsItems = this.#items.filter((axisItem) =>{
-      return axisItem.includeTotals === true;
-    });
-    return totalsItems.length ? totalsItems : undefined;
-  }
-
-  setItems(items) {
-    this.#items = items;
-  }
-
-}
+// Re-export for backward compatibility — consumers can still import from this file
+export { QueryAxisItem } from './QueryAxisItem.js';
+export { QueryAxis } from './QueryAxis.js';
 
 export class QueryModel extends EventEmitter {
 
@@ -792,14 +87,14 @@ export class QueryModel extends EventEmitter {
     if (!sampling){
       return undefined;
     }
-    
+
     if (axisId === undefined){
       return sampling;
     }
-    
+
     return sampling[axisId];
   }
-  
+
   /**
    * @param {string} cellheadersaxis
    * @returns {void}
@@ -915,11 +210,11 @@ export class QueryModel extends EventEmitter {
     if (oldDatasource) {
       this.#datasource.removeEventListener('destroy', this.#destroyDatasourceHandler.bind(this));
     }
-    
+
     if (dontClear !== true) {
       this.#clear();
     }
-    
+
     this.#datasource = datasource;
 
     if (datasource){
@@ -1063,7 +358,7 @@ export class QueryModel extends EventEmitter {
         }
       }
     }
-    
+
     if (!config.parser) {
       if (foundItem && foundItem.parser) {
         config.parser = foundItem.parser;
@@ -1075,11 +370,11 @@ export class QueryModel extends EventEmitter {
         }
       }
     }
-    
+
     if (axis === QueryModel.AXIS_FILTERS && !config.filter && foundItem && foundItem.filter){
       config.filter = foundItem.filter;
     }
-    
+
     const axesChangeInfo = {};
     const eventData = {
       axesChanged: axesChangeInfo
@@ -1087,7 +382,7 @@ export class QueryModel extends EventEmitter {
     axesChangeInfo[config.axis] = {
       added: [config]
     };
-    
+
     if (foundItem){
       let axisChangeInfo = axesChangeInfo[foundItem.axis];
       if (!axisChangeInfo) {
@@ -1137,13 +432,13 @@ export class QueryModel extends EventEmitter {
     const eventData = {
       axesChanged: axesChangeInfo
     };
-    
+
     const oldAxisId = item.axis;
     axesChangeInfo[oldAxisId] = {
       removed: [item]
     };
     this.fireEvent('beforechange', eventData);
-    
+
     const axis = this.getQueryAxis(oldAxisId);
     const removedItem = axis.removeItem(item);
     axis.syncItemIndices();
@@ -1170,7 +465,7 @@ export class QueryModel extends EventEmitter {
     axesChangeInfo[axisId] = {
       changed: itemChangeInfo
     };
-    
+
     return axesChangeInfo;
   }
 
@@ -1192,19 +487,19 @@ export class QueryModel extends EventEmitter {
     const eventData = {
       axesChanged: axesChangeInfo
     };
-    
+
     const axisId = queryModelItem.axis;
     const axis = this.getQueryAxis(axisId);
     const items = axis.getItems();
     const item = items[queryModelItem.index];
-    
+
     const propertyName = 'includeTotals';
     axesChangeInfo = QueryModel.#getAxisItemChangeInfo(
-      item, 
-      propertyName, 
+      item,
+      propertyName,
       value
     );
-    
+
     this.fireEvent('beforechange', eventData);
     item[propertyName] = value;
     this.fireEvent('change', eventData);
@@ -1301,7 +596,7 @@ export class QueryModel extends EventEmitter {
     const eventData = {
       axesChanged: axesChangeInfo
     }
-    
+
     axesChangeInfo[axisId1] = {};
     axesChangeInfo[axisId2] = {};
 
@@ -1338,7 +633,7 @@ export class QueryModel extends EventEmitter {
     if (axisId !== QueryModel.AXIS_FILTERS){
       throw new Error(`Item is not a filter axis item!`);
     }
-    
+
     const queryModelItem = this.findItem(queryAxisItem);
     if (!queryModelItem) {
       throw new Error(`Item is not part of the model!`);
@@ -1357,11 +652,11 @@ export class QueryModel extends EventEmitter {
       filter = undefined;
     }
     const updatedQueryAxisItem = items[queryModelItem.index];
-    
+
     const propertyName = 'filter';
     const axesChangeInfo = QueryModel.#getAxisItemChangeInfo(
-      updatedQueryAxisItem, 
-      propertyName, 
+      updatedQueryAxisItem,
+      propertyName,
       filter
     );
     const eventData = {
@@ -1371,7 +666,7 @@ export class QueryModel extends EventEmitter {
     updatedQueryAxisItem[propertyName] = filter;
     this.fireEvent('change', eventData);
   }
-  
+
   /**
    * @param {QueryAxisItemConfig} queryAxisItem
    * @param {'open'|'closed'} toggleState
@@ -1381,7 +676,7 @@ export class QueryModel extends EventEmitter {
     if (queryAxisItem.axis !== QueryModel.AXIS_FILTERS){
       throw new Error(`Item is not a filter axis item!`);
     }
-    
+
     const queryModelItem = this.findItem(queryAxisItem);
     if (!queryModelItem) {
       throw new Error(`Item is not part of the model!`);
@@ -1393,8 +688,8 @@ export class QueryModel extends EventEmitter {
 
     const propertyName = 'toggleState';
     const axesChangeInfo = QueryModel.#getAxisItemChangeInfo(
-      item, 
-      propertyName, 
+      item,
+      propertyName,
       toggleState
     );
     const eventData = {
@@ -1449,7 +744,7 @@ export class QueryModel extends EventEmitter {
 
     // Sort the items.
     // The implied SQL condition is independent of the order of the items
-    // and by sorting, we make it easy to see if a change in the filter axis 
+    // and by sorting, we make it easy to see if a change in the filter axis
     // could actually affect the result.
     items = items.sort((filterItem1, filterItem2) =>{
       const id1 = QueryAxisItem.getIdForQueryAxisItem(filterItem1);
@@ -1463,13 +758,13 @@ export class QueryModel extends EventEmitter {
       }
       return 0;
     });
-    
+
     // Generate the SQL for each item.
     const conditions = items.map((item) =>{
       const itemCondition = QueryAxisItem.getFilterConditionSql(item, alias);
       return itemCondition;
     });
-    
+
     if (!conditions.length) {
       return undefined;
     }
@@ -1486,7 +781,7 @@ export class QueryModel extends EventEmitter {
   static compareStates(oldState, newState){
     oldState = oldState || {};
     newState = newState || {};
-    
+
     function getPropertyNames(){
       const propertyNames = {};
       for (let i = 0; i < arguments.length; i++){
@@ -1500,7 +795,7 @@ export class QueryModel extends EventEmitter {
       }
       return Object.keys(propertyNames);
     }
-    
+
     function compareObjects(oldState, newState, ignoreProperties){
       const propertiesChanged = {};
       const propertyNames = getPropertyNames(oldState, newState);
@@ -1511,11 +806,11 @@ export class QueryModel extends EventEmitter {
         }
         const oldValue = oldState[propertyName];
         const newValue = newState[propertyName];
-        
+
         if (JSON.stringify(oldValue) === JSON.stringify(newValue)) {
           continue;
         }
-        
+
         propertiesChanged[propertyName] = {
           oldValue: oldValue,
           newValue: newValue
@@ -1523,7 +818,7 @@ export class QueryModel extends EventEmitter {
       }
       return Object.keys(propertiesChanged).length ? propertiesChanged : undefined;
     }
-    
+
     function axisAsObject(axis){
       return axis.reduce((acc, curr) =>{
         const id = QueryAxisItem.getIdForQueryAxisItem(curr);
@@ -1531,7 +826,7 @@ export class QueryModel extends EventEmitter {
         return acc;
       }, {});
     }
-    
+
     const axesChanged = {};
     const oldAxes = oldState.axes || {};
     const newAxes = newState.axes || {};
@@ -1566,7 +861,7 @@ export class QueryModel extends EventEmitter {
           axisChange.added.push(newAxisItem);
         }
       }
-      
+
       if (!axisChange.added.length){
         delete axisChange.added;
       }
@@ -1580,7 +875,7 @@ export class QueryModel extends EventEmitter {
         axesChanged[axisId] = axisChange;
       }
     }
-    
+
     const stateChange = {};
     const propertiesChanged = compareObjects(oldState, newState, ['axes']) || {};
     if (Object.keys(propertiesChanged)){
@@ -1734,7 +1029,7 @@ export class QueryModel extends EventEmitter {
           await this.addItem(config);
         }
       }
-      
+
       const sampling = queryModelState.sampling || undefined;
       this.#sampling = sampling;
     }
@@ -1747,7 +1042,7 @@ export class QueryModel extends EventEmitter {
       }
     }
   }
-  
+
   /**
    * @param {QueryModelState} queryModelState
    * @returns {Object.<string, {columnType: string}>|null}
@@ -1774,6 +1069,9 @@ export class QueryModel extends EventEmitter {
   }
 
 }
+
+// Set forward reference so QueryAxisItem can check AXIS_FILTERS
+_setQueryModelRef(QueryModel);
 
 export let queryModel;
 export function initQueryModel(){

--- a/tests/unit/datasource-export.test.js
+++ b/tests/unit/datasource-export.test.js
@@ -1,0 +1,199 @@
+vi.mock('../../src/SettingsDialog/SettingsDialog.js', () => ({
+  settings: {
+    getSettings(keyPath) {
+      const key = Array.isArray(keyPath) ? keyPath[keyPath.length - 1] : keyPath;
+      const defaults = {
+        exportUi: { exportDestinationFile: false, exportDestinationClipboard: true },
+      };
+      return defaults[key] || {};
+    },
+    assignSettings() {},
+    addEventListener() {},
+    removeEventListener() {},
+  },
+}));
+
+vi.mock('../../src/ErrorDialog/ErrorDialog.js', () => ({
+  showErrorDialog: vi.fn(),
+  getDataFromError: vi.fn((e) => ({ title: String(e), description: String(e) })),
+  initErrorDialog: vi.fn(),
+}));
+
+vi.mock('../../src/PageStateManager/PageStateManager.js', () => ({
+  PageStateManager: class {
+    static getPageState() { return {}; }
+  },
+}));
+
+import {
+  datasourceExportMenuId,
+  getDownloadMenuHTML,
+  getDatasourceExportSettings,
+  getCaptionForDatasource,
+  sortDatasources,
+} from '../../src/DataSource/DataSourceExport.js';
+import { DuckDbDataSource } from '../../src/DataSource/duckdb/DuckDbDataSource.js';
+
+describe('DataSourceExport', () => {
+
+  describe('datasourceExportMenuId', () => {
+    it('should be the expected string constant', () => {
+      expect(datasourceExportMenuId).toBe('datasourceExportMenu');
+    });
+  });
+
+  describe('getDownloadMenuHTML', () => {
+    it('should return HTML string with menu element', () => {
+      const html = getDownloadMenuHTML();
+      expect(html).toContain('<menu');
+      expect(html).toContain(`id="${datasourceExportMenuId}"`);
+    });
+
+    it('should include all known file types', () => {
+      const html = getDownloadMenuHTML();
+      const fileTypes = Object.keys(DuckDbDataSource.fileTypes);
+      fileTypes.forEach(type => {
+        expect(html).toContain(`value="${type}"`);
+      });
+    });
+
+    it('should filter out fromFileType when includeFromFileType is false', () => {
+      const html = getDownloadMenuHTML('csv', false);
+      expect(html).not.toContain('value="csv"');
+    });
+
+    it('should include fromFileType when includeFromFileType is not false', () => {
+      const html = getDownloadMenuHTML('csv', true);
+      expect(html).toContain('value="csv"');
+    });
+
+    it('should include fromFileType by default', () => {
+      const html = getDownloadMenuHTML('csv');
+      expect(html).toContain('value="csv"');
+    });
+  });
+
+  describe('getDatasourceExportSettings', () => {
+    it('should return sqlite export settings', () => {
+      const settings = getDatasourceExportSettings('sqlite');
+      expect(settings.exportType).toBe('exportSqlite');
+      expect(settings.exportSqlite).toBe(true);
+      expect(settings.exportDelimited).toBe(false);
+      expect(settings.exportDestinationFile).toBe(true);
+      expect(settings.exportDestinationClipboard).toBe(false);
+    });
+
+    it('should return duckdb export settings', () => {
+      const settings = getDatasourceExportSettings('duckdb');
+      expect(settings.exportType).toBe('exportDuckdb');
+      expect(settings.exportDuckdb).toBe(true);
+    });
+
+    it('should return csv export settings', () => {
+      const settings = getDatasourceExportSettings('csv');
+      expect(settings.exportType).toBe('exportDelimited');
+      expect(settings.exportDelimited).toBe(true);
+    });
+
+    it('should return parquet export settings', () => {
+      const settings = getDatasourceExportSettings('parquet');
+      expect(settings.exportType).toBe('exportParquet');
+      expect(settings.exportParquet).toBe(true);
+    });
+
+    it('should override exportDestination settings from user prefs', () => {
+      const settings = getDatasourceExportSettings('csv');
+      // Should override the mock settings (clipboard=true → false, file=false → true)
+      expect(settings.exportDestinationFile).toBe(true);
+      expect(settings.exportDestinationClipboard).toBe(false);
+    });
+  });
+
+  describe('getCaptionForDatasource', () => {
+    function makeDatasource(type, overrides = {}) {
+      return {
+        getType: () => type,
+        getFileNameWithoutExtension: () => overrides.fileName || 'test_file',
+        getObjectName: () => overrides.objectName || 'test_table',
+        getBaseUrl: () => overrides.baseUrl || 'http://example.com',
+        getDatasetId: () => overrides.datasetId || 'dataset1',
+        getId: () => overrides.id || 'ds-123',
+      };
+    }
+
+    it('should return filename for FILE type', () => {
+      const ds = makeDatasource(DuckDbDataSource.types.FILE, { fileName: 'sales' });
+      expect(getCaptionForDatasource(ds)).toBe('sales');
+    });
+
+    it('should return filename for DUCKDB type', () => {
+      const ds = makeDatasource(DuckDbDataSource.types.DUCKDB, { fileName: 'mydb' });
+      expect(getCaptionForDatasource(ds)).toBe('mydb');
+    });
+
+    it('should return filename for SQLITE type', () => {
+      const ds = makeDatasource(DuckDbDataSource.types.SQLITE, { fileName: 'app' });
+      expect(getCaptionForDatasource(ds)).toBe('app');
+    });
+
+    it('should return object name for TABLE type', () => {
+      const ds = makeDatasource(DuckDbDataSource.types.TABLE, { objectName: 'users' });
+      expect(getCaptionForDatasource(ds)).toBe('users');
+    });
+
+    it('should return object name for VIEW type', () => {
+      const ds = makeDatasource(DuckDbDataSource.types.VIEW, { objectName: 'v_sales' });
+      expect(getCaptionForDatasource(ds)).toBe('v_sales');
+    });
+
+    it('should return object name for TABLEFUNCTION type', () => {
+      const ds = makeDatasource(DuckDbDataSource.types.TABLEFUNCTION, { objectName: 'fn1' });
+      expect(getCaptionForDatasource(ds)).toBe('fn1');
+    });
+
+    it('should return baseUrl + datasetId for remote type', () => {
+      const ds = makeDatasource('remote', { baseUrl: 'https://api.test', datasetId: 'ds42' });
+      expect(getCaptionForDatasource(ds)).toBe('https://api.test — ds42');
+    });
+
+    it('should return id for unknown type', () => {
+      const ds = makeDatasource('unknown-type', { id: 'custom-id' });
+      expect(getCaptionForDatasource(ds)).toBe('custom-id');
+    });
+  });
+
+  describe('sortDatasources', () => {
+    function makeDatasource(type, fileName) {
+      return {
+        getType: () => type,
+        getFileNameWithoutExtension: () => fileName,
+        getObjectName: () => fileName,
+        getId: () => fileName,
+      };
+    }
+
+    it('should sort datasources alphabetically by caption', () => {
+      const datasources = {
+        'ds3': makeDatasource(DuckDbDataSource.types.FILE, 'charlie'),
+        'ds1': makeDatasource(DuckDbDataSource.types.FILE, 'alpha'),
+        'ds2': makeDatasource(DuckDbDataSource.types.FILE, 'bravo'),
+      };
+      const sorted = sortDatasources(datasources);
+      const keys = Object.keys(sorted);
+      expect(keys).toEqual(['ds1', 'ds2', 'ds3']);
+    });
+
+    it('should handle empty datasources', () => {
+      const sorted = sortDatasources({});
+      expect(Object.keys(sorted)).toEqual([]);
+    });
+
+    it('should handle single datasource', () => {
+      const datasources = {
+        'ds1': makeDatasource(DuckDbDataSource.types.FILE, 'only'),
+      };
+      const sorted = sortDatasources(datasources);
+      expect(Object.keys(sorted)).toEqual(['ds1']);
+    });
+  });
+});

--- a/tests/unit/duckdb-datasource-config.test.js
+++ b/tests/unit/duckdb-datasource-config.test.js
@@ -1,0 +1,158 @@
+import {
+  datasourceTypes,
+  fileTypeDefinitions,
+  readerArguments,
+  getFileNameParts,
+  getFileTypeInfo,
+  globPathPattern,
+} from '../../src/DataSource/duckdb/DuckDbDataSourceConfig.js';
+
+describe('DuckDbDataSourceConfig', () => {
+
+  describe('datasourceTypes', () => {
+    it('should export all expected datasource type constants', () => {
+      expect(datasourceTypes.DUCKDB).toBe('duckdb');
+      expect(datasourceTypes.FILE).toBe('file');
+      expect(datasourceTypes.FILES).toBe('files');
+      expect(datasourceTypes.SQLITE).toBe('sqlite');
+      expect(datasourceTypes.SQLQUERY).toBe('sql');
+      expect(datasourceTypes.TABLE).toBe('table');
+      expect(datasourceTypes.TABLEFUNCTION).toBe('table function');
+      expect(datasourceTypes.URL).toBe('url');
+      expect(datasourceTypes.VIEW).toBe('view');
+    });
+  });
+
+  describe('fileTypeDefinitions', () => {
+    it('should define csv with read_csv reader', () => {
+      const csv = fileTypeDefinitions['csv'];
+      expect(csv).toBeDefined();
+      expect(csv.datasourceType).toBe(datasourceTypes.FILE);
+      expect(csv.duckdb_reader).toBe('read_csv');
+      expect(csv.duckdb_sniffer).toBe('sniff_csv');
+      expect(csv.mimeType).toBe('text/csv');
+    });
+
+    it('should define tsv with read_csv reader', () => {
+      const tsv = fileTypeDefinitions['tsv'];
+      expect(tsv).toBeDefined();
+      expect(tsv.duckdb_reader).toBe('read_csv');
+    });
+
+    it('should define json with read_json_auto reader', () => {
+      const json = fileTypeDefinitions['json'];
+      expect(json).toBeDefined();
+      expect(json.duckdb_reader).toBe('read_json_auto');
+      expect(json.duckdb_extension).toBe('json');
+    });
+
+    it('should define parquet with read_parquet reader', () => {
+      const parquet = fileTypeDefinitions['parquet'];
+      expect(parquet).toBeDefined();
+      expect(parquet.duckdb_reader).toBe('read_parquet');
+      expect(parquet.mimeType).toBe('application/vnd.apache.parquet');
+    });
+
+    it('should define xlsx with read_xlsx reader and excel extension', () => {
+      const xlsx = fileTypeDefinitions['xlsx'];
+      expect(xlsx).toBeDefined();
+      expect(xlsx.duckdb_reader).toBe('read_xlsx');
+      expect(xlsx.duckdb_extension).toBe('excel');
+    });
+
+    it('should define duckdb as DUCKDB datasource type', () => {
+      const duckdb = fileTypeDefinitions['duckdb'];
+      expect(duckdb).toBeDefined();
+      expect(duckdb.datasourceType).toBe(datasourceTypes.DUCKDB);
+    });
+
+    it('should define sqlite with sqlite_scanner extension', () => {
+      const sqlite = fileTypeDefinitions['sqlite'];
+      expect(sqlite).toBeDefined();
+      expect(sqlite.datasourceType).toBe(datasourceTypes.SQLITE);
+      expect(sqlite.duckdb_extension).toBe('sqlite_scanner');
+    });
+
+    it('should have entries for all expected file types', () => {
+      const expectedTypes = ['csv', 'tsv', 'txt', 'json', 'jsonl', 'parquet', 'xlsx', 'duckdb', 'sqlite'];
+      expectedTypes.forEach(type => {
+        expect(fileTypeDefinitions[type]).toBeDefined();
+      });
+    });
+  });
+
+  describe('readerArguments', () => {
+    it('should define read_csv arguments', () => {
+      expect(readerArguments.read_csv).toBeDefined();
+      expect(readerArguments.read_csv.store_rejects).toBe(false);
+    });
+
+    it('should define sniff_csv arguments', () => {
+      expect(readerArguments.sniff_csv).toBeDefined();
+      expect(readerArguments.sniff_csv.sample_size).toBe(20480);
+    });
+
+    it('should define read_json_auto arguments', () => {
+      expect(readerArguments.read_json_auto).toBeDefined();
+      expect(readerArguments.read_json_auto.ignore_errors).toBe(true);
+      expect(readerArguments.read_json_auto.maximum_object_size).toBe(16777216);
+    });
+  });
+
+  describe('getFileNameParts', () => {
+    it('should parse a simple filename', () => {
+      const result = getFileNameParts('data.csv');
+      expect(result.extension).toBe('csv');
+      expect(result.lowerCaseExtension).toBe('csv');
+      expect(result.fileNameWithoutExtension).toBe('data');
+    });
+
+    it('should handle uppercase extensions', () => {
+      const result = getFileNameParts('data.CSV');
+      expect(result.extension).toBe('CSV');
+      expect(result.lowerCaseExtension).toBe('csv');
+      expect(result.fileNameWithoutExtension).toBe('data');
+    });
+
+    it('should handle filenames with multiple dots', () => {
+      const result = getFileNameParts('my.data.file.parquet');
+      expect(result.extension).toBe('parquet');
+      expect(result.fileNameWithoutExtension).toBe('my.data.file');
+    });
+
+    it('should return undefined for filenames without extension', () => {
+      expect(getFileNameParts('noextension')).toBeUndefined();
+    });
+
+    it('should handle File objects', () => {
+      const file = new File([''], 'test.json', { type: 'application/json' });
+      const result = getFileNameParts(file);
+      expect(result.extension).toBe('json');
+      expect(result.fileNameWithoutExtension).toBe('test');
+    });
+  });
+
+  describe('getFileTypeInfo', () => {
+    it('should return file type info for known types', () => {
+      expect(getFileTypeInfo('csv')).toBe(fileTypeDefinitions['csv']);
+      expect(getFileTypeInfo('parquet')).toBe(fileTypeDefinitions['parquet']);
+    });
+
+    it('should return undefined for unknown types', () => {
+      expect(getFileTypeInfo('unknown')).toBeUndefined();
+    });
+  });
+
+  describe('globPathPattern', () => {
+    it('should match glob characters', () => {
+      expect(globPathPattern.test('*.csv')).toBe(true);
+      expect(globPathPattern.test('data?.csv')).toBe(true);
+      expect(globPathPattern.test('[a-z].csv')).toBe(true);
+    });
+
+    it('should not match plain filenames', () => {
+      expect(globPathPattern.test('data.csv')).toBe(false);
+      expect(globPathPattern.test('path/to/file.parquet')).toBe(false);
+    });
+  });
+});

--- a/tests/unit/pivot-table-ui-utils.test.js
+++ b/tests/unit/pivot-table-ui-utils.test.js
@@ -1,0 +1,204 @@
+import {
+  pivotTableUiDefaults,
+  getTotalsItemsIndices,
+  isTotalsMember,
+  getDittoMark,
+  getHideRepeatingAxisValues,
+  getMaxCellWidth,
+} from '../../src/PivotTableUi/PivotTableUiUtils.js';
+
+describe('PivotTableUiUtils', () => {
+
+  describe('pivotTableUiDefaults', () => {
+    it('should export expected default values', () => {
+      expect(pivotTableUiDefaults.resizeTimeout).toBe(1000);
+      expect(pivotTableUiDefaults.scrollTimeout).toBe(500);
+      expect(pivotTableUiDefaults.columnHeaderResizeTimeout).toBe(500);
+      expect(pivotTableUiDefaults.maximumCellWidth).toBe(30);
+      expect(pivotTableUiDefaults.defaultDittoMark).toBe('〃');
+      expect(pivotTableUiDefaults.defaultHideRepeatingAxisValues).toBe(true);
+      expect(pivotTableUiDefaults.defaultPageSize).toBe(100);
+      expect(pivotTableUiDefaults.templateId).toBe('pivotTableUiTemplate');
+    });
+  });
+
+  describe('getTotalsItemsIndices', () => {
+    it('should return undefined for null/empty input', () => {
+      expect(getTotalsItemsIndices(null)).toBeUndefined();
+      expect(getTotalsItemsIndices([])).toBeUndefined();
+      expect(getTotalsItemsIndices(undefined)).toBeUndefined();
+    });
+
+    it('should return undefined when no items have includeTotals', () => {
+      const items = [
+        { columnName: 'a' },
+        { columnName: 'b' },
+      ];
+      const result = getTotalsItemsIndices(items);
+      expect(result).toEqual([]);
+    });
+
+    it('should return indices of items with includeTotals in reverse order', () => {
+      const items = [
+        { columnName: 'a', includeTotals: true },
+        { columnName: 'b' },
+        { columnName: 'c', includeTotals: true },
+      ];
+      const result = getTotalsItemsIndices(items);
+      expect(result).toEqual([2, 0]);
+    });
+
+    it('should return single index when one item has includeTotals', () => {
+      const items = [
+        { columnName: 'a' },
+        { columnName: 'b', includeTotals: true },
+      ];
+      const result = getTotalsItemsIndices(items);
+      expect(result).toEqual([1]);
+    });
+
+    it('should return all indices when all items have includeTotals', () => {
+      const items = [
+        { includeTotals: true },
+        { includeTotals: true },
+        { includeTotals: true },
+      ];
+      const result = getTotalsItemsIndices(items);
+      expect(result).toEqual([2, 1, 0]);
+    });
+  });
+
+  describe('isTotalsMember', () => {
+    it('should return Infinity when groupingId is falsy', () => {
+      expect(isTotalsMember(undefined, [0], 0)).toBe(Infinity);
+      expect(isTotalsMember(null, [0], 0)).toBe(Infinity);
+      expect(isTotalsMember(0n, [0], 0)).toBe(Infinity);
+    });
+
+    it('should return Infinity when totalsItemsIndices is empty or null', () => {
+      expect(isTotalsMember(1n, null, 0)).toBe(Infinity);
+      expect(isTotalsMember(1n, [], 0)).toBe(Infinity);
+      expect(isTotalsMember(1n, undefined, 0)).toBe(Infinity);
+    });
+
+    it('should return Infinity when currentItemIndex is undefined', () => {
+      expect(isTotalsMember(1n, [0], undefined)).toBe(Infinity);
+    });
+
+    it('should identify totals member with single totals item', () => {
+      // groupingId = 1n means bit 0 is set
+      const result = isTotalsMember(1n, [2], 0);
+      expect(result).toBe(2);
+    });
+
+    it('should identify totals member with multiple totals items', () => {
+      // groupingId = 2n means bit 1 is set (the higher-order bit)
+      // With totalsItemsIndices [1, 0], i starts at 1n, bit 1 is set, so returns totalsItemsIndices[1] = 0
+      const result = isTotalsMember(2n, [1, 0], 0);
+      expect(result).toBe(0);
+    });
+
+    it('should return Infinity when no bits match', () => {
+      // groupingId has no bits set that correspond to totals indices
+      const result = isTotalsMember(0n, [0], 0);
+      expect(result).toBe(Infinity);
+    });
+  });
+
+  describe('getDittoMark', () => {
+    it('should return default ditto mark when settings is null', () => {
+      expect(getDittoMark(null)).toBe('〃');
+    });
+
+    it('should return default ditto mark when settings is undefined', () => {
+      expect(getDittoMark(undefined)).toBe('〃');
+    });
+
+    it('should return custom ditto mark from plain settings object', () => {
+      const settings = { dittoMark: '″' };
+      expect(getDittoMark(settings)).toBe('″');
+    });
+
+    it('should use getSettings method when available', () => {
+      const settings = {
+        getSettings(key) {
+          if (key === 'pivotSettings') return { dittoMark: '--' };
+          return {};
+        }
+      };
+      expect(getDittoMark(settings)).toBe('--');
+    });
+
+    it('should return default when getSettings returns no dittoMark', () => {
+      const settings = {
+        getSettings() { return {}; }
+      };
+      expect(getDittoMark(settings)).toBe('〃');
+    });
+  });
+
+  describe('getHideRepeatingAxisValues', () => {
+    it('should return true by default when settings is null', () => {
+      expect(getHideRepeatingAxisValues(null)).toBe(true);
+    });
+
+    it('should return true by default when settings is undefined', () => {
+      expect(getHideRepeatingAxisValues(undefined)).toBe(true);
+    });
+
+    it('should return false when setting is explicitly false', () => {
+      const settings = { hideRepeatingAxisValues: false };
+      expect(getHideRepeatingAxisValues(settings)).toBe(false);
+    });
+
+    it('should use getSettings method when available', () => {
+      const settings = {
+        getSettings(key) {
+          if (key === 'pivotSettings') return { hideRepeatingAxisValues: false };
+          return {};
+        }
+      };
+      expect(getHideRepeatingAxisValues(settings)).toBe(false);
+    });
+  });
+
+  describe('getMaxCellWidth', () => {
+    it('should return 30 by default when settings is null', () => {
+      expect(getMaxCellWidth(null)).toBe(30);
+    });
+
+    it('should return 30 by default when settings is undefined', () => {
+      expect(getMaxCellWidth(undefined)).toBe(30);
+    });
+
+    it('should parse and return custom width from settings', () => {
+      const settings = { maxCellWidth: '50' };
+      expect(getMaxCellWidth(settings)).toBe(50);
+    });
+
+    it('should return default for zero width', () => {
+      const settings = { maxCellWidth: '0' };
+      expect(getMaxCellWidth(settings)).toBe(30);
+    });
+
+    it('should return default for negative width', () => {
+      const settings = { maxCellWidth: '-5' };
+      expect(getMaxCellWidth(settings)).toBe(30);
+    });
+
+    it('should return default for non-numeric width', () => {
+      const settings = { maxCellWidth: 'abc' };
+      expect(getMaxCellWidth(settings)).toBe(30);
+    });
+
+    it('should use getSettings method when available', () => {
+      const settings = {
+        getSettings(key) {
+          if (key === 'pivotSettings') return { maxCellWidth: '100' };
+          return {};
+        }
+      };
+      expect(getMaxCellWidth(settings)).toBe(100);
+    });
+  });
+});

--- a/tests/unit/query-axis.test.js
+++ b/tests/unit/query-axis.test.js
@@ -1,0 +1,221 @@
+vi.mock('../../src/SettingsDialog/SettingsDialog.js', () => ({
+  settings: {
+    getSettings(keyPath) {
+      const key = Array.isArray(keyPath) ? keyPath[keyPath.length - 1] : keyPath;
+      const defaults = {
+        sqlSettings: { alwaysQuoteIdentifiers: false, keywordLetterCase: 'upperCase', commaStyle: 'newlineBefore' },
+        localeSettings: { nullString: 'NULL', locale: ['en-US'] },
+      };
+      return defaults[key] || {};
+    },
+    assignSettings() {},
+    addEventListener() {},
+    removeEventListener() {},
+  },
+}));
+
+vi.mock('../../src/ErrorDialog/ErrorDialog.js', () => ({
+  showErrorDialog: vi.fn(),
+  getDataFromError: vi.fn((e) => ({ title: String(e), description: String(e) })),
+  initErrorDialog: vi.fn(),
+}));
+
+import { QueryAxis } from '../../src/QueryModel/QueryModel.js';
+
+describe('QueryAxis', () => {
+  let axis;
+
+  beforeEach(() => {
+    axis = new QueryAxis();
+  });
+
+  describe('addItem', () => {
+    it('should add an item and return it with an index', () => {
+      const result = axis.addItem({ columnName: 'col1', columnType: 'VARCHAR' });
+      expect(result.columnName).toBe('col1');
+      expect(result.index).toBe(0);
+    });
+
+    it('should add multiple items with sequential indices', () => {
+      axis.addItem({ columnName: 'col1' });
+      axis.addItem({ columnName: 'col2' });
+      const items = axis.getItems();
+      expect(items.length).toBe(2);
+      expect(items[0].columnName).toBe('col1');
+      expect(items[1].columnName).toBe('col2');
+    });
+
+    it('should insert at specific index', () => {
+      axis.addItem({ columnName: 'col1' });
+      axis.addItem({ columnName: 'col3' });
+      axis.addItem({ columnName: 'col2', index: 1 });
+      const items = axis.getItems();
+      expect(items[1].columnName).toBe('col2');
+    });
+
+    it('should clamp negative index to 0', () => {
+      axis.addItem({ columnName: 'col1' });
+      axis.addItem({ columnName: 'col0', index: -5 });
+      const items = axis.getItems();
+      expect(items[0].columnName).toBe('col0');
+    });
+
+    it('should clamp out-of-bounds index to end', () => {
+      axis.addItem({ columnName: 'col1' });
+      axis.addItem({ columnName: 'col2', index: 100 });
+      const items = axis.getItems();
+      expect(items[1].columnName).toBe('col2');
+    });
+
+    it('should not include axis property in the added item', () => {
+      const result = axis.addItem({ columnName: 'col1', axis: 'rows' });
+      expect(result.axis).toBeUndefined();
+    });
+  });
+
+  describe('findItem', () => {
+    it('should find an item by columnName', () => {
+      axis.addItem({ columnName: 'col1' });
+      const found = axis.findItem({ columnName: 'col1' });
+      expect(found).toBeDefined();
+      expect(found.columnName).toBe('col1');
+      expect(found.index).toBe(0);
+    });
+
+    it('should return undefined when item not found', () => {
+      axis.addItem({ columnName: 'col1' });
+      const found = axis.findItem({ columnName: 'col2' });
+      expect(found).toBeUndefined();
+    });
+
+    it('should find item by columnName and derivation', () => {
+      axis.addItem({ columnName: 'date_col', derivation: 'year' });
+      axis.addItem({ columnName: 'date_col', derivation: 'month' });
+      const found = axis.findItem({ columnName: 'date_col', derivation: 'month' });
+      expect(found).toBeDefined();
+      expect(found.derivation).toBe('month');
+      expect(found.index).toBe(1);
+    });
+
+    it('should find item by columnName and aggregator', () => {
+      axis.addItem({ columnName: 'amount', aggregator: 'sum' });
+      axis.addItem({ columnName: 'amount', aggregator: 'avg' });
+      const found = axis.findItem({ columnName: 'amount', aggregator: 'avg' });
+      expect(found).toBeDefined();
+      expect(found.aggregator).toBe('avg');
+    });
+
+    it('should return a copy of the item (not the original)', () => {
+      axis.addItem({ columnName: 'col1' });
+      const found = axis.findItem({ columnName: 'col1' });
+      found.columnName = 'modified';
+      const foundAgain = axis.findItem({ columnName: 'col1' });
+      expect(foundAgain).toBeDefined();
+    });
+
+    it('should deep copy filter when present', () => {
+      axis.addItem({ columnName: 'col1', filter: { values: [1, 2, 3] } });
+      const found = axis.findItem({ columnName: 'col1' });
+      found.filter.values.push(4);
+      const foundAgain = axis.findItem({ columnName: 'col1' });
+      expect(foundAgain.filter.values).toEqual([1, 2, 3]);
+    });
+
+    it('should match memberExpressionPath as array', () => {
+      axis.addItem({ columnName: 'col1', memberExpressionPath: ['a', 'b'] });
+      const found = axis.findItem({ columnName: 'col1', memberExpressionPath: ['a', 'b'] });
+      expect(found).toBeDefined();
+    });
+
+    it('should not match when memberExpressionPath differs', () => {
+      axis.addItem({ columnName: 'col1', memberExpressionPath: ['a', 'b'] });
+      const found = axis.findItem({ columnName: 'col1', memberExpressionPath: ['a', 'c'] });
+      expect(found).toBeUndefined();
+    });
+  });
+
+  describe('removeItem', () => {
+    it('should remove an existing item', () => {
+      axis.addItem({ columnName: 'col1' });
+      axis.addItem({ columnName: 'col2' });
+      const removed = axis.removeItem({ columnName: 'col1' });
+      expect(removed).toBeDefined();
+      expect(removed.columnName).toBe('col1');
+      expect(axis.getItems().length).toBe(1);
+    });
+
+    it('should return undefined when item not found', () => {
+      const removed = axis.removeItem({ columnName: 'nonexistent' });
+      expect(removed).toBeUndefined();
+    });
+  });
+
+  describe('clear', () => {
+    it('should remove all items', () => {
+      axis.addItem({ columnName: 'col1' });
+      axis.addItem({ columnName: 'col2' });
+      axis.clear();
+      expect(axis.getItems().length).toBe(0);
+    });
+  });
+
+  describe('getItems', () => {
+    it('should return a copy of the items array', () => {
+      axis.addItem({ columnName: 'col1' });
+      const items = axis.getItems();
+      items.push({ columnName: 'col2' });
+      expect(axis.getItems().length).toBe(1);
+    });
+  });
+
+  describe('syncItemIndices', () => {
+    it('should update indices after removal', () => {
+      axis.addItem({ columnName: 'col1' });
+      axis.addItem({ columnName: 'col2' });
+      axis.addItem({ columnName: 'col3' });
+      axis.removeItem({ columnName: 'col1' });
+      axis.syncItemIndices();
+      const items = axis.getItems();
+      expect(items[0].index).toBe(0);
+      expect(items[1].index).toBe(1);
+    });
+  });
+
+  describe('getTotalsItems', () => {
+    it('should return undefined when no items have includeTotals', () => {
+      axis.addItem({ columnName: 'col1' });
+      expect(axis.getTotalsItems()).toBeUndefined();
+    });
+
+    it('should return items with includeTotals', () => {
+      axis.addItem({ columnName: 'col1', includeTotals: true });
+      axis.addItem({ columnName: 'col2' });
+      const totals = axis.getTotalsItems();
+      expect(totals).toBeDefined();
+      expect(totals.length).toBe(1);
+      expect(totals[0].columnName).toBe('col1');
+    });
+  });
+
+  describe('getCaption', () => {
+    it('should return <empty> for empty axis', () => {
+      expect(axis.getCaption()).toBe('<empty>');
+    });
+
+    it('should return quoted item caption for single item', () => {
+      axis.addItem({ columnName: 'col1', columnType: 'INTEGER' });
+      const caption = axis.getCaption();
+      expect(caption).toContain('col1');
+    });
+  });
+
+  describe('setItems', () => {
+    it('should replace all items', () => {
+      axis.addItem({ columnName: 'col1' });
+      axis.setItems([{ columnName: 'new1' }, { columnName: 'new2' }]);
+      const items = axis.getItems();
+      expect(items.length).toBe(2);
+      expect(items[0].columnName).toBe('new1');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Splits the 4 largest files (QueryModel 1642→940, DuckDbDataSource 1329→1172, PivotTableUi 2620→2565, DataSourcesUi 1020→900 lines) into smaller, focused modules
- Full backward compatibility maintained via re-exports and delegation — no consumer changes needed
- Added 95 new unit tests (121→216 total) covering all extracted modules
- Build verified: 88 modules, 270 KB JS bundle, all 216 tests passing

### Extracted modules
| Original | Extracted | Lines | Content |
|---|---|---|---|
| QueryModel.js | QueryAxisItem.js | 576 | QueryAxisItem class + formatting/SQL/filter logic |
| QueryModel.js | QueryAxis.js | 146 | QueryAxis class with CRUD operations |
| DuckDbDataSource.js | DuckDbDataSourceConfig.js | 206 | Type constants, file type definitions, reader args, filename utilities |
| PivotTableUi.js | PivotTableUiUtils.js | 128 | Totals calculation, settings helpers, configuration defaults |
| DataSourcesUi.js | DataSourceExport.js | 182 | Export menu HTML, format prompt, export settings, datasource captions/sorting |

Closes #255

## Test plan
- [x] All 216 unit tests pass (95 new)
- [x] Vite build succeeds with correct module count
- [x] Bundle size unchanged (~270 KB JS)
- [ ] Manual smoke test of pivot table rendering
- [ ] Manual smoke test of datasource export/download
- [ ] Manual smoke test of query model operations (add/remove axis items)

🤖 Generated with [Claude Code](https://claude.com/claude-code)