### PR TITLE
refactor: extract HTML templates into component files

### DIFF
--- a/src/AttributeUi/AttributeUi.js
+++ b/src/AttributeUi/AttributeUi.js
@@ -1,7 +1,8 @@
 import { QueryAxisItem, QueryAxis, QueryModel, queryModel } from '../QueryModel/QueryModel.js';
 import { Internationalization } from '../Internationalization/Internationalization.js';
 import { DragAndDropHelper } from '../DragAndDrop/DragAndDropHelper.js';
-import { byId, createEl, instantiateTemplate, setAttributes, getAncestorWithTagName, getClassNames } from '../util/dom/dom.js';
+import { byId, createEl, instantiateTemplate, setAttributes, getAncestorWithTagName, getClassNames, registerTemplates } from '../util/dom/dom.js';
+import attributeTemplatesHtml from './templates.html?raw';
 import { showErrorDialog } from '../ErrorDialog/ErrorDialog.js';
 import {
   getDataTypeInfo,
@@ -783,6 +784,7 @@ export class AttributeUi {
   }
 
   constructor(id, queryModel){
+    registerTemplates(attributeTemplatesHtml);
     this.#id = id;
     this.#queryModel = queryModel;
 

--- a/src/AttributeUi/templates.html
+++ b/src/AttributeUi/templates.html
@@ -1,0 +1,24 @@
+<template id="attribute-node">
+  <details role="treeitem" data-nodetype="">
+    <summary>
+      <span class="label"></span>
+    </summary>
+  </details>
+</template>
+
+<template id="attribute-node-axis-dummybutton">
+  <span class="attributeUiAxisButton" data-axis=""></span>
+</template>
+
+<template id="attribute-node-axis-checkbox">
+  <label
+    class="attributeUiAxisButton"
+    data-axis=""
+    data-title-checked=""
+    data-title-unchecked=""
+    title=""
+    for=""
+  >
+    <input type="checkbox"/>
+  </label>
+</template>

--- a/src/DataSource/DataSourcesUi.js
+++ b/src/DataSource/DataSourcesUi.js
@@ -1,5 +1,6 @@
 import { EventEmitter } from '../util/event/EventEmitter.js';
-import { byId, instantiateTemplate } from '../util/dom/dom.js';
+import { byId, instantiateTemplate, registerTemplates } from '../util/dom/dom.js';
+import dataSourceTemplatesHtml from './templates.html?raw';
 import { settings } from '../SettingsDialog/SettingsDialog.js';
 import { DuckDbDataSource } from './duckdb/DuckDbDataSource.js';
 import { Internationalization } from '../Internationalization/Internationalization.js';
@@ -27,6 +28,7 @@ export class DataSourcesUi extends EventEmitter {
 
   constructor(id){
     super(['change']);
+    registerTemplates(dataSourceTemplatesHtml);
     this.#id = id;
 
     const dom = this.getDom();

--- a/src/DataSource/templates.html
+++ b/src/DataSource/templates.html
@@ -1,0 +1,54 @@
+<template id="dataSourceGroupNodeActionButton">
+  <label
+    class="${class}"
+    for="${id}"
+    title="${title}"
+  >
+    <button id="${id}" aria-label="${title}"></button>
+  </label>
+</template>
+
+<template id="dataSourceNode">
+  <details
+    role="treeitem"
+    data-nodetype="datasource"
+    data-datasourcetype="${datasourceType}"
+    title="${title}"
+  >
+    <summary>
+      <span class="label i18nIgnore">${caption}</span>
+    </summary>
+  </details>
+</template>
+
+<template id="dataSourceGroupNode">
+  <details
+    role="treeitem"
+    data-nodetype="datasourcegroup"
+    title="${title}"
+    data-grouptype="${group-type}"
+    data-datasourceids="${datasource-list}"
+    open="true"
+  >
+    <summary>
+      <span class="label">${caption}</span>
+    </summary>
+  </details>
+</template>
+
+<template id="dataSourceSchemaNode">
+  <details
+    role="treeitem"
+    data-nodetype="duckdb_schema"
+    title="${title}"
+    data-grouptype="${group-type}"
+    data-datasourceids="${datasource-list}"
+    data-catalog-name="${catalogName}"
+    data-schema-name="${schemaName}"
+    open="true"
+  >
+    <summary>
+      <span class="label i18nIgnore">${caption}</span>
+    </summary>
+  </details>
+</template>

--- a/src/DataSourceMenu/DataSourceMenu.js
+++ b/src/DataSourceMenu/DataSourceMenu.js
@@ -1,16 +1,18 @@
-import { byId } from '../util/dom/dom.js';
+import { byId, registerTemplates } from '../util/dom/dom.js';
 import { bufferEvents } from '../util/event/EventBuffer.js';
 import { QueryModel, queryModel } from '../QueryModel/QueryModel.js';
 import { datasourcesUi } from '../DataSource/DataSourcesUi.js';
+import dataSourceMenuTemplatesHtml from './templates.html?raw';
 
 export class DataSourceMenu {
- 
+
   #id = undefined;
   #queryModel = undefined;
   #datasourcesUi = undefined;
   #queryModelStateBeforeChange;
- 
+
   constructor(id, queryModel, datasourcesUi){
+    registerTemplates(dataSourceMenuTemplatesHtml);
     this.#id = id;
     this.#queryModel = queryModel;
     this.#datasourcesUi = datasourcesUi;

--- a/src/DataSourceMenu/templates.html
+++ b/src/DataSourceMenu/templates.html
@@ -1,0 +1,18 @@
+<template id="datasource-menu-item">
+  <li
+    role="menuitem"
+    data-nodetype="datasource"
+    data-datasourcetype=""
+    data-datasource-id=""
+    popovertarget="dataSourceMenu"
+  >
+    <input
+      type="radio"
+      name="compatibleDatasources"
+    />
+    <button
+      popovertarget="dataSourceMenu"
+    ></button>
+    <label for="datasourceMenu-${index}"></label>
+  </li>
+</template>

--- a/src/PivotTableUi/PivotTableUi.js
+++ b/src/PivotTableUi/PivotTableUi.js
@@ -1,6 +1,7 @@
 import { EventEmitter } from '../util/event/EventEmitter.js';
 import { bufferEvents } from '../util/event/EventBuffer.js';
-import { byId, instantiateTemplate, hasClass, getChildWithClassName, createEl } from '../util/dom/dom.js';
+import { byId, instantiateTemplate, hasClass, getChildWithClassName, createEl, registerTemplates } from '../util/dom/dom.js';
+import pivotTableTemplatesHtml from './templates.html?raw';
 import { settings } from '../SettingsDialog/SettingsDialog.js';
 import { ContextMenu } from '../ContextMenu/ContextMenu.js';
 import { TupleSet } from '../DataSet/TupleSet.js';
@@ -48,6 +49,7 @@ export class PivotTableUi extends EventEmitter {
 
   constructor(config){
     super(['updated', 'busy']);
+    registerTemplates(pivotTableTemplatesHtml);
     this.#initDom(config);
     this.#id = config.id;
 

--- a/src/PivotTableUi/templates.html
+++ b/src/PivotTableUi/templates.html
@@ -1,0 +1,30 @@
+<template id="pivotTableUiTemplate">
+  <!-- pivotTableUi: outmost container of the pivot table-->
+  <div
+    id=""
+    class="pivotTableUiContainer"
+    style="
+      flex-grow: 1;
+      width: 100%;
+      height: 100%;
+      border-width: 1px;
+      border-color: var( --huey-dark-border-color );
+      border-top-style: solid;
+    "
+    aria-busy="false"
+    data-needs-update="false"
+  >
+    <div class="pivotTableUiInnerContainer">
+      <!-- pivotTableColumnsSizer: sizer to generate the horizontal scrollbar -->
+      <div class="pivotTableUiSizer pivotTableUiHorizontalSizer"></div>
+      <!-- pivotTableColumnsSizer: sizer to generate the vertical scrollbar -->
+      <div class="pivotTableUiSizer pivotTableUiVerticalSizer"></div>
+
+      <!-- the actual table structure -->
+      <div class="pivotTableUiTable" role="grid">
+        <div class="pivotTableUiTableHeader" role="rowgroup"></div>
+        <div class="pivotTableUiTableBody" role="rowgroup"></div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/QueryUi/QueryUi.js
+++ b/src/QueryUi/QueryUi.js
@@ -1,4 +1,5 @@
-import { byId, instantiateTemplate } from '../util/dom/dom.js';
+import { byId, instantiateTemplate, registerTemplates } from '../util/dom/dom.js';
+import queryUiTemplatesHtml from './templates.html?raw';
 import { Internationalization } from '../Internationalization/Internationalization.js';
 import { QueryModel, QueryAxisItem, queryModel } from '../QueryModel/QueryModel.js';
 import { DragAndDropHelper } from '../DragAndDrop/DragAndDropHelper.js';
@@ -18,6 +19,7 @@ export class QueryUi {
   #filterDialog = filterDialog;
 
   constructor(config){
+    registerTemplates(queryUiTemplatesHtml);
     this.#container = config.container
     this.#id = config.id || 'queryUi';
 

--- a/src/QueryUi/templates.html
+++ b/src/QueryUi/templates.html
@@ -1,0 +1,92 @@
+<template id="queryUiTemplate">
+  <div
+    id=""
+    class="queryUi"
+    data-cellheadersaxis="columns"
+  >
+  </div>
+</template>
+
+<template id="queryUiAxis">
+  <section>
+    <header>
+      <label><button id="-axis-primary-action" aria-label="Axis primary action"></button></label>
+      <h1></h1>
+    </header>
+    <ol>
+    </ol>
+    <footer>
+      <label title="Remove all items from this axis"><button id="-clear-axis">Clear axis</button></label>
+    </footer>
+  </section>
+</template>
+
+<template id="queryUiAxisItem">
+  <li draggable="true">
+    <label title="Move this item to the left">
+      <button id="-move-left">Move this item to the left</button>
+    </label>
+    <span></span>
+    <menu>
+      <label title="Calculate totals for this level">
+        <input id="-toggle-totals" type="checkbox"/>
+      </label>
+      <label title="Move this item to the other axis">
+        <button id="-move-to-other-axis">Move this item to the other axis</button>
+      </label>
+      <label title="Remove this item from the axis">
+        <button id="-remove-from-axis">Remove this item from the axis</button>
+      </label>
+    </menu>
+    <label title="Move this item to the right">
+      <button id="-move-right">Move this item to the right</button>
+    </label>
+  </li>
+</template>
+
+<template id="queryUiFilterAxisItemValue">
+  <li role="menuitem">
+    <label
+      title="Use the checkbox to enable/disable this condition"
+      for=""
+    >
+      <span></span>
+      <input
+        id=""
+        type="checkbox"
+      />
+    </label>
+    <label
+      title="Remove this filter condition"
+      for=""
+    >
+      <button></button>
+    </label>
+  </li>
+</template>
+
+<template id="queryUiFilterAxisItem">
+  <li draggable="true">
+    <label title="Move this item to the left">
+      <button id="-move-left">Move this item to the left</button>
+    </label>
+    <details>
+      <summary>
+        <span></span>
+      </summary>
+      <header title="Filter condition type"></header>
+      <ol role="menu"></ol>
+    </details>
+    <menu>
+      <label title="Click to open the filter dialog to edit the filter.">
+        <button id="-edit-filter-condition">Click to open the filter dialog to edit the filter.</button>
+      </label>
+      <label title="Remove this item from the axis">
+        <button id="-remove-from-axis">Remove this item from the axis</button>
+      </label>
+    </menu>
+    <label title="Move this item to the right">
+      <button id="-move-right">Move this item to the right</button>
+    </label>
+  </li>
+</template>

--- a/src/UploadUi/UploadUi.js
+++ b/src/UploadUi/UploadUi.js
@@ -1,4 +1,5 @@
-import { byId, createEl, instantiateTemplate } from '../util/dom/dom.js';
+import { byId, createEl, instantiateTemplate, registerTemplates } from '../util/dom/dom.js';
+import uploadTemplatesHtml from './templates.html?raw';
 import { Internationalization } from '../Internationalization/Internationalization.js';
 import { Routing } from '../Routing/Routing.js';
 import { datasourcesUi } from '../DataSource/DataSourcesUi.js';
@@ -42,6 +43,7 @@ export class UploadUi {
   }
 
   init(){
+    registerTemplates(uploadTemplatesHtml);
     this.#getCancelButton().addEventListener('click', async () =>{
       await this.#cancelUploads();
       this.getDialog().close();

--- a/src/UploadUi/templates.html
+++ b/src/UploadUi/templates.html
@@ -1,0 +1,16 @@
+<template id="uploadItemTemplate">
+  <details id="filename">
+    <summary>
+      <span></span>
+      <menu></menu>
+      <progress
+        max="100"
+        value="0"
+        aria-valuemin="0"
+        aria-valuemax="100"
+        aria-valuenow="0"
+      />
+    </summary>
+    <p></p>
+  </details>
+</template>

--- a/src/index.html
+++ b/src/index.html
@@ -173,23 +173,6 @@
         </div>
       </header>
       
-      <template id="uploadItemTemplate">
-        <details id="filename">
-          <summary>
-            <span></span>
-            <menu></menu>
-            <progress 
-              max="100"
-              value="0"
-              aria-valuemin="0"
-              aria-valuemax="100"
-              aria-valuenow="0"
-            />
-          </summary>
-          <p></p>
-        </details>
-      </template>
-      
       <section id="uploadProgressList">
       </section>
       
@@ -1419,26 +1402,6 @@
       </footer>
     </dialog>
 
-    <!-- this template is to present datasources in a prompt dialog and is used by the PageStateManager -->
-    <template id="datasource-menu-item">
-      <li 
-        role="menuitem" 
-        data-nodetype="datasource" 
-        data-datasourcetype=""
-        data-datasource-id=""
-        popovertarget="dataSourceMenu"
-      >
-        <input 
-          type="radio" 
-          name="compatibleDatasources"
-        />
-        <button
-          popovertarget="dataSourceMenu"
-        ></button>
-        <label for="datasourceMenu-${index}"></label>
-      </li>
-    </template>
-    
     <dialog
       id="datasourceSettingsDialog"
       draggable="true"      
@@ -1921,130 +1884,6 @@
       </li>
     </menu>
 
-    <template id="pivotTableUiTemplate">
-      <!-- pivotTableUi: outmost container of the pivot table-->
-      <div
-        id=""
-        class="pivotTableUiContainer"
-        style="
-          flex-grow: 1;
-          width: 100%;
-          height: 100%;
-          border-width: 1px;
-          border-color: var( --huey-dark-border-color );
-          border-top-style: solid;
-        "
-        aria-busy="false"
-        data-needs-update="false"
-      >
-        <div class="pivotTableUiInnerContainer">
-          <!-- pivotTableColumnsSizer: sizer to generate the horizontal scrollbar -->
-          <div class="pivotTableUiSizer pivotTableUiHorizontalSizer"></div>
-          <!-- pivotTableColumnsSizer: sizer to generate the vertical scrollbar -->
-          <div class="pivotTableUiSizer pivotTableUiVerticalSizer"></div>
-
-          <!-- the actual table structure -->
-          <div class="pivotTableUiTable" role="grid">
-            <div class="pivotTableUiTableHeader" role="rowgroup"></div>
-            <div class="pivotTableUiTableBody" role="rowgroup"></div>
-          </div>
-        </div>
-      </div>
-    </template>
-
-    <template id="queryUiTemplate">
-      <div
-        id=""
-        class="queryUi"
-        data-cellheadersaxis="columns"
-      >
-      </div>
-    </template>
-
-    <template id="queryUiAxis">
-      <section>
-        <header>
-          <label><button id="-axis-primary-action" aria-label="Axis primary action"></button></label>
-          <h1></h1>
-        </header>
-        <ol>
-        </ol>
-        <footer>
-          <label title="Remove all items from this axis"><button id="-clear-axis">Clear axis</button></label>
-        </footer>
-      </section>
-    </template>
-
-    <template id="queryUiAxisItem">
-      <li draggable="true">
-        <label title="Move this item to the left">
-          <button id="-move-left">Move this item to the left</button>
-        </label>
-        <span></span>
-        <menu>
-          <label title="Calculate totals for this level">
-            <input id="-toggle-totals" type="checkbox"/>
-          </label>
-          <label title="Move this item to the other axis">
-            <button id="-move-to-other-axis">Move this item to the other axis</button>
-          </label>
-          <label title="Remove this item from the axis">
-            <button id="-remove-from-axis">Remove this item from the axis</button>
-          </label>
-        </menu>
-        <label title="Move this item to the right">
-          <button id="-move-right">Move this item to the right</button>
-        </label>
-      </li>
-    </template>
-
-    <template id="queryUiFilterAxisItemValue">
-      <li role="menuitem">
-        <label 
-          title="Use the checkbox to enable/disable this condition"
-          for=""
-        >
-          <span></span>
-          <input
-            id=""
-            type="checkbox"
-          />
-        </label>
-        <label 
-          title="Remove this filter condition"
-          for=""
-        >
-          <button></button>
-        </label>
-      </li>
-    </template>
-
-    <template id="queryUiFilterAxisItem">
-      <li draggable="true">
-        <label title="Move this item to the left">
-          <button id="-move-left">Move this item to the left</button>
-        </label>
-        <details>
-          <summary>
-            <span></span>
-          </summary>
-          <header title="Filter condition type"></header>
-          <ol role="menu"></ol>
-        </details>
-        <menu>
-          <label title="Click to open the filter dialog to edit the filter.">
-            <button id="-edit-filter-condition">Click to open the filter dialog to edit the filter.</button>
-          </label>
-          <label title="Remove this item from the axis">
-            <button id="-remove-from-axis">Remove this item from the axis</button>
-          </label>
-        </menu>
-        <label title="Move this item to the right">
-          <button id="-move-right">Move this item to the right</button>
-        </label>
-      </li>
-    </template>
-
     <main
       id="layout"
       class="layout"
@@ -2295,62 +2134,7 @@
             role="tabpanel"
           >
             <label for="uploader">Drop some files here, or click the Upload button:</label>
-            
-            <template id="dataSourceGroupNodeActionButton">
-              <label
-                class="${class}"
-                for="${id}"
-                title="${title}"
-              >
-                <button id="${id}" aria-label="${title}"></button>
-              </label>
-            </template>
-            
-            <template id="dataSourceNode">
-              <details
-                role="treeitem"
-                data-nodetype="datasource"
-                data-datasourcetype="${datasourceType}"
-                title="${title}"
-              >
-                <summary>
-                  <span class="label i18nIgnore">${caption}</span>
-                </summary>
-              </details>
-            </template>
-            
-            <template id="dataSourceGroupNode">
-              <details
-                role="treeitem"
-                data-nodetype="datasourcegroup"
-                title="${title}"
-                data-grouptype="${group-type}"
-                data-datasourceids="${datasource-list}"
-                open="true"
-              >
-                <summary>
-                  <span class="label">${caption}</span>
-                </summary>
-              </details>
-            </template>
-            
-            <template id="dataSourceSchemaNode">
-              <details
-                role="treeitem"
-                data-nodetype="duckdb_schema"
-                title="${title}"
-                data-grouptype="${group-type}"
-                data-datasourceids="${datasource-list}"
-                data-catalog-name="${catalogName}"
-                data-schema-name="${schemaName}"
-                open="true"
-              >
-                <summary>
-                  <span class="label i18nIgnore">${caption}</span>
-                </summary>
-              </details>
-            </template>
-            
+
             <div
               id="datasourcesUi"
               role="tree"
@@ -2387,31 +2171,6 @@
               </fieldset>
             </search>
 
-            <template id="attribute-node">
-              <details role="treeitem" data-nodetype="">
-                <summary>
-                  <span class="label"></span>
-                </summary>
-              </details>
-            </template>
-            
-            <template id="attribute-node-axis-dummybutton">
-              <span class="attributeUiAxisButton" data-axis=""></span>
-            </template>
-            
-            <template id="attribute-node-axis-checkbox">
-              <label 
-                class="attributeUiAxisButton" 
-                data-axis=""
-                data-title-checked=""
-                data-title-unchecked=""
-                title=""
-                for=""
-              >
-                <input type="checkbox"/>
-              </label>
-            </template>
-            
             <div
               id="attributeUi"
               class="attributeUi"

--- a/src/util/dom/dom.js
+++ b/src/util/dom/dom.js
@@ -234,6 +234,24 @@ export function getChildWithClassName(dom, className){
   //throw new Error(`Couldn't find element with classname ${className}`);
 }
 
+/**
+ * Parse an HTML string containing <template> elements and append them to
+ * the document body so they can be found by instantiateTemplate / byId.
+ * Skips templates whose id already exists in the DOM (idempotent).
+ * @param {string} html - Raw HTML string with one or more <template> elements
+ */
+export function registerTemplates(html) {
+  const container = document.createElement('div');
+  // Trusted application markup — these are bundled template strings, not user input.
+  container.innerHTML = html;
+  const templates = container.querySelectorAll('template');
+  for (const tpl of templates) {
+    if (!document.getElementById(tpl.id)) {
+      document.body.appendChild(tpl);
+    }
+  }
+}
+
 export function escapeHtmlText(text){
   return text.replace(/[&<>]/g, (match) =>{
     switch(match) {

--- a/tests/unit/dom.test.js
+++ b/tests/unit/dom.test.js
@@ -3,6 +3,7 @@ import {
   createEl,
   escapeHtmlText,
   instantiateTemplate,
+  registerTemplates,
   setClass,
 } from '../../src/util/dom/dom.js';
 
@@ -66,5 +67,45 @@ describe('dom utilities', () => {
     });
     expect(nodeWithAttributes.id).toBe('node-attributes');
     expect(nodeWithAttributes.className).toBe('item active');
+  });
+
+  describe('registerTemplates', () => {
+    test('registers templates from HTML string into the DOM', () => {
+      const html = `
+        <template id="testTemplate1"><div class="test1">Test 1</div></template>
+        <template id="testTemplate2"><span>Test 2</span></template>
+      `;
+      registerTemplates(html);
+
+      const tpl1 = byId('testTemplate1');
+      expect(tpl1).not.toBeNull();
+      expect(tpl1.tagName).toBe('TEMPLATE');
+
+      const tpl2 = byId('testTemplate2');
+      expect(tpl2).not.toBeNull();
+
+      // Templates should be usable with instantiateTemplate
+      const node1 = instantiateTemplate('testTemplate1');
+      expect(node1.className).toBe('test1');
+      expect(node1.textContent).toBe('Test 1');
+    });
+
+    test('is idempotent — does not duplicate templates', () => {
+      const html = '<template id="idempotentTest"><div>Once</div></template>';
+      registerTemplates(html);
+      registerTemplates(html);
+
+      const matches = document.querySelectorAll('#idempotentTest');
+      expect(matches.length).toBe(1);
+    });
+
+    test('does not overwrite existing templates', () => {
+      document.body.innerHTML = '<template id="existingTpl"><p>Original</p></template>';
+      const html = '<template id="existingTpl"><p>Replaced</p></template>';
+      registerTemplates(html);
+
+      const node = instantiateTemplate('existingTpl');
+      expect(node.textContent).toBe('Original');
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Extracts all 15 `<template>` elements from `index.html` (2431→2190 lines) into co-located `templates.html` files per component
- Adds `registerTemplates()` utility to `dom.js` for loading templates from imported HTML strings (idempotent, safe)
- Each component imports its template HTML via Vite `?raw` and registers at initialization
- index.html output size reduced from 90.82 KB to 83.11 KB

### Template files created
| Component | File | Templates |
|---|---|---|
| UploadUi | `templates.html` | uploadItemTemplate |
| DataSourceMenu | `templates.html` | datasource-menu-item |
| PivotTableUi | `templates.html` | pivotTableUiTemplate |
| QueryUi | `templates.html` | 5 templates (queryUi*, queryUiFilter*) |
| DataSource | `templates.html` | 4 templates (dataSource*) |
| AttributeUi | `templates.html` | 3 templates (attribute-node*) |

Closes #258

## Test plan
- [x] All 124 unit tests pass (3 new for registerTemplates)
- [x] Vite build succeeds (89 modules)
- [x] index.html reduced by 241 lines
- [ ] Manual smoke test: upload dialog renders correctly
- [ ] Manual smoke test: datasource tree renders correctly
- [ ] Manual smoke test: pivot table renders correctly
- [ ] Manual smoke test: query axis UI renders correctly
- [ ] Manual smoke test: attribute tree renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)