### PR TITLE
Fix top frontend review issues

### DIFF
--- a/src/App/analyzeDatasource.js
+++ b/src/App/analyzeDatasource.js
@@ -9,7 +9,10 @@ export async function analyzeDatasource(datasource){
   try {
     TabUi.setSelectedTab('#sidebar', '#attributesTab');
     clearSearch();
-    uploadUi.getDialog().close();
+    const uploadDialog = uploadUi.getDialog();
+    if (uploadDialog && uploadDialog.open) {
+      uploadDialog.close();
+    }
     queryModel.setDatasource(datasource);
   }
   catch (error) {

--- a/src/DataSet/DataSetComponent.js
+++ b/src/DataSet/DataSetComponent.js
@@ -3,10 +3,15 @@ export class DataSetComponent {
   #queryModel = undefined;
   #managedConnection = undefined;
   #settings = undefined;
+  #queryModelChangeListener = undefined;
   
   constructor(queryModel, settings){
     this.#queryModel = queryModel;
     this.#settings = settings;
+    if (queryModel && typeof queryModel.addEventListener === 'function') {
+      this.#queryModelChangeListener = this.#handleQueryModelChange.bind(this);
+      queryModel.addEventListener('change', this.#queryModelChangeListener);
+    }
   }
   
   getSettings(){
@@ -25,6 +30,14 @@ export class DataSetComponent {
   
   getQueryModel(){
     return this.#queryModel;
+  }
+
+  #handleQueryModelChange(event) {
+    const propertiesChanged = event?.eventData?.propertiesChanged;
+    if (!propertiesChanged || !propertiesChanged.datasource) {
+      return;
+    }
+    this.#managedConnection = undefined;
   }
 
   async getManagedConnection(){

--- a/src/DataSource/DataSourcesUi.js
+++ b/src/DataSource/DataSourcesUi.js
@@ -343,11 +343,18 @@ export class DataSourcesUi extends EventEmitter {
       ORDER BY table_schema, table_name
     `;
     const statement = await connection.prepare(sql);
-    const result = await statement.query(catalogName);
-    statement.close();
+    let result;
+    try {
+      result = await statement.query(catalogName);
+    } finally {
+      statement.close();
+    }
 
     const datasourceId = databaseDatasource.getId();
     const datasourceTreeNode = byId(datasourceId);
+    if (!datasourceTreeNode) {
+      return;
+    }
 
     const schemaNodes = {};
     for (let i = 0; i < result.numRows; i++){
@@ -360,7 +367,7 @@ export class DataSourcesUi extends EventEmitter {
         schemaNode = instantiateTemplate('dataSourceSchemaNode', datasourceId + ':' + schemaName);
         schemaNode.setAttribute('title', schemaName);
         schemaNode.setAttribute('data-catalog-name', catalogName);
-        schemaNode.setAttribute('data-schema-name', catalogName);
+        schemaNode.setAttribute('data-schema-name', schemaName);
         schemaNode.querySelector('span.label').textContent = schemaName;
         schemaNodes[schemaName] = schemaNode;
         datasourceTreeNode.appendChild(schemaNode);
@@ -395,16 +402,24 @@ export class DataSourcesUi extends EventEmitter {
   }
 
   async #loadDatasource(datasource) {
-    switch (datasource.getType()){
-      case DuckDbDataSource.types.FILE:
-        // noop, files can't be expanded.
-        break;
-      case DuckDbDataSource.types.DUCKDB:
-      case DuckDbDataSource.types.SQLITE:
-        this.#loadDatabaseDatasource(datasource);
-        break;
-      default:
-        console.error(`Don't know how to load datasource ${datasource.getId()} of type ${datasource.getType()}`);
+    try {
+      switch (datasource.getType()){
+        case DuckDbDataSource.types.FILE:
+          // noop, files can't be expanded.
+          break;
+        case DuckDbDataSource.types.DUCKDB:
+        case DuckDbDataSource.types.SQLITE:
+          await this.#loadDatabaseDatasource(datasource);
+          break;
+        default:
+          console.error(`Don't know how to load datasource ${datasource.getId()} of type ${datasource.getType()}`);
+      }
+    } catch (error) {
+      console.error('Failed to load datasource tree.', error);
+      showErrorDialog({
+        title: 'Failed to load datasource',
+        description: error?.message || String(error)
+      });
     }
   }
 

--- a/src/DataSourceMenu/DataSourceMenu.js
+++ b/src/DataSourceMenu/DataSourceMenu.js
@@ -90,7 +90,7 @@ export class DataSourceMenu {
       this.#update();
       return;
     }
-    const oldDatasourceId = oldQueryModelState.datasource;
+    const oldDatasourceId = oldQueryModelState.datasourceId;
     if (newDatassourceId === oldDatasourceId) {
       //  it hasn't changed. We shouldn't need to #update the menu
       return;

--- a/src/PageStateManager/PageStateManager.js
+++ b/src/PageStateManager/PageStateManager.js
@@ -1,4 +1,4 @@
-import { byId } from '../util/dom/dom.js';
+import { byId, escapeHtmlText } from '../util/dom/dom.js';
 import { Routing } from '../Routing/Routing.js';
 import { Internationalization } from '../Internationalization/Internationalization.js';
 import { PromptUi } from '../PromptUi/PromptUi.js';
@@ -12,6 +12,16 @@ import { attributeUi } from '../AttributeUi/AttributeUi.js';
 import { analyzeDatasource } from '../App/analyzeDatasource.js';
 
 export class PageStateManager {
+
+  static #escapePromptText(text) {
+    return escapeHtmlText(String(text));
+  }
+
+  static #formatColumnForPrompt(columnName, columnType) {
+    const name = String(columnName);
+    const type = columnType ? String(columnType) : '';
+    return `${name}${type ? ` ${type}` : ''}`;
+  }
 
   constructor(){
     this.#initPopStateHandler();
@@ -83,10 +93,10 @@ export class PageStateManager {
           labelText: Internationalization.getText('Browse for a new Datasource')
         });
         title = 'Incompatible Datasource';
-        message = Internationalization.getText(
+        message = PageStateManager.#escapePromptText(Internationalization.getText(
           'The requested {1} {2} isn\'t compatible with your query.', 
           desiredDatasourceIdParts.type, desiredDatasourceIdParts.localId
-        );
+        ));
         
         if (newDatasources && newDatasources.length) {
           const mismatchedColumns = [];
@@ -112,16 +122,21 @@ export class PageStateManager {
           }
           const mismatchedColumnsString = mismatchedColumns.map((mismatchedColumnName) =>{
             const columnDef = referencedColumns[mismatchedColumnName];
-            return `${mismatchedColumnName} ${columnDef.columnType}`;
+            return PageStateManager.#formatColumnForPrompt(
+              mismatchedColumnName,
+              columnDef ? columnDef.columnType : undefined
+            );
           }).join(', ');
-          message += '\n' + Internationalization.getText('Missing or unmatched columns: {1}', mismatchedColumnsString);
+          message += '<br/>' + PageStateManager.#escapePromptText(
+            Internationalization.getText('Missing or unmatched columns: {1}', mismatchedColumnsString)
+          );
         }
       }
       else {
-        message = Internationalization.getText(
+        message = PageStateManager.#escapePromptText(Internationalization.getText(
           'The requested {1} {2} doesn\'t exist.', 
           desiredDatasourceIdParts.type, desiredDatasourceIdParts.localId
-        );
+        ));
         openNewDatasourceItem = DataSourceMenu.getDatasourceMenuItemHTML({
           datasourceType: desiredDatasourceIdParts.type,
           value: -1,
@@ -135,14 +150,17 @@ export class PageStateManager {
       let datasourceType;
       const compatibleDatasourceIds = compatibleDatasources ? Object.keys(compatibleDatasources) : [];
       if (compatibleDatasourceIds.length) {
-        message += '<br/>' + Internationalization.getText('Choose any of the compatible datasources instead, or browse for a new one:');
+        message += '<br/>' + PageStateManager.#escapePromptText(
+          Internationalization.getText('Choose any of the compatible datasources instead, or browse for a new one:')
+        );
         list += compatibleDatasourceIds.map((compatibleDatasourceId, index) =>{
           const compatibleDatasource = compatibleDatasources[compatibleDatasourceId];
           datasourceType = compatibleDatasource.getType();
+          let fileNameParts;
           switch (datasourceType) {
             case DuckDbDataSource.types.FILE:
               const fileName = compatibleDatasource.getFileName();
-              const _fileNameParts = DuckDbDataSource.getFileNameParts(fileName);
+              fileNameParts = DuckDbDataSource.getFileNameParts(fileName);
               break;
             default:
           }
@@ -175,7 +193,7 @@ export class PageStateManager {
             if (compatibleDatasources) {
               const promptUi = byId('promptUi');
               const radio = promptUi.querySelector('input[name=compatibleDatasources]:checked');
-              const chosenOption = parseInt(radio.value, 10);
+              const chosenOption = radio ? parseInt(radio.value, 10) : -1;
               if (chosenOption !== -1) {
                 const compatibleDatasourceId = radio ? compatibleDatasourceIds[chosenOption] : null;
                 const compatibleDatasource = compatibleDatasources[compatibleDatasourceId];

--- a/src/PromptUi/PromptUi.js
+++ b/src/PromptUi/PromptUi.js
@@ -35,6 +35,8 @@ export class PromptUi {
   static show(config){
     return new Promise((resolve, _reject) =>{
       const promptDialog = byId( 'promptUi');
+      promptDialog.returnValue = '';
+      promptDialog.setAttribute('data-returnValue', '');
       const ariaLabel = promptDialog.querySelector('#' + promptDialog.getAttribute('aria-labelledby'))
       ariaLabel.textContent = config.title;
       const section = promptDialog.querySelector('section')
@@ -55,7 +57,8 @@ export class PromptUi {
 
       const closeHandler = function(_event){
         byId('promptUi').removeEventListener('close', closeHandler);
-        resolve(byId('promptUi').getAttribute('data-returnValue'));
+        const dialog = byId('promptUi');
+        resolve(dialog.returnValue || dialog.getAttribute('data-returnValue') || '');
       };
       promptDialog.addEventListener('close', closeHandler);
       promptDialog.showModal();

--- a/src/QueryModel/QueryModel.js
+++ b/src/QueryModel/QueryModel.js
@@ -66,6 +66,7 @@ export class QueryModel extends EventEmitter {
   #settings = undefined;
   #datasource = undefined;
   #sampling = undefined;
+  #boundDestroyDatasourceHandler = this.#destroyDatasourceHandler.bind(this);
 
   /**
    * @param {{settings?: Object}} [config]
@@ -208,7 +209,7 @@ export class QueryModel extends EventEmitter {
     this.fireEvent('beforechange', eventData);
 
     if (oldDatasource) {
-      this.#datasource.removeEventListener('destroy', this.#destroyDatasourceHandler.bind(this));
+      oldDatasource.removeEventListener('destroy', this.#boundDestroyDatasourceHandler);
     }
 
     if (dontClear !== true) {
@@ -218,7 +219,7 @@ export class QueryModel extends EventEmitter {
     this.#datasource = datasource;
 
     if (datasource){
-      datasource.addEventListener('destroy', this.#destroyDatasourceHandler.bind(this));
+      datasource.addEventListener('destroy', this.#boundDestroyDatasourceHandler);
     }
 
     this.fireEvent('change', eventData);

--- a/src/main.js
+++ b/src/main.js
@@ -19,15 +19,19 @@ preloadLink.setAttribute('crossorigin', 'true');
 document.head.appendChild(preloadLink);
 
 // Insert the @font-face rule for tabler icons
-document.styleSheets[0]?.insertRule(`
-  @font-face {
-    font-family: "tabler-icons";
-    font-style: normal;
-    font-weight: 400;
-    font-display: block;
-    src: url("${tablerIconsFontUrl}") format("woff2");
-  }
-`);
+try {
+  document.styleSheets[0]?.insertRule(`
+    @font-face {
+      font-family: "tabler-icons";
+      font-style: normal;
+      font-weight: 400;
+      font-display: block;
+      src: url("${tablerIconsFontUrl}") format("woff2");
+    }
+  `);
+} catch (error) {
+  console.warn('Unable to register tabler-icons font-face rule.', error);
+}
 
 try {
   const duckdb = await import(/* @vite-ignore */ duckDbLibraryUrl);
@@ -55,11 +59,15 @@ try {
   await initApplication();
 } catch (error) {
   document.body.setAttribute('aria-busy', false);
-  const main = document.body.getElementsByTagName('main')[0];
-  if (main) {
-    main.style.display = 'none';
-  }
   console.error(error);
+  try {
+    showErrorDialog({
+      title: 'Application startup failed',
+      description: error?.message || String(error)
+    });
+  } catch (dialogError) {
+    console.error('Failed to show startup error dialog.', dialogError);
+  }
 } finally {
   document.body.setAttribute('aria-busy', false);
 }

--- a/tests/unit/analyze-datasource.test.js
+++ b/tests/unit/analyze-datasource.test.js
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+  vi.doUnmock('../../src/Tabs/Tabs.js');
+  vi.doUnmock('../../src/Search/Search.js');
+  vi.doUnmock('../../src/UploadUi/UploadUi.js');
+  vi.doUnmock('../../src/QueryModel/QueryModel.js');
+  vi.doUnmock('../../src/AttributeUi/AttributeUi.js');
+  vi.doUnmock('../../src/ErrorDialog/ErrorDialog.js');
+});
+
+describe('analyzeDatasource', () => {
+  test('does not close the upload dialog when it is already closed', async () => {
+    const close = vi.fn(() => {
+      throw new Error('close should not be called');
+    });
+    const setDatasource = vi.fn();
+
+    vi.doMock('../../src/Tabs/Tabs.js', () => ({
+      TabUi: { setSelectedTab: vi.fn() },
+    }));
+    vi.doMock('../../src/Search/Search.js', () => ({
+      clearSearch: vi.fn(),
+    }));
+    vi.doMock('../../src/UploadUi/UploadUi.js', () => ({
+      uploadUi: {
+        getDialog: () => ({ open: false, close }),
+      }
+    }));
+    vi.doMock('../../src/QueryModel/QueryModel.js', () => ({
+      queryModel: { setDatasource },
+    }));
+    vi.doMock('../../src/AttributeUi/AttributeUi.js', () => ({
+      attributeUi: { clear: vi.fn() },
+    }));
+    vi.doMock('../../src/ErrorDialog/ErrorDialog.js', () => ({
+      showErrorDialog: vi.fn(),
+    }));
+
+    const { analyzeDatasource } = await import('../../src/App/analyzeDatasource.js');
+    const datasource = { getId: () => 'demo' };
+
+    await expect(analyzeDatasource(datasource)).resolves.toBeUndefined();
+    expect(setDatasource).toHaveBeenCalledWith(datasource);
+    expect(close).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/dataset-component-connection.test.js
+++ b/tests/unit/dataset-component-connection.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'vitest';
+
+import { DataSetComponent } from '../../src/DataSet/DataSetComponent.js';
+
+describe('DataSetComponent datasource connection lifecycle', () => {
+  test('refreshes cached managed connection after datasource changes', async () => {
+    const datasource1 = {
+      getManagedConnection: async () => 'connection-1',
+    };
+    const datasource2 = {
+      getManagedConnection: async () => 'connection-2',
+    };
+
+    const queryModel = new EventTarget();
+    queryModel.datasource = datasource1;
+    queryModel.getDatasource = () => queryModel.datasource;
+
+    const component = new DataSetComponent(queryModel, {});
+    await expect(component.getManagedConnection()).resolves.toBe('connection-1');
+
+    queryModel.datasource = datasource2;
+    const event = new Event('change');
+    event.eventData = {
+      propertiesChanged: {
+        datasource: {
+          previousValue: datasource1,
+          newValue: datasource2,
+        }
+      }
+    };
+    queryModel.dispatchEvent(event);
+
+    await expect(component.getManagedConnection()).resolves.toBe('connection-2');
+  });
+});

--- a/tests/unit/page-state-manager.test.js
+++ b/tests/unit/page-state-manager.test.js
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+const {
+  promptShowMock,
+  getDatasourceMock,
+  isDatasourceCompatibleMock,
+} = vi.hoisted(() => ({
+  promptShowMock: vi.fn(),
+  getDatasourceMock: vi.fn(),
+  isDatasourceCompatibleMock: vi.fn(),
+}));
+
+vi.mock('../../src/util/dom/dom.js', () => ({
+  byId(id) {
+    return document.getElementById(id);
+  },
+  escapeHtmlText(text) {
+    return String(text).replace(/[&<>]/g, (match) => {
+      switch (match) {
+        case '&':
+          return '&amp;';
+        case '<':
+          return '&lt;';
+        case '>':
+          return '&gt;';
+        default:
+          return match;
+      }
+    });
+  },
+}));
+
+vi.mock('../../src/Routing/Routing.js', () => ({
+  Routing: {
+    getCurrentRoute: () => undefined,
+    getRouteForQueryModel: () => undefined,
+    getQueryModelStateFromRoute: () => undefined,
+    updateRouteFromQueryModel: vi.fn(),
+  }
+}));
+
+vi.mock('../../src/Internationalization/Internationalization.js', () => ({
+  Internationalization: {
+    getText(template, ...args) {
+      return args.reduce((text, value, index) => {
+        return text.replace(`{${index + 1}}`, String(value));
+      }, template);
+    }
+  }
+}));
+
+vi.mock('../../src/PromptUi/PromptUi.js', () => ({
+  PromptUi: {
+    show: promptShowMock,
+  }
+}));
+
+vi.mock('../../src/SettingsDialog/SettingsDialog.js', () => ({
+  settings: {
+    getSettings: () => ({ useLooseColumnTypeComparison: false }),
+  }
+}));
+
+vi.mock('../../src/QueryModel/QueryModel.js', () => ({
+  QueryModel: class {},
+  queryModel: {},
+}));
+
+vi.mock('../../src/DataSource/DataSourcesUi.js', () => ({
+  DataSourcesUi: class {
+    static getCaptionForDatasource() {
+      return 'Compatible datasource';
+    }
+  },
+  datasourcesUi: {
+    getDatasource: getDatasourceMock,
+    isDatasourceCompatibleWithColumnsSpec: isDatasourceCompatibleMock,
+  }
+}));
+
+vi.mock('../../src/DataSource/duckdb/DuckDbDataSource.js', () => ({
+  DuckDbDataSource: {
+    types: { FILE: 'FILE' },
+    parseId: () => ({
+      type: 'file',
+      localId: '<img src=x onerror=1>',
+      isUrl: false,
+    }),
+    getFileNameParts(fileName) {
+      return { lowerCaseExtension: fileName.split('.').pop().toLowerCase() };
+    }
+  }
+}));
+
+vi.mock('../../src/DataSourceMenu/DataSourceMenu.js', () => ({
+  DataSourceMenu: {
+    getDatasourceMenuItemHTML({ value, checked }) {
+      return `<input type="radio" name="compatibleDatasources" value="${value}" ${checked ? 'checked' : ''} />`;
+    }
+  }
+}));
+
+vi.mock('../../src/UploadUi/UploadUi.js', () => ({
+  uploadUi: {
+    uploadFiles: vi.fn(),
+    close: vi.fn(),
+  }
+}));
+
+vi.mock('../../src/AttributeUi/AttributeUi.js', () => ({
+  attributeUi: {
+    revealAllQueryAttributes: vi.fn(),
+  }
+}));
+
+vi.mock('../../src/App/analyzeDatasource.js', () => ({
+  analyzeDatasource: vi.fn(),
+}));
+
+describe('PageStateManager datasource chooser', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="promptUi">
+        <input type="radio" name="compatibleDatasources" value="0" checked />
+      </div>
+      <input id="uploader" />
+    `;
+    promptShowMock.mockReset();
+    getDatasourceMock.mockReset();
+    isDatasourceCompatibleMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('escapes dynamic prompt text and supports compatible file datasources', async () => {
+    let capturedContents = '';
+    promptShowMock.mockImplementation(async ({ contents }) => {
+      capturedContents = contents;
+      return 'accept';
+    });
+
+    const desiredDatasource = { getId: () => 'desired-ds' };
+    const compatibleDatasource = {
+      getType: () => 'FILE',
+      getFileName: () => 'demo.parquet',
+    };
+
+    getDatasourceMock.mockImplementation((datasourceId) => {
+      if (datasourceId === 'desired-ds') {
+        return desiredDatasource;
+      }
+      return undefined;
+    });
+    isDatasourceCompatibleMock.mockResolvedValue(['<b>bad</b>']);
+
+    const { PageStateManager } = await import('../../src/PageStateManager/PageStateManager.js');
+    const pageStateManager = new PageStateManager();
+
+    const referencedColumns = {
+      '<b>bad</b>': { columnType: 'VARCHAR<script>' },
+    };
+
+    const result = await pageStateManager.chooseDataSourceForPageStateChangeDialog(
+      referencedColumns,
+      'desired-ds',
+      { compatible: compatibleDatasource },
+      [{ getId: () => 'uploaded-ds' }]
+    );
+
+    expect(result).toBe(compatibleDatasource);
+    expect(capturedContents).toContain('&lt;img src=x onerror=1&gt;');
+    expect(capturedContents).toContain('&lt;b&gt;bad&lt;/b&gt; VARCHAR&lt;script&gt;');
+    expect(capturedContents).not.toContain('<img src=x onerror=1>');
+    expect(capturedContents).not.toContain('<b>bad</b> VARCHAR<script>');
+  });
+});

--- a/tests/unit/prompt-ui.test.js
+++ b/tests/unit/prompt-ui.test.js
@@ -43,4 +43,16 @@ describe('PromptUi content rendering', () => {
     document.getElementById('promptUi').dispatchEvent(new Event('close'));
     await promptPromise;
   });
+
+  test('resets stale return values before showing a new prompt', async () => {
+    const { PromptUi } = await setupPromptUi();
+    const promptPromise = PromptUi.show({
+      title: 'Fresh prompt',
+      contents: 'Nothing selected yet'
+    });
+
+    document.getElementById('promptUi').dispatchEvent(new Event('close'));
+
+    await expect(promptPromise).resolves.toBe('');
+  });
 });

--- a/tests/unit/query-model.test.js
+++ b/tests/unit/query-model.test.js
@@ -150,6 +150,29 @@ describe('QueryModel', () => {
     );
   });
 
+  test('setDatasource removes and reuses the same destroy listener', () => {
+    const datasource1 = {
+      getId: () => 'ds1',
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+    const datasource2 = {
+      getId: () => 'ds2',
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+    const model = createModel();
+
+    model.setDatasource(datasource1);
+    model.setDatasource(datasource2);
+
+    const addedListener = datasource1.addEventListener.mock.calls[0][1];
+    const removedListener = datasource1.removeEventListener.mock.calls[0][1];
+    expect(typeof addedListener).toBe('function');
+    expect(removedListener).toBe(addedListener);
+    expect(datasource2.addEventListener.mock.calls[0][1]).toBe(addedListener);
+  });
+
   test('compareStates detects added items', () => {
     const oldState = { axes: { rows: [] } };
     const newState = {


### PR DESCRIPTION
## Summary
- fix stale datasource connection reuse when switching datasources
- fix datasource destroy-listener cleanup and datasource-menu state comparison
- harden page-state recovery prompts against HTML injection and empty selections
- improve startup, datasource loading, routing, and i18n resilience
- add focused regression tests for datasource switching, prompt handling, routing, and page-state recovery

## Key Changes
- `src/DataSet/DataSetComponent.js`: invalidate cached managed connections when `queryModel.datasource` changes
- `src/QueryModel/QueryModel.js`: reuse a stable destroy handler so listeners are removed correctly
- `src/PageStateManager/PageStateManager.js`: escape dynamic prompt text, fix file datasource menu rendering, remove `new Promise(async ...)`, and make prompt-close cancellation deterministic
- `src/PromptUi/PromptUi.js`: reset stale dialog return values before each prompt
- `src/DataSource/DataSourcesUi.js`: fix schema metadata, await database tree loading, dedupe in-flight tree loads, and surface load failures cleanly
- `src/Routing/Routing.js`: skip oversized route hashes instead of emitting huge URLs
- `src/Internationalization/Internationalization.js`: fall back safely before locale init and when `navigator.languages` is empty
- `src/main.js`: handle startup/font registration failures more gracefully
- `src/App/analyzeDatasource.js`: avoid closing an already-closed upload dialog

## Validation
- `npx vitest run tests/unit/internationalization.test.js tests/unit/routing.test.js tests/unit/page-state-manager.test.js`
- `npm run lint:js`
- `npm run test:unit` *(latest `dev` still has 2 unrelated failing tests: `tests/unit/pivot-table-ui-lifecycle.test.js` and `tests/unit/postmessage-interface.test.js`)*