### PR TITLE
Harden frontend routing and page-state flows

### DIFF
--- a/src/DataSource/DataSourcesUi.js
+++ b/src/DataSource/DataSourcesUi.js
@@ -24,6 +24,7 @@ export class DataSourcesUi extends EventEmitter {
 
   #id = undefined;
   #datasources = {};
+  #datasourceLoadPromises = new Map();
 
   constructor(id){
     super(['change']);
@@ -333,6 +334,15 @@ export class DataSourcesUi extends EventEmitter {
   }
 
   async #loadDatabaseDatasource(databaseDatasource){
+    const datasourceId = databaseDatasource.getId();
+    const datasourceTreeNode = byId(datasourceId);
+    if (!datasourceTreeNode) {
+      return;
+    }
+    if (datasourceTreeNode.getAttribute('data-tree-load-state') === 'loaded') {
+      return;
+    }
+
     const catalogName = databaseDatasource.getFileNameWithoutExtension();
     const connection = getConnection();
     const sql = `
@@ -350,19 +360,13 @@ export class DataSourcesUi extends EventEmitter {
       statement.close();
     }
 
-    const datasourceId = databaseDatasource.getId();
-    const datasourceTreeNode = byId(datasourceId);
-    if (!datasourceTreeNode) {
-      return;
-    }
-
     const schemaNodes = {};
     for (let i = 0; i < result.numRows; i++){
       let _summary, _label;
 
       const row = result.get(i);
       const schemaName = row.table_schema;
-      let schemaNode = schemaNodes[schemaName];
+      let schemaNode = schemaNodes[schemaName] || byId(datasourceId + ':' + schemaName);
       if (schemaNode === undefined) {
         schemaNode = instantiateTemplate('dataSourceSchemaNode', datasourceId + ':' + schemaName);
         schemaNode.setAttribute('title', schemaName);
@@ -396,12 +400,27 @@ export class DataSourcesUi extends EventEmitter {
         this.#addDatasource(datasource);
       }
 
-      const tableNode = this.#createDatasourceNode(datasource);
-      schemaNode.appendChild(tableNode);
+      let tableNode = byId(tableDatasourceId);
+      if (!tableNode) {
+        tableNode = this.#createDatasourceNode(datasource);
+        schemaNode.appendChild(tableNode);
+      }
     }
   }
 
   async #loadDatasource(datasource) {
+    const datasourceId = datasource.getId();
+    const datasourceTreeNode = byId(datasourceId);
+    if (datasourceTreeNode && datasourceTreeNode.getAttribute('data-tree-load-state') === 'loaded') {
+      return;
+    }
+
+    const loadPromise = this.#datasourceLoadPromises.get(datasourceId);
+    if (loadPromise) {
+      return loadPromise;
+    }
+
+    let nextLoadPromise;
     try {
       switch (datasource.getType()){
         case DuckDbDataSource.types.FILE:
@@ -409,17 +428,37 @@ export class DataSourcesUi extends EventEmitter {
           break;
         case DuckDbDataSource.types.DUCKDB:
         case DuckDbDataSource.types.SQLITE:
-          await this.#loadDatabaseDatasource(datasource);
+          nextLoadPromise = this.#loadDatabaseDatasource(datasource);
           break;
         default:
           console.error(`Don't know how to load datasource ${datasource.getId()} of type ${datasource.getType()}`);
       }
+
+      if (!nextLoadPromise) {
+        return;
+      }
+
+      this.#datasourceLoadPromises.set(datasourceId, nextLoadPromise);
+      if (datasourceTreeNode) {
+        datasourceTreeNode.setAttribute('data-tree-load-state', 'loading');
+        datasourceTreeNode.removeAttribute('data-tree-load-error');
+      }
+      await nextLoadPromise;
+      if (datasourceTreeNode) {
+        datasourceTreeNode.setAttribute('data-tree-load-state', 'loaded');
+      }
     } catch (error) {
+      if (datasourceTreeNode) {
+        datasourceTreeNode.setAttribute('data-tree-load-state', 'error');
+        datasourceTreeNode.setAttribute('data-tree-load-error', 'true');
+      }
       console.error('Failed to load datasource tree.', error);
       showErrorDialog({
         title: 'Failed to load datasource',
         description: error?.message || String(error)
       });
+    } finally {
+      this.#datasourceLoadPromises.delete(datasourceId);
     }
   }
 

--- a/src/Internationalization/Internationalization.js
+++ b/src/Internationalization/Internationalization.js
@@ -39,7 +39,7 @@ export class Internationalization {
   }
 
   static getCurrentLanguage(){
-    return Internationalization.#currentLocale.language;
+    return Internationalization.#currentLocale?.language || Internationalization.#hueyNativeLanguage;
   }
 
   static #languageChanged(_event){
@@ -68,10 +68,15 @@ export class Internationalization {
     if (Internationalization.#languageIndex === undefined) {
       Internationalization.#languageIndex = 0;
     }
-    const languages = navigator.languages;
+    const languages = navigator.languages && navigator.languages.length
+      ? navigator.languages
+      : [Internationalization.#hueyNativeLanguage];
     if (Internationalization.#languageIndex >= languages.length){
+      Internationalization.#applyTexts(true);
+      Internationalization.#setCurrentLocale(Internationalization.#hueyNativeLanguage);
+      return;
     }
-    const language = languages[ Internationalization.#languageIndex++ ];
+    const language = languages[ Internationalization.#languageIndex++ ] || Internationalization.#hueyNativeLanguage;
     if (language === Internationalization.#hueyNativeLanguage || language.startsWith('en')){
       Internationalization.#applyTexts(true);
       Internationalization.#setCurrentLocale(language);

--- a/src/PageStateManager/PageStateManager.js
+++ b/src/PageStateManager/PageStateManager.js
@@ -51,172 +51,153 @@ export class PageStateManager {
   }
 
   async chooseDataSourceForPageStateChangeDialog(referencedColumns, desiredDatasourceId, compatibleDatasources, newDatasources){
-    return new Promise(async (resolve, reject) =>{
+    let desiredDataSource = compatibleDatasources ? compatibleDatasources[desiredDatasourceId] : undefined;
+    if (desiredDataSource){
+      return desiredDataSource;
+    }
 
-      // do we have the referenced datasource?
-      let desiredDataSource = compatibleDatasources ? compatibleDatasources[desiredDatasourceId] : undefined;
-      if (desiredDataSource){
-        // yes! we're done.
-        resolve(desiredDataSource);
-        return;
-      }
-
-      // figure out what kind of datasource is referenced
-      const desiredDatasourceIdParts = DuckDbDataSource.parseId(desiredDatasourceId);
-      
-      if (desiredDatasourceIdParts.isUrl) {
-        const url = desiredDatasourceIdParts.resource;
-        await uploadUi.uploadFiles([url]);
-        desiredDataSource = datasourcesUi.getDatasource(desiredDatasourceId);
-        if (desiredDataSource) {
-          const isCompatible = await datasourcesUi.isDatasourceCompatibleWithColumnsSpec(
-            desiredDatasourceId,
-            referencedColumns,
-            true
-          );
-          if (isCompatible === true) {
-            uploadUi.close();
-            resolve(desiredDataSource);
-            return;
-          }
-        }
-      }
-
-      let title;
-      let message;;
-      const existingDatasource = datasourcesUi.getDatasource(desiredDatasourceId);
-      let openNewDatasourceItem;
-      if (existingDatasource) {
-        openNewDatasourceItem = DataSourceMenu.getDatasourceMenuItemHTML({
-          value: -1,
-          checked: true,
-          labelText: Internationalization.getText('Browse for a new Datasource')
-        });
-        title = 'Incompatible Datasource';
-        message = PageStateManager.#escapePromptText(Internationalization.getText(
-          'The requested {1} {2} isn\'t compatible with your query.', 
-          desiredDatasourceIdParts.type, desiredDatasourceIdParts.localId
-        ));
-        
-        if (newDatasources && newDatasources.length) {
-          const mismatchedColumns = [];
-          const datasourceSettings = settings.getSettings('datasourceSettings');
-          const useLooseColumnComparisonType = datasourceSettings.useLooseColumnTypeComparison;
-          for (let i = 0; i < newDatasources.length; i++){
-            const newDatasource = newDatasources[i];
-            const datasourceId = newDatasource.getId();
-            const isCompatible = await datasourcesUi.isDatasourceCompatibleWithColumnsSpec(
-              datasourceId, 
-              referencedColumns, 
-              useLooseColumnComparisonType
-            );
-            if (isCompatible === true){
-              // this shouldn't happen
-              continue;
-            }
-            isCompatible.forEach((columnName) =>{
-              if (mismatchedColumns.indexOf(columnName) === -1) {
-                mismatchedColumns.push(columnName);
-              }
-            })
-          }
-          const mismatchedColumnsString = mismatchedColumns.map((mismatchedColumnName) =>{
-            const columnDef = referencedColumns[mismatchedColumnName];
-            return PageStateManager.#formatColumnForPrompt(
-              mismatchedColumnName,
-              columnDef ? columnDef.columnType : undefined
-            );
-          }).join(', ');
-          message += '<br/>' + PageStateManager.#escapePromptText(
-            Internationalization.getText('Missing or unmatched columns: {1}', mismatchedColumnsString)
-          );
-        }
-      }
-      else {
-        message = PageStateManager.#escapePromptText(Internationalization.getText(
-          'The requested {1} {2} doesn\'t exist.', 
-          desiredDatasourceIdParts.type, desiredDatasourceIdParts.localId
-        ));
-        openNewDatasourceItem = DataSourceMenu.getDatasourceMenuItemHTML({
-          datasourceType: desiredDatasourceIdParts.type,
-          value: -1,
-          checked: true,
-          labelText: Internationalization.getText('Browse to open {1}', desiredDatasourceIdParts.localId)
-        });
-        title = 'Datasource not found';
-      }
-
-      let list = '<menu class="dataSources">';
-      let datasourceType;
-      const compatibleDatasourceIds = compatibleDatasources ? Object.keys(compatibleDatasources) : [];
-      if (compatibleDatasourceIds.length) {
-        message += '<br/>' + PageStateManager.#escapePromptText(
-          Internationalization.getText('Choose any of the compatible datasources instead, or browse for a new one:')
+    const desiredDatasourceIdParts = DuckDbDataSource.parseId(desiredDatasourceId);
+    
+    if (desiredDatasourceIdParts.isUrl) {
+      const url = desiredDatasourceIdParts.resource;
+      await uploadUi.uploadFiles([url]);
+      desiredDataSource = datasourcesUi.getDatasource(desiredDatasourceId);
+      if (desiredDataSource) {
+        const isCompatible = await datasourcesUi.isDatasourceCompatibleWithColumnsSpec(
+          desiredDatasourceId,
+          referencedColumns,
+          true
         );
-        list += compatibleDatasourceIds.map((compatibleDatasourceId, index) =>{
-          const compatibleDatasource = compatibleDatasources[compatibleDatasourceId];
-          datasourceType = compatibleDatasource.getType();
-          let fileNameParts;
-          switch (datasourceType) {
-            case DuckDbDataSource.types.FILE:
-              const fileName = compatibleDatasource.getFileName();
-              fileNameParts = DuckDbDataSource.getFileNameParts(fileName);
-              break;
-            default:
-          }
-          const caption = DataSourcesUi.getCaptionForDatasource(compatibleDatasource);
-          const datasourceItem = DataSourceMenu.getDatasourceMenuItemHTML({
-            datasourceType: datasourceType,
-            fileType: fileNameParts ? fileNameParts.lowerCaseExtension : undefined,
-            index: index,
-            value: index,
-            labelText: caption
-          });
-          return datasourceItem;
-        }).join('\n');
-      }
-
-      list += openNewDatasourceItem;
-      list += "</menu>";
-      message += list;
-
-      const choice = PromptUi.show({
-        title: Internationalization.getText(title),
-        contents: message,
-        allowUnsafeHtml: true
-      });
-
-      choice
-      .then((choice) =>{
-        switch (choice) {
-          case 'accept':
-            if (compatibleDatasources) {
-              const promptUi = byId('promptUi');
-              const radio = promptUi.querySelector('input[name=compatibleDatasources]:checked');
-              const chosenOption = radio ? parseInt(radio.value, 10) : -1;
-              if (chosenOption !== -1) {
-                const compatibleDatasourceId = radio ? compatibleDatasourceIds[chosenOption] : null;
-                const compatibleDatasource = compatibleDatasources[compatibleDatasourceId];
-                resolve(compatibleDatasource);
-                return;
-              }
-            }
-            byId('uploader').click();
-            // TODO: there's a loose end here
-            // this function returns a promise so we should either reject or resolve.
-            // but this code path does neither.
-            resolve(null);
-            break;
-          case 'reject':
-            reject();
-            break;
+        if (isCompatible === true) {
+          uploadUi.close();
+          return desiredDataSource;
         }
-      })
-      .catch((error) => {
-        console.error('Error in chooseDataSourceForPageStateChangeDialog', error);
-        reject(error);
+      }
+    }
+
+    let title;
+    let message;
+    const existingDatasource = datasourcesUi.getDatasource(desiredDatasourceId);
+    let openNewDatasourceItem;
+    if (existingDatasource) {
+      openNewDatasourceItem = DataSourceMenu.getDatasourceMenuItemHTML({
+        value: -1,
+        checked: true,
+        labelText: Internationalization.getText('Browse for a new Datasource')
       });
+      title = 'Incompatible Datasource';
+      message = PageStateManager.#escapePromptText(Internationalization.getText(
+        'The requested {1} {2} isn\'t compatible with your query.', 
+        desiredDatasourceIdParts.type, desiredDatasourceIdParts.localId
+      ));
+      
+      if (newDatasources && newDatasources.length) {
+        const mismatchedColumns = [];
+        const datasourceSettings = settings.getSettings('datasourceSettings');
+        const useLooseColumnComparisonType = datasourceSettings.useLooseColumnTypeComparison;
+        for (let i = 0; i < newDatasources.length; i++){
+          const newDatasource = newDatasources[i];
+          const datasourceId = newDatasource.getId();
+          const isCompatible = await datasourcesUi.isDatasourceCompatibleWithColumnsSpec(
+            datasourceId, 
+            referencedColumns, 
+            useLooseColumnComparisonType
+          );
+          if (isCompatible === true){
+            continue;
+          }
+          isCompatible.forEach((columnName) =>{
+            if (mismatchedColumns.indexOf(columnName) === -1) {
+              mismatchedColumns.push(columnName);
+            }
+          });
+        }
+        const mismatchedColumnsString = mismatchedColumns.map((mismatchedColumnName) =>{
+          const columnDef = referencedColumns[mismatchedColumnName];
+          return PageStateManager.#formatColumnForPrompt(
+            mismatchedColumnName,
+            columnDef ? columnDef.columnType : undefined
+          );
+        }).join(', ');
+        message += '<br/>' + PageStateManager.#escapePromptText(
+          Internationalization.getText('Missing or unmatched columns: {1}', mismatchedColumnsString)
+        );
+      }
+    }
+    else {
+      message = PageStateManager.#escapePromptText(Internationalization.getText(
+        'The requested {1} {2} doesn\'t exist.', 
+        desiredDatasourceIdParts.type, desiredDatasourceIdParts.localId
+      ));
+      openNewDatasourceItem = DataSourceMenu.getDatasourceMenuItemHTML({
+        datasourceType: desiredDatasourceIdParts.type,
+        value: -1,
+        checked: true,
+        labelText: Internationalization.getText('Browse to open {1}', desiredDatasourceIdParts.localId)
+      });
+      title = 'Datasource not found';
+    }
+
+    let list = '<menu class="dataSources">';
+    let datasourceType;
+    const compatibleDatasourceIds = compatibleDatasources ? Object.keys(compatibleDatasources) : [];
+    if (compatibleDatasourceIds.length) {
+      message += '<br/>' + PageStateManager.#escapePromptText(
+        Internationalization.getText('Choose any of the compatible datasources instead, or browse for a new one:')
+      );
+      list += compatibleDatasourceIds.map((compatibleDatasourceId, index) =>{
+        const compatibleDatasource = compatibleDatasources[compatibleDatasourceId];
+        datasourceType = compatibleDatasource.getType();
+        let fileNameParts;
+        switch (datasourceType) {
+          case DuckDbDataSource.types.FILE:
+            const fileName = compatibleDatasource.getFileName();
+            fileNameParts = DuckDbDataSource.getFileNameParts(fileName);
+            break;
+          default:
+        }
+        const caption = DataSourcesUi.getCaptionForDatasource(compatibleDatasource);
+        const datasourceItem = DataSourceMenu.getDatasourceMenuItemHTML({
+          datasourceType: datasourceType,
+          fileType: fileNameParts ? fileNameParts.lowerCaseExtension : undefined,
+          index: index,
+          value: index,
+          labelText: caption
+        });
+        return datasourceItem;
+      }).join('\n');
+    }
+
+    list += openNewDatasourceItem;
+    list += '</menu>';
+    message += list;
+
+    const choice = await PromptUi.show({
+      title: Internationalization.getText(title),
+      contents: message,
+      allowUnsafeHtml: true
     });
+
+    switch (choice) {
+      case 'accept':
+        if (compatibleDatasources) {
+          const promptUi = byId('promptUi');
+          const radio = promptUi ? promptUi.querySelector('input[name=compatibleDatasources]:checked') : null;
+          const chosenOption = radio ? parseInt(radio.value, 10) : -1;
+          if (chosenOption !== -1) {
+            const compatibleDatasourceId = compatibleDatasourceIds[chosenOption];
+            return compatibleDatasources[compatibleDatasourceId];
+          }
+        }
+        byId('uploader')?.click();
+        return null;
+      case 'reject':
+      case '':
+      case undefined:
+        throw new Error('Datasource selection canceled.');
+      default:
+        throw new Error(`Unexpected prompt result: ${choice}`);
+    }
   }
 
   async setPageState(newRoute, newUploadResults){

--- a/src/Routing/Routing.js
+++ b/src/Routing/Routing.js
@@ -2,6 +2,8 @@
 import { QueryModel } from '../QueryModel/QueryModel.js';
 
 export class Routing {
+
+  static #maxRouteLength = 8192;
  
   static getQueryModelStateFromRoute(route){
     try {
@@ -41,6 +43,10 @@ export class Routing {
     const ascii = encodeURIComponent( json );
     const base64 = btoa( ascii ); 
     const route = base64;
+    if (route.length > Routing.#maxRouteLength) {
+      console.warn(`Route too large to store in location hash (${route.length} > ${Routing.#maxRouteLength}).`);
+      return undefined;
+    }
     return route;
   }
 

--- a/tests/unit/internationalization.test.js
+++ b/tests/unit/internationalization.test.js
@@ -80,4 +80,20 @@ describe('Internationalization', () => {
     expect(script).not.toBeNull();
     expect(script.getAttribute('src')).toContain('Internationalization/i18n/fr-FR.js');
   });
+
+  test('getCurrentLanguage falls back to native language before locale init', async () => {
+    const Internationalization = await loadI18nWithLanguages([]);
+
+    expect(Internationalization.getCurrentLanguage()).toBe('en');
+  });
+
+  test('initialization falls back to native language when navigator.languages is empty', async () => {
+    const Internationalization = await loadI18nWithLanguages([]);
+    const selectorSpy = mockUnsupportedSelector();
+
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    expect(Internationalization.getCurrentLanguage()).toBe('en');
+    selectorSpy.mockRestore();
+  });
 });

--- a/tests/unit/page-state-manager.test.js
+++ b/tests/unit/page-state-manager.test.js
@@ -175,4 +175,16 @@ describe('PageStateManager datasource chooser', () => {
     expect(capturedContents).not.toContain('<img src=x onerror=1>');
     expect(capturedContents).not.toContain('<b>bad</b> VARCHAR<script>');
   });
+
+  test('treats prompt close as a deterministic cancel path', async () => {
+    promptShowMock.mockResolvedValue('');
+    getDatasourceMock.mockReturnValue(undefined);
+
+    const { PageStateManager } = await import('../../src/PageStateManager/PageStateManager.js');
+    const pageStateManager = new PageStateManager();
+
+    await expect(
+      pageStateManager.chooseDataSourceForPageStateChangeDialog({}, 'desired-ds', undefined, undefined)
+    ).rejects.toThrow('Datasource selection canceled.');
+  });
 });

--- a/tests/unit/routing.test.js
+++ b/tests/unit/routing.test.js
@@ -60,4 +60,18 @@ describe('Routing', () => {
     expect(Routing.getRouteForQueryModel({ queryModel: {} })).toBeDefined();
     expect(Routing.getRouteForQueryModel(null)).toBeUndefined();
   });
+
+  test('oversized route state is not serialized into the hash', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const route = Routing.getRouteForQueryModel({
+      datasourceId: 'ds1',
+      axes: {
+        rows: [{ columnName: 'x'.repeat(9000) }],
+      },
+    });
+
+    expect(route).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- harden i18n fallback behavior before locale initialization and when `navigator.languages` is empty
- refactor page-state datasource selection to remove the async `Promise` anti-pattern and make prompt-close cancellation deterministic
- prevent oversized query-state routes from being written into the URL hash
- deduplicate datasource tree loading and track load state for database datasource expansion

## Key Changes
- `src/Internationalization/Internationalization.js`: add safe language fallback behavior
- `src/PageStateManager/PageStateManager.js`: simplify datasource chooser flow and make cancel behavior explicit
- `src/Routing/Routing.js`: skip oversized route hashes and log a warning instead
- `src/DataSource/DataSourcesUi.js`: prevent duplicate in-flight datasource tree loads and repeated node insertion
- `tests/unit/internationalization.test.js`: cover early/fallback i18n behavior
- `tests/unit/routing.test.js`: cover oversized route rejection
- `tests/unit/page-state-manager.test.js`: cover deterministic cancel flow

## Validation
- `npx vitest run tests/unit/internationalization.test.js tests/unit/routing.test.js tests/unit/page-state-manager.test.js`
- `npm run lint:js` *(warnings only, no errors)*
- `npm run test:unit` *(latest `dev` still has 2 unrelated failing tests: `tests/unit/pivot-table-ui-lifecycle.test.js` and `tests/unit/postmessage-interface.test.js`)*