### PR TITLE
CI flaky tests

### DIFF
--- a/server/tests/test_query_budget.py
+++ b/server/tests/test_query_budget.py
@@ -83,15 +83,19 @@ def test_queue_depth_rejects_overflow(
     }
 
     def first_request():
-        return client.post("/query/cells", json=request_body)
+        # Separate clients avoid TestClient internal request serialization,
+        # which can make this concurrency test nondeterministic.
+        with TestClient(client.app) as first_client:
+            return first_client.post("/query/cells", json=request_body)
 
-    with ThreadPoolExecutor(max_workers=1) as pool:
-        first = pool.submit(first_request)
-        # Wait until the first request has definitely acquired the budget slot
-        # before sending the second, so the queue overflow is guaranteed.
-        assert in_execute.wait(timeout=5)
-        second_result = client.post("/query/cells", json=request_body)
-        first_result = first.result(timeout=10)
+    with TestClient(client.app) as second_client:
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            first = pool.submit(first_request)
+            # Wait until the first request has definitely acquired the budget slot
+            # before sending the second, so the queue overflow is guaranteed.
+            assert in_execute.wait(timeout=5)
+            second_result = second_client.post("/query/cells", json=request_body)
+            first_result = first.result(timeout=10)
 
     assert first_result.status_code in (200, 504)
     assert second_result.status_code == 429


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix flaky `test_queue_depth_rejects_overflow` by using separate `TestClient` instances for concurrent requests.

---
<p><a href="https://cursor.com/agents/bc-22deea62-2635-4a6e-a605-4575018bc459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22deea62-2635-4a6e-a605-4575018bc459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->