### PR TITLE
fix: update postmessage-interface test for ES6 class RemoteQueryAdapter

### DIFF
--- a/tests/unit/postmessage-interface.test.js
+++ b/tests/unit/postmessage-interface.test.js
@@ -123,7 +123,7 @@ describe('PostMessageInterface security hardening', () => {
 
   test('registers postMessage globals explicitly for external API integration', () => {
     expect(window.RemoteDatasource).toBeTypeOf('function');
-    expect(window.RemoteQueryAdapter).toBeTypeOf('object');
+    expect(window.RemoteQueryAdapter).toBeTypeOf('function');
     expect(window.postMessageInterface).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary
- Fixes test assertion broken by PR #289 which refactored `RemoteQueryAdapter` from IIFE singleton (`typeof 'object'`) to ES6 static class (`typeof 'function'`)

Closes #313

## Test plan
- [x] `postmessage-interface.test.js` — 6/6 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)