### PR TITLE
Fix datasource settings columns rendering

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -191,7 +191,7 @@ export function initApplication(){
   }, null, 50);
 
   const tupleNumberFormatter = createNumberFormatter(0).format;
-  pivotTableUi.addEventListener('updated', async (e) =>{
+  pivotTableUi.addEventListener('updated', (e) =>{
     const eventData = e.eventData;
     const status = eventData.status;
     

--- a/src/App/analyzeDatasource.js
+++ b/src/App/analyzeDatasource.js
@@ -5,7 +5,7 @@ import { queryModel } from '../QueryModel/QueryModel.js';
 import { attributeUi } from '../AttributeUi/AttributeUi.js';
 import { showErrorDialog } from '../ErrorDialog/ErrorDialog.js';
 
-export async function analyzeDatasource(datasource){
+export function analyzeDatasource(datasource){
   try {
     TabUi.setSelectedTab('#sidebar', '#attributesTab');
     clearSearch();

--- a/src/DataSet/CellSet.js
+++ b/src/DataSet/CellSet.js
@@ -239,7 +239,15 @@ export class CellSet extends DataSetComponent {
 
     const tupleSetIndex = numTupleSets - numRanges;
     const tupleSet = tupleSets[tupleSetIndex];
-    const tupleCount = tupleSet.getTupleCountSync();
+    let tupleCount = tupleSet.getTupleCountSync();
+    if (!tupleCount) {
+      const queryAxisItems = tupleSet.getQueryAxisItems();
+      if (queryAxisItems.length === 0) {
+        // An empty axis still contributes one synthetic coordinate so measure-only
+        // layouts can fetch cells without requiring a physical tuple row.
+        tupleCount = 1;
+      }
+    }
 
     const range = ranges.shift();
     const fromTuple = range[0];
@@ -265,39 +273,41 @@ export class CellSet extends DataSetComponent {
 
   #getTuplesCte(tuplesToQuery, tuplesFields, includeGroupingId){
     const tupleSets = this.#tupleSets;
-    const totalsItems = [];
+    const axisItemsByTupleSet = tupleSets.map((tupleSet) => {
+      return tupleSet.getQueryAxisItems();
+    });
+    const totalsItems = axisItemsByTupleSet.map((queryAxisItems) => {
+      return queryAxisItems.filter((queryAxisItem) => {
+        return queryAxisItem.includeTotals;
+      });
+    });
     const combinationTuples = [];
-    let allQueryAxisItems = [];
+    const allQueryAxisItems = axisItemsByTupleSet.flat();
     const cellIndices = Object.keys(tuplesToQuery);
     _cells: for (let i = 0; i < cellIndices.length; i++) {
       let groupingId = 0;
       const cellIndex = cellIndices[i];
       const combinationTuple = [cellIndex];
       const tuples = tuplesToQuery[cellIndex];
-      _tuples: for (let j = 0; j < tuples.length; j++){
-        const tupleSet = tupleSets[j];
-        const queryAxisItems = tupleSet.getQueryAxisItems();
-        if (i === 0) {
-          allQueryAxisItems = allQueryAxisItems.concat(queryAxisItems);
-          totalsItems[j] = queryAxisItems.filter((queryAxisItem) =>{
-            return queryAxisItem.includeTotals;
-          });
-        }
+      _tuples: for (let j = 0; j < tupleSets.length; j++){
+        const queryAxisItems = axisItemsByTupleSet[j];
         if (j && totalsItems[j] && totalsItems[j].length){
           groupingId <<= totalsItems[j].length;
         }
         const tuple = tuples[j];
-        if (tuple){
+        const fields = tuplesFields[j] || [];
+        if (tuple) {
           groupingId |= parseInt(tuple[TupleSet.groupingIdAlias]) || 0;
-          const tupleValues = tuple.values;
-          const fields = tuplesFields[j];
-          _fields: for (let k = 0; k < queryAxisItems.length; k++){
-            const queryAxisItem = queryAxisItems[k];
-            const tupleValue = tupleValues[k];
-            const tupleValueField = fields[k];
-            const literal = getTupleValueLiteral(queryAxisItem, tupleValue, tupleValueField);
-            combinationTuple.push(literal);
-          }
+        }
+        const tupleValues = tuple ? tuple.values : [];
+        _fields: for (let k = 0; k < queryAxisItems.length; k++){
+          const queryAxisItem = queryAxisItems[k];
+          const tupleValue = tupleValues[k];
+          const tupleValueField = fields[k];
+          const literal = tuple
+            ? getTupleValueLiteral(queryAxisItem, tupleValue, tupleValueField)
+            : 'NULL';
+          combinationTuple.push(literal);
         }
       }
       if (includeGroupingId) {
@@ -307,7 +317,14 @@ export class CellSet extends DataSetComponent {
     }
     
     if (cellIndices.length === 0){
-      combinationTuples.push([0]);
+      const emptyTuple = [0];
+      for (let i = 0; i < allQueryAxisItems.length; i++) {
+        emptyTuple.push('NULL');
+      }
+      if (includeGroupingId) {
+        emptyTuple.push(0);
+      }
+      combinationTuples.push(emptyTuple);
     }
     let tuplesSql = combinationTuples.map((combinationTuple) =>{
       return `(${combinationTuple.join(', ')})`;
@@ -640,6 +657,33 @@ export class CellSet extends DataSetComponent {
     return cells;
   }
 
+  async #ensureTuplesReadyForRanges(ranges){
+    const preloadPromises = [];
+    for (let i = 0; i < this.#tupleSets.length; i++) {
+      const tupleSet = this.#tupleSets[i];
+      const range = ranges[i];
+      if (!tupleSet || !range) {
+        continue;
+      }
+      const queryAxisItems = tupleSet.getQueryAxisItems();
+      if (!queryAxisItems.length) {
+        continue;
+      }
+      if (typeof tupleSet.getTuples !== 'function') {
+        continue;
+      }
+      const from = range[0];
+      let count = range[1] - range[0];
+      if (count <= 0) {
+        count = 1;
+      }
+      preloadPromises.push(tupleSet.getTuples(count, from));
+    }
+    if (preloadPromises.length) {
+      await Promise.all(preloadPromises);
+    }
+  }
+
   // ranges is aa list of tuple index pairs
   async getCells(ranges){
     const queryModel = this.getQueryModel();
@@ -649,6 +693,8 @@ export class CellSet extends DataSetComponent {
     if (cellsAxisItems.length === 0){
       return undefined;
     }
+
+    await this.#ensureTuplesReadyForRanges(ranges);
 
     const tupleIndices = this.getTupleRanges(ranges);
     const tupleSets = this.#tupleSets;
@@ -714,10 +760,18 @@ export class CellSet extends DataSetComponent {
         const tupleIndex = tupleIndicesItem[j];
         const tupleSet = tupleSets[j];
 
-        const tuple = tupleSet.getTupleSync(tupleIndex);
+        let tuple = tupleSet.getTupleSync(tupleIndex);
         if (!tuple) {
-          // this shouldn't happen!
-          // if we arrive here it means we messed up while calculating the tuple ranges.
+          const queryAxisItems = tupleSet.getQueryAxisItems();
+          const tupleCount = tupleSet.getTupleCountSync();
+          if (queryAxisItems.length && tupleCount !== 0) {
+            const fetchedTuples = await tupleSet.getTuples(1, tupleIndex);
+            tuple = fetchedTuples && fetchedTuples.length ? fetchedTuples[0] : tupleSet.getTupleSync(tupleIndex);
+          }
+        }
+        if (!tuple) {
+          // Empty axes may intentionally have no physical tuple. Non-empty axes should
+          // usually have been loaded by now, but if not we skip and let SQL fall back.
           continue;
         }
         tuplesForCell[j] = tuple;

--- a/src/DataSet/TupleSet.js
+++ b/src/DataSet/TupleSet.js
@@ -331,10 +331,8 @@ export class TupleSet extends DataSetComponent {
   /**
    * @returns {Promise<number|undefined>}
    */
-  async getTupleCount(){
-    return new Promise(function(resolve, _reject){
-      resolve(this.#tupleCount);
-    });
+  getTupleCount(){
+    return Promise.resolve(this.#tupleCount);
   }
 
   #loadTuples(resultSet, offset) {

--- a/src/DatasourceSettingsDialog/DatasourceSettingsDialog.css
+++ b/src/DatasourceSettingsDialog/DatasourceSettingsDialog.css
@@ -18,3 +18,23 @@ dialog#datasourceSettingsDialog {
 output#datasourceFileSize:not(:empty):after {
   content: ' bytes';
 }
+
+dialog#datasourceSettingsDialog .datasourceSettingsColumnsTable {
+  width: 100%;
+  border-collapse: collapse;
+  background-color: var( --huey-light-background-color );
+}
+
+dialog#datasourceSettingsDialog .datasourceSettingsColumnsTable th,
+dialog#datasourceSettingsDialog .datasourceSettingsColumnsTable td {
+  padding: 2px 6px;
+  border: 1px solid var( --huey-light-border-color );
+  text-align: left;
+  white-space: nowrap;
+}
+
+dialog#datasourceSettingsDialog .datasourceSettingsColumnsTable th {
+  position: sticky;
+  top: 0;
+  background-color: var( --huey-medium-background-color );
+}

--- a/src/DatasourceSettingsDialog/DatasourceSettingsDialog.js
+++ b/src/DatasourceSettingsDialog/DatasourceSettingsDialog.js
@@ -51,8 +51,7 @@ export class DatasourceSettingsDialog extends SettingsDialogBase {
   #datasource = undefined;
 
   #columnsTabDatasource = undefined;
-  #columnsTabQueryModel = undefined;
-  #columnsTabPivotTableUi = undefined;
+  #columnsTabPanel = undefined;
 
   #rejectsDatasource = undefined;
   #rejectsTabQueryModel = undefined;
@@ -96,6 +95,78 @@ export class DatasourceSettingsDialog extends SettingsDialogBase {
     this.#initCsvReaderOptionsTab();
     this.#initColumnsTab();
     this.#initRejectsTab();
+  }
+
+  async #waitForDialogLayout(){
+    await new Promise((resolve) => {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(resolve);
+      });
+    });
+  }
+
+  async #getColumnsTabQueryResult(sql){
+    const connection = this.#columnsTabDatasource.getManagedConnection();
+    const result = await connection.query(sql);
+    const rowCount = result.numRows || 0;
+    const fields = result.schema && result.schema.fields ? result.schema.fields.map((field) => field.name) : [];
+    const rows = [];
+    for (let i = 0; i < rowCount; i++) {
+      const row = result.get(i);
+      const plainRow = {};
+      for (let j = 0; j < fields.length; j++) {
+        const fieldName = fields[j];
+        plainRow[fieldName] = row[fieldName];
+      }
+      rows.push(plainRow);
+    }
+    return {
+      fields,
+      rows
+    };
+  }
+
+  #renderColumnsTabResult(fields, rows){
+    if (!this.#columnsTabPanel) {
+      return;
+    }
+
+    const fieldOrder = ['#', 'column_name', 'column_type'].filter((fieldName) => {
+      return fields.indexOf(fieldName) !== -1;
+    });
+    const fieldLabels = {
+      '#': '#',
+      column_name: 'Column Name',
+      column_type: 'Data Type'
+    };
+
+    const table = document.createElement('table');
+    table.className = 'datasourceSettingsColumnsTable';
+
+    const thead = document.createElement('thead');
+    const headerRow = document.createElement('tr');
+    fieldOrder.forEach((fieldName) => {
+      const th = document.createElement('th');
+      th.textContent = fieldLabels[fieldName];
+      headerRow.appendChild(th);
+    });
+    thead.appendChild(headerRow);
+    table.appendChild(thead);
+
+    const tbody = document.createElement('tbody');
+    rows.forEach((row) => {
+      const tr = document.createElement('tr');
+      fieldOrder.forEach((fieldName) => {
+        const td = document.createElement('td');
+        const value = row[fieldName];
+        td.textContent = value === null || value === undefined ? '' : String(value);
+        tr.appendChild(td);
+      });
+      tbody.appendChild(tr);
+    });
+    table.appendChild(tbody);
+
+    this.#columnsTabPanel.replaceChildren(table);
   }
 
   async #autodetectCsvReaderSettings(_event){
@@ -187,26 +258,15 @@ export class DatasourceSettingsDialog extends SettingsDialogBase {
       getDatabase(),
       'DESCRIBE SELECT 1'
     );
-
-    this.#columnsTabQueryModel = new QueryModel();
     
     const tabId = 'datasourceSettingsDialogColumnsTab';
-    const columnsTabPanel = TabUi.getTabPanel(
+    this.#columnsTabPanel = TabUi.getTabPanel(
       DatasourceSettingsDialog.#tabListSelector,
       `#${tabId}`
     );
-    this.#columnsTabPivotTableUi = new PivotTableUi({
-      container: columnsTabPanel,
-      id: tabId + 'PivotTableUi',
-      queryModel: this.#columnsTabQueryModel,
-      settings: DatasourceSettingsDialog.#dialogPivotSettings()
-    });
-    
-    //let pivotTableUiContextMenu = new ContextMenu(this.#columnsTabPivotTableUi, 'pivotTableContextMenu');
-     
   }
 
-  async #downloadCsvReaderRejectsHandler(_event){
+  #downloadCsvReaderRejectsHandler(_event){
     const exportUiSettings = settings.getSettings('exportUi');
     exportUiSettings.exportTitleTemplate = '${datasource}';
     exportUiSettings.exportResultShapePivot = true;
@@ -255,7 +315,7 @@ export class DatasourceSettingsDialog extends SettingsDialogBase {
     });
   }
 
-  #updateColumnsTabData(){
+  async #updateColumnsTabData(){
     const datasource = this.#datasource;
 
     // Prepare our column datasource (reuse same instance; setState will clear and repopulate)
@@ -265,22 +325,11 @@ export class DatasourceSettingsDialog extends SettingsDialogBase {
       `FROM (${datasource.getSqlForTableSchema()}) as ds_schema`
     ].join('\n');
     this.#columnsTabDatasource.setSqlQuery(sql);
-
-    // re-initialize the query model.
-    const axes = {};
-    axes[QueryModel.AXIS_ROWS] = [{column: '#', columnType: 'USMALLINT'}];
-    axes[QueryModel.AXIS_CELLS] = [
-      {caption: "Column Name", column: 'column_name', columnType: 'VARCHAR', aggregator: 'min'},
-      {caption: "Data Type", column: 'column_type', columnType: 'VARCHAR', aggregator: 'min'}
-    ];
-    this.#columnsTabQueryModel.setState({
-      axes: axes,
-      datasource: this.#columnsTabDatasource
-    });
-    this.#columnsTabPivotTableUi.updatePivotTableUi();
+    const result = await this.#getColumnsTabQueryResult(sql);
+    this.#renderColumnsTabResult(result.fields, result.rows);
   }
 
-  #updateRejectsTabData(){
+  async #updateRejectsTabData(){
     const datasource = this.#datasource;
 
     // first clean up the datasource
@@ -310,7 +359,7 @@ export class DatasourceSettingsDialog extends SettingsDialogBase {
       axes: axes,
       datasource: rejectsDatasource
     });
-    this.#rejectsTabPivotTableUi.updatePivotTableUi();
+    await this.#rejectsTabPivotTableUi.updatePivotTableUi();
   }
 
   async setDatasource(datasource){
@@ -340,19 +389,20 @@ export class DatasourceSettingsDialog extends SettingsDialogBase {
 
     byId('datasourceFileSize').value = fileSize;
 
-    this.#updateColumnsTabData();
-    this.#updateRejectsTabData();
-
     TabUi.setSelectedTab(
       DatasourceSettingsDialog.#tabListSelector,
       '#datasourceSettingsDialogColumnsTab'
     );
+
+    await this.#waitForDialogLayout();
+    await this.#updateColumnsTabData();
+    await this.#updateRejectsTabData();
   }
 
   open(datasource) {
-    this.setDatasource(datasource);
     const settings = datasource.getSettings();
     super.open(settings);
+    void this.setDatasource(datasource);
   }
 }
 

--- a/src/PivotTableUi/PivotTableUi.js
+++ b/src/PivotTableUi/PivotTableUi.js
@@ -564,7 +564,7 @@ export class PivotTableUi extends EventEmitter {
     if (tupleIndexInfo.cellsAxisItemIndex){
       tupleCount += 1;
     }
-    const allTupleCount = this.#columnsTupleSet.getTupleCountSync();
+    const allTupleCount = this.#getEffectiveTupleCountForAxis(QueryModel.AXIS_COLUMNS);
     if (tupleIndexInfo.tupleIndex + tupleCount >= allTupleCount) {
       const maxPhysicalColumn = allTupleCount * tupleIndexInfo.factor;
       physicalColumnsAxisTupleIndex = maxPhysicalColumn - count;
@@ -642,7 +642,7 @@ export class PivotTableUi extends EventEmitter {
       tupleCount += 1;
     }
     const tupleSet = this.#columnsTupleSet;
-    const lastTupleIndex = tupleSet.getTupleCountSync() - 1;
+    const lastTupleIndex = this.#getEffectiveTupleCountForAxis(axisId) - 1;
 
     const queryModel = this.getQueryModel();
     const queryAxis = queryModel.getColumnsAxis();
@@ -824,7 +824,7 @@ export class PivotTableUi extends EventEmitter {
       tupleCount += 1;
     }      
     const tupleSet = this.#rowsTupleSet;
-    const lastTupleIndex = tupleSet.getTupleCountSync() - 1;
+    const lastTupleIndex = this.#getEffectiveTupleCountForAxis(axisId) - 1;
 
     const queryModel = this.getQueryModel();
     const queryAxis = queryModel.getRowsAxis();
@@ -1143,7 +1143,7 @@ export class PivotTableUi extends EventEmitter {
           }
         }
         else {
-          numColumnsAxisTuples = 0;
+          numColumnsAxisTuples = cellsAxisItems.length ? 1 : 0;
         }
         numRowsAxisTuples = rowsAxisItems.length ? tableBodyRows.length - 1 : 0;
         break;
@@ -1156,7 +1156,7 @@ export class PivotTableUi extends EventEmitter {
           }
         }
         else {
-          numRowsAxisTuples = 0;
+          numRowsAxisTuples = cellsAxisItems.length ? 1 : 0;
         }
         break;
     }
@@ -1696,8 +1696,11 @@ export class PivotTableUi extends EventEmitter {
             "role": "rowheader"
           });
 
-          const headerCell = firstTableHeaderRowCells[bodyRow.childNodes.length];
-          let headerCellWidth = parseInt(headerCell.style.width, 10);
+          const headerCell = firstTableHeaderRowCells.item(bodyRow.childNodes.length);
+          let headerCellWidth = parseInt(headerCell && headerCell.style ? headerCell.style.width : '', 10);
+          if (isNaN(headerCellWidth)) {
+            headerCellWidth = 0;
+          }
 
           bodyRow.appendChild(cell);
 
@@ -1741,7 +1744,9 @@ export class PivotTableUi extends EventEmitter {
               headerCellWidth = PivotTableUi.#maximumCellWidth;
             }
 
-            headerCell.style.width = headerCellWidth + 'ch';
+            if (headerCell) {
+              headerCell.style.width = headerCellWidth + 'ch';
+            }
             cell.style.width = headerCellWidth + 'ch';
           }
         }
@@ -1941,6 +1946,36 @@ export class PivotTableUi extends EventEmitter {
     sizer.style.width = size + 'px';
   }
 
+  #getEffectiveTupleCountForAxis(axisId){
+    let tupleSet;
+    switch (axisId){
+      case QueryModel.AXIS_COLUMNS:
+        tupleSet = this.#columnsTupleSet;
+        break;
+      case QueryModel.AXIS_ROWS:
+        tupleSet = this.#rowsTupleSet;
+        break;
+      default:
+        throw new Error(`Invalid axis id ${axisId}.`);
+    }
+
+    const tupleCount = tupleSet.getTupleCountSync();
+    if (tupleCount === undefined) {
+      return 1;
+    }
+
+    if (tupleCount === 0) {
+      const queryModel = this.getQueryModel();
+      const axisItems = queryModel.getQueryAxis(axisId).getItems();
+      const cellsAxisItems = queryModel.getCellsAxis().getItems();
+      if (axisItems.length === 0 && queryModel.getCellHeadersAxis() === axisId && cellsAxisItems.length) {
+        return 1;
+      }
+    }
+
+    return tupleCount;
+  }
+
   #getNumberOfPhysicalTuplesForAxis(axisId){
     const queryModel = this.getQueryModel();
     const cellHeadersAxis = queryModel.getCellHeadersAxis();
@@ -1955,22 +1990,7 @@ export class PivotTableUi extends EventEmitter {
     if (!factor) {
       factor = 1;
     }
-
-    let tupleSet;
-    switch (axisId){
-      case QueryModel.AXIS_COLUMNS:
-        tupleSet = this.#columnsTupleSet;
-        break;
-      case QueryModel.AXIS_ROWS:
-        tupleSet = this.#rowsTupleSet;
-        break;
-      default:
-        throw new Error(`Invalid axis id ${axisId}.`);
-    }
-    let tupleCount = tupleSet.getTupleCountSync();
-    if (tupleCount === undefined) {
-      tupleCount = 1;
-    }
+    const tupleCount = this.#getEffectiveTupleCountForAxis(axisId);
     const numberOfPhysicalRows = tupleCount * factor;
     return numberOfPhysicalRows;
   }

--- a/tests/unit/cellset-fetch.test.js
+++ b/tests/unit/cellset-fetch.test.js
@@ -137,4 +137,436 @@ describe('CellSet cell fetching flows', () => {
     expect(secondFetch[0].values[measureSql]).toBe(42);
     expect(cellSet.getCellValueFields()[measureSql].type.typeId).toBe(DOUBLE_TYPE_ID);
   });
+
+  test('builds a valid local cells query when rows exist and the columns axis is empty', async () => {
+    const queryModelModule = await import('../../src/QueryModel/QueryModel.js');
+    const { CellSet } = await import('../../src/DataSet/CellSet.js');
+
+    const rowItem = {
+      axis: queryModelModule.QueryModel.AXIS_ROWS,
+      columnName: '#',
+      columnType: 'USMALLINT',
+    };
+    const measureItem = {
+      axis: queryModelModule.QueryModel.AXIS_CELLS,
+      columnName: 'column_name',
+      columnType: 'VARCHAR',
+      aggregator: 'min',
+      caption: 'Column Name',
+    };
+
+    const query = vi.fn().mockResolvedValue({
+      numRows: 1,
+      schema: {
+        fields: [
+          { name: '__huey_cellIndex' },
+          { name: 'MIN( "__data"."column_name" )', type: { typeId: 5 } },
+        ],
+      },
+      get() {
+        return {
+          __huey_cellIndex: 0,
+          'MIN( "__data"."column_name" )': 'id',
+        };
+      },
+    });
+
+    const datasource = {
+      getType() {
+        return 'file';
+      },
+      getManagedConnection() {
+        return { query };
+      },
+      getFromClauseSql() {
+        return 'FROM test_relation';
+      },
+    };
+
+    const queryModel = {
+      getDatasource() {
+        return datasource;
+      },
+      getCellsAxis() {
+        return { getItems: () => [measureItem] };
+      },
+      getRowsAxis() {
+        return { getItems: () => [rowItem] };
+      },
+      getColumnsAxis() {
+        return { getItems: () => [] };
+      },
+      getFiltersAxis() {
+        return { getItems: () => [] };
+      },
+      getSampling() {
+        return undefined;
+      },
+    };
+
+    const rowsTupleSet = {
+      getTupleCountSync() {
+        return 1;
+      },
+      getTupleSync() {
+        return { values: [1] };
+      },
+      getTupleValueFields() {
+        return [{ name: '#', type: { typeId: 5 } }];
+      },
+      getQueryAxisItems() {
+        return [rowItem];
+      },
+    };
+    const columnsTupleSet = {
+      getTupleCountSync() {
+        return 0;
+      },
+      getTupleSync() {
+        return undefined;
+      },
+      getTupleValueFields() {
+        return [];
+      },
+      getQueryAxisItems() {
+        return [];
+      },
+    };
+
+    const cellSet = new CellSet(queryModel, [rowsTupleSet, columnsTupleSet], createSettings());
+    const cells = await cellSet.getCells([[0, 1], [0, 0]]);
+
+    expect(query).toHaveBeenCalledTimes(1);
+    const sql = query.mock.calls[0][0];
+    expect(sql).toContain(', __huey_tuples(\n  __huey_cellIndex\n, "#"');
+    expect(sql).toContain('ON  __huey_tuples."#" is not distinct from __huey_cells."#"');
+    expect(Object.values(cells[0].values)).toEqual(['id']);
+  });
+
+  test('keeps tuple relation columns when one axis tuple is missing', async () => {
+    const queryModelModule = await import('../../src/QueryModel/QueryModel.js');
+    const { CellSet } = await import('../../src/DataSet/CellSet.js');
+
+    const rowItem = {
+      axis: queryModelModule.QueryModel.AXIS_ROWS,
+      columnName: '#',
+      columnType: 'USMALLINT',
+    };
+    const measureItem = {
+      axis: queryModelModule.QueryModel.AXIS_CELLS,
+      columnName: 'column_name',
+      columnType: 'VARCHAR',
+      aggregator: 'min',
+      caption: 'Column Name',
+    };
+
+    const query = vi.fn().mockResolvedValue({
+      numRows: 1,
+      schema: {
+        fields: [
+          { name: '__huey_cellIndex' },
+          { name: 'MIN( "__data"."column_name" )', type: { typeId: 5 } },
+        ],
+      },
+      get() {
+        return {
+          __huey_cellIndex: 0,
+          'MIN( "__data"."column_name" )': 'id',
+        };
+      },
+    });
+
+    const datasource = {
+      getType() {
+        return 'file';
+      },
+      getManagedConnection() {
+        return { query };
+      },
+      getFromClauseSql() {
+        return 'FROM test_relation';
+      },
+    };
+
+    const queryModel = {
+      getDatasource() {
+        return datasource;
+      },
+      getCellsAxis() {
+        return { getItems: () => [measureItem] };
+      },
+      getRowsAxis() {
+        return { getItems: () => [rowItem] };
+      },
+      getColumnsAxis() {
+        return { getItems: () => [] };
+      },
+      getFiltersAxis() {
+        return { getItems: () => [] };
+      },
+      getSampling() {
+        return undefined;
+      },
+    };
+
+    const rowsTupleSet = {
+      getTupleCountSync() {
+        return 1;
+      },
+      getTupleSync() {
+        return { values: [1] };
+      },
+      getTupleValueFields() {
+        return [{ name: '#', type: { typeId: 5 } }];
+      },
+      getQueryAxisItems() {
+        return [rowItem];
+      },
+    };
+    const columnsTupleSet = {
+      getTupleCountSync() {
+        return 1;
+      },
+      getTupleSync() {
+        return undefined;
+      },
+      getTupleValueFields() {
+        return [];
+      },
+      getQueryAxisItems() {
+        return [];
+      },
+    };
+
+    const cellSet = new CellSet(queryModel, [rowsTupleSet, columnsTupleSet], createSettings());
+    await cellSet.getCells([[0, 1], [0, 1]]);
+
+    expect(query).toHaveBeenCalledTimes(1);
+    const sql = query.mock.calls[0][0];
+    expect(sql).toContain(', __huey_tuples(\n  __huey_cellIndex\n, "#"');
+    expect(sql).not.toContain(', __huey_tuples(\n  __huey_cellIndex\n) AS');
+  });
+
+  test('preloads missing row tuples before building the local cells query', async () => {
+    const queryModelModule = await import('../../src/QueryModel/QueryModel.js');
+    const { CellSet } = await import('../../src/DataSet/CellSet.js');
+
+    const rowItem = {
+      axis: queryModelModule.QueryModel.AXIS_ROWS,
+      columnName: '#',
+      columnType: 'USMALLINT',
+    };
+    const measureItem = {
+      axis: queryModelModule.QueryModel.AXIS_CELLS,
+      columnName: 'column_name',
+      columnType: 'VARCHAR',
+      aggregator: 'min',
+      caption: 'Column Name',
+    };
+
+    const query = vi.fn().mockResolvedValue({
+      numRows: 1,
+      schema: {
+        fields: [
+          { name: '__huey_cellIndex' },
+          { name: 'MIN( "__data"."column_name" )', type: { typeId: 5 } },
+        ],
+      },
+      get() {
+        return {
+          __huey_cellIndex: 0,
+          'MIN( "__data"."column_name" )': 'id',
+        };
+      },
+    });
+
+    const datasource = {
+      getType() {
+        return 'file';
+      },
+      getManagedConnection() {
+        return { query };
+      },
+      getFromClauseSql() {
+        return 'FROM test_relation';
+      },
+    };
+
+    const queryModel = {
+      getDatasource() {
+        return datasource;
+      },
+      getCellsAxis() {
+        return { getItems: () => [measureItem] };
+      },
+      getRowsAxis() {
+        return { getItems: () => [rowItem] };
+      },
+      getColumnsAxis() {
+        return { getItems: () => [] };
+      },
+      getFiltersAxis() {
+        return { getItems: () => [] };
+      },
+      getSampling() {
+        return undefined;
+      },
+    };
+
+    let rowLoaded = false;
+    const rowsTupleSet = {
+      getTupleCountSync() {
+        return rowLoaded ? 1 : undefined;
+      },
+      getTupleSync() {
+        return rowLoaded ? { values: [1] } : undefined;
+      },
+      getTupleValueFields() {
+        return [{ name: '#', type: { typeId: 5 } }];
+      },
+      getQueryAxisItems() {
+        return [rowItem];
+      },
+      getTuples: vi.fn(async () => {
+        rowLoaded = true;
+        return [{ values: [1] }];
+      }),
+    };
+    const columnsTupleSet = {
+      getTupleCountSync() {
+        return 0;
+      },
+      getTupleSync() {
+        return undefined;
+      },
+      getTupleValueFields() {
+        return [];
+      },
+      getQueryAxisItems() {
+        return [];
+      },
+      getTuples: vi.fn(async () => []),
+    };
+
+    const cellSet = new CellSet(queryModel, [rowsTupleSet, columnsTupleSet], createSettings());
+    await cellSet.getCells([[0, 1], [0, 1]]);
+
+    expect(rowsTupleSet.getTuples).toHaveBeenCalledWith(1, 0);
+    const sql = query.mock.calls[0][0];
+    expect(sql).toContain('(0, 1)');
+    expect(sql).not.toContain('(0, NULL)');
+  });
+
+  test('preloads requested tuple ranges even when tuple count is already known', async () => {
+    const queryModelModule = await import('../../src/QueryModel/QueryModel.js');
+    const { CellSet } = await import('../../src/DataSet/CellSet.js');
+
+    const rowItem = {
+      axis: queryModelModule.QueryModel.AXIS_ROWS,
+      columnName: '#',
+      columnType: 'USMALLINT',
+    };
+    const measureItem = {
+      axis: queryModelModule.QueryModel.AXIS_CELLS,
+      columnName: 'column_name',
+      columnType: 'VARCHAR',
+      aggregator: 'min',
+      caption: 'Column Name',
+    };
+
+    const query = vi.fn().mockResolvedValue({
+      numRows: 1,
+      schema: {
+        fields: [
+          { name: '__huey_cellIndex' },
+          { name: 'MIN( "__data"."column_name" )', type: { typeId: 5 } },
+        ],
+      },
+      get() {
+        return {
+          __huey_cellIndex: 0,
+          'MIN( "__data"."column_name" )': 'id',
+        };
+      },
+    });
+
+    const datasource = {
+      getType() {
+        return 'file';
+      },
+      getManagedConnection() {
+        return { query };
+      },
+      getFromClauseSql() {
+        return 'FROM test_relation';
+      },
+    };
+
+    const queryModel = {
+      getDatasource() {
+        return datasource;
+      },
+      getCellsAxis() {
+        return { getItems: () => [measureItem] };
+      },
+      getRowsAxis() {
+        return { getItems: () => [rowItem] };
+      },
+      getColumnsAxis() {
+        return { getItems: () => [] };
+      },
+      getFiltersAxis() {
+        return { getItems: () => [] };
+      },
+      getSampling() {
+        return undefined;
+      },
+    };
+
+    let loadedRange;
+    const rowsTupleSet = {
+      getTupleCountSync() {
+        return 25;
+      },
+      getTupleSync(index) {
+        if (loadedRange && index >= loadedRange[0] && index < loadedRange[1]) {
+          return { values: [index + 1] };
+        }
+        return undefined;
+      },
+      getTupleValueFields() {
+        return [{ name: '#', type: { typeId: 5 } }];
+      },
+      getQueryAxisItems() {
+        return [rowItem];
+      },
+      getTuples: vi.fn(async (count, from) => {
+        loadedRange = [from, from + count];
+        return Array.from({ length: count }, (_value, idx) => ({ values: [from + idx + 1] }));
+      }),
+    };
+    const columnsTupleSet = {
+      getTupleCountSync() {
+        return 0;
+      },
+      getTupleSync() {
+        return undefined;
+      },
+      getTupleValueFields() {
+        return [];
+      },
+      getQueryAxisItems() {
+        return [];
+      },
+      getTuples: vi.fn(async () => []),
+    };
+
+    const cellSet = new CellSet(queryModel, [rowsTupleSet, columnsTupleSet], createSettings());
+    await cellSet.getCells([[0, 25], [0, 1]]);
+
+    expect(rowsTupleSet.getTuples).toHaveBeenCalledWith(25, 0);
+    const sql = query.mock.calls[0][0];
+    expect(sql).toContain('(0, 1)');
+    expect(sql).toContain('(24, 25)');
+  });
 });

--- a/tests/unit/pivot-table-ui-lifecycle.test.js
+++ b/tests/unit/pivot-table-ui-lifecycle.test.js
@@ -258,6 +258,35 @@ describe('PivotTableUi lifecycle flows', () => {
     expect(pivotTableUi.getDom().querySelector('.pivotTableUiTableBody').childNodes.length).toBeGreaterThan(0);
   });
 
+  test('updatePivotTableUi requests one synthetic column tuple when only cell headers are on columns', async () => {
+    const { PivotTableUi } = await import('../../src/PivotTableUi/PivotTableUi.js');
+    const pivotTableUi = new PivotTableUi({
+      id: 'pivotTableUi',
+      container: 'workarea',
+      queryModel: createQueryModel(),
+      settings: {
+        getSettings(path) {
+          if (path === 'querySettings') {
+            return { autoRunQuery: false, autoRunQueryTimeout: 1 };
+          }
+          if (path === 'pivotSettings') {
+            return { totalsString: 'Totals', hideRepeatingAxisValues: true, defaultDittoMark: '〃', maximumCellWidth: 30 };
+          }
+          return {};
+        },
+      },
+    });
+
+    const innerContainer = pivotTableUi.getDom().querySelector('.pivotTableUiInnerContainer');
+    const table = pivotTableUi.getDom().querySelector('.pivotTableUiTable');
+    setElementDimensions(innerContainer, { clientWidth: 640, clientHeight: 320, scrollWidth: 640, scrollHeight: 320, scrollLeft: 0, scrollTop: 0 });
+    setElementDimensions(table, { clientWidth: 240, clientHeight: 120 });
+
+    await pivotTableUi.updatePivotTableUi();
+
+    expect(cellSetInstances[0].getCells).toHaveBeenCalledWith([[0, 1], [0, 1]]);
+  });
+
   test('cancel query button cancels pending tuple and cell requests and marks the table dirty', async () => {
     const { PivotTableUi } = await import('../../src/PivotTableUi/PivotTableUi.js');
     const pivotTableUi = new PivotTableUi({


### PR DESCRIPTION
## Summary
- render the datasource settings Columns tab from the schema query result directly
- harden tuple/cell handling for empty synthetic axes in PivotTableUi and CellSet
- add regression coverage for the schema/cell query edge cases

## Validation
- npm run test:unit -- tests/unit/pivot-table-ui-lifecycle.test.js tests/unit/cellset-fetch.test.js tests/unit/cellset-core.test.js
- npm run lint:js