### PR TITLE
Relax Playwright app readiness check

### DIFF
--- a/tests/ui/helpers/app-bootstrap.js
+++ b/tests/ui/helpers/app-bootstrap.js
@@ -12,7 +12,9 @@ async function waitForAppReady(page) {
   await expect(page.locator('body')).toHaveAttribute('aria-busy', 'false', { timeout: 60000 });
   await expect(page.locator('#layout')).toBeVisible({ timeout: 60000 });
   await expect(page.locator('#uploader')).toBeAttached({ timeout: 20000 });
-  await expect(page.locator('#runQueryButton')).toBeVisible({ timeout: 30000 });
+  // Autorun may be enabled by persisted settings, in which case the manual
+  // run button remains in the DOM but is intentionally hidden.
+  await expect(page.locator('#runQueryButton')).toBeAttached({ timeout: 30000 });
 }
 
 async function uploadFixtureAndWaitForAttributes(page, fixturePath) {


### PR DESCRIPTION
## Summary
- relax the shared Playwright app-readiness check so it only requires `#runQueryButton` to be attached, not visible
- handle the case where persisted autorun settings intentionally hide the manual run button

## Why
- the existing helper treats a hidden `#runQueryButton` as an app startup failure
- when autorun is enabled, the button remains in the DOM but is intentionally hidden by CSS
- that causes slow 30-second readiness timeouts and noisy e2e failures across multiple specs

## Validation
- local Playwright verification was not practical in this sandbox because the preview server bind is restricted
- this PR is intended for GitHub CI verification