### PR TITLE
Stabilize flaky frontend async tests

### DIFF
--- a/tests/unit/pivot-table-ui-lifecycle.test.js
+++ b/tests/unit/pivot-table-ui-lifecycle.test.js
@@ -274,7 +274,7 @@ describe('PivotTableUi lifecycle flows', () => {
     });
 
     document.getElementById('cancelQueryButton').click();
-    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(tupleSetInstances[0].cancelPendingQuery).toHaveBeenCalledTimes(1);
     expect(tupleSetInstances[1].cancelPendingQuery).toHaveBeenCalledTimes(1);

--- a/tests/unit/postmessage-interface.test.js
+++ b/tests/unit/postmessage-interface.test.js
@@ -226,7 +226,7 @@ describe('PostMessageInterface security hardening', () => {
         },
       },
     }));
-    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
 
     const [response] = source.postMessage.mock.calls[0];
     expect(response.status.code).toBe('Ok');


### PR DESCRIPTION
## Summary
- stabilize `pivot-table-ui-lifecycle` by waiting for the async cancel handler to complete
- stabilize `postmessage-interface` by waiting for the async message handler to complete before asserting on the response

## Validation
- `npx vitest run tests/unit/pivot-table-ui-lifecycle.test.js tests/unit/postmessage-interface.test.js`