### PR TITLE
Add frontend performance benchmark harness

### DIFF
--- a/benchmarks/ui/baseline_metrics.json
+++ b/benchmarks/ui/baseline_metrics.json
@@ -1,0 +1,67 @@
+{
+  "profile": "local-dev-reference-2026-03-09",
+  "notes": "Reference frontend benchmark baseline captured on a local development machine via scripts/ui_benchmark_runner.cjs. Use for relative before/after comparisons, not as a hard universal SLO.",
+  "scenarios": [
+    {
+      "name": "app_ready",
+      "wallTimeMs": 4135,
+      "uiMetrics": null,
+      "sql": {
+        "count": 0,
+        "totalTimeMs": 0,
+        "byKind": {}
+      }
+    },
+    {
+      "name": "upload_wide_schema",
+      "wallTimeMs": 3967,
+      "uiMetrics": null,
+      "sql": {
+        "count": 0,
+        "totalTimeMs": 0,
+        "byKind": {}
+      }
+    },
+    {
+      "name": "long_pivot_first_run",
+      "wallTimeMs": 455,
+      "uiMetrics": {
+        "queryTimeMs": 50,
+        "renderTimeMs": 141,
+        "totalTimeMs": 191
+      },
+      "sql": {
+        "count": 2,
+        "totalTimeMs": 148,
+        "byKind": {
+          "tuples": 1,
+          "cells": 1
+        }
+      }
+    },
+    {
+      "name": "long_pivot_rerun",
+      "wallTimeMs": 71,
+      "uiMetrics": {
+        "queryTimeMs": 0,
+        "renderTimeMs": 46,
+        "totalTimeMs": 46
+      },
+      "sql": {
+        "count": 0,
+        "totalTimeMs": 0,
+        "byKind": {}
+      }
+    },
+    {
+      "name": "long_pivot_scroll",
+      "wallTimeMs": 512,
+      "uiMetrics": null,
+      "sql": {
+        "count": 0,
+        "totalTimeMs": 0,
+        "byKind": {}
+      }
+    }
+  ]
+}

--- a/docs/frontend-performance-benchmarks.md
+++ b/docs/frontend-performance-benchmarks.md
@@ -1,0 +1,78 @@
+# Frontend performance benchmarks
+
+This document describes the repeatable benchmark workflow for Huey's local-mode frontend performance.
+
+## Goal
+
+Use the same benchmark scenarios before and after frontend optimizations so changes are measured against a stable baseline instead of relying on ad hoc console inspection.
+
+## Runner
+
+Run:
+
+```bash
+npm run perf:ui
+```
+
+By default this:
+
+- builds the frontend bundle
+- starts the local preview server on `http://127.0.0.1:8765`
+- runs benchmark scenarios in Chromium
+- writes artifacts to `artifacts/ui-benchmarks/latest`
+
+Optional flags:
+
+```bash
+node scripts/ui_benchmark_runner.cjs --output-dir artifacts/ui-benchmarks/run-a --baseline benchmarks/ui/baseline_metrics.json
+```
+
+## Scenarios
+
+The benchmark runner currently measures:
+
+- `app_ready`: app load to interactive shell
+- `upload_wide_schema`: upload `tests/fixtures/parquet/wide.parquet` and wait for schema/attributes
+- `long_pivot_first_run`: upload `tests/fixtures/parquet/long.parquet`, build a pivot, and run the first query
+- `long_pivot_rerun`: re-run the same pivot to observe cache behavior
+- `long_pivot_scroll`: scroll an already-run tall pivot and measure viewport update latency
+
+## Metrics
+
+Each scenario records:
+
+- `wallTimeMs`: end-to-end wall clock time for the scenario
+- `uiMetrics.queryTimeMs`: Huey's measured query time when available
+- `uiMetrics.renderTimeMs`: Huey's measured render time when available
+- `uiMetrics.totalTimeMs`: Huey's measured total time when available
+- `sql.count`: number of DuckDB queries logged during the scenario
+- `sql.totalTimeMs`: summed DuckDB query time from logged statements
+- `sql.byKind`: query counts split into `schema`, `tuples`, `cells`, and `other`
+
+## Artifacts
+
+The runner writes:
+
+- `ui-benchmark-report.json`: full machine-readable report
+- `ui-benchmark-report.csv`: tabular metrics for spreadsheet or diff tooling
+- `ui-benchmark-summary.md`: human-readable summary with baseline deltas
+- `webserver.log`: build/preview server output captured during the run
+
+## Baseline comparison
+
+If `benchmarks/ui/baseline_metrics.json` exists, the runner compares current results against the baseline and reports deltas for:
+
+- wall clock time
+- UI total time
+- total SQL time
+
+The baseline is intended as a reference point for local development and PR comparisons, not as a hard universal SLO.
+
+## Merge policy for optimization PRs
+
+For frontend performance PRs:
+
+1. Run the benchmark before the optimization.
+2. Run it again after the optimization.
+3. Attach or summarize the delta in the PR.
+4. Do not merge if representative scenarios regress without a clear reason.

--- a/docs/ui-performance-validation.md
+++ b/docs/ui-performance-validation.md
@@ -22,4 +22,4 @@ The existing UI smoke test (`npm run test:ui`) verifies that the app loads and t
 - Use Playwright’s `page.waitForLoadState('domcontentloaded')` and measure time to a stable selector (e.g. `#workarea` visible).
 - Fail the build if time exceeds a threshold (e.g. 10 s in CI).
 
-For now, performance validation is manual; automate when baseline and SLOs are defined.
+For automated local-mode benchmarking and baseline comparison, see [frontend-performance-benchmarks.md](./frontend-performance-benchmarks.md).

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:coverage": "vitest run --coverage",
     "pretest:ui": "node scripts/check-node-version.js",
     "test:ui":   "playwright test",
+    "perf:ui":   "node scripts/ui_benchmark_runner.cjs",
     "lint:js":   "eslint src/ --max-warnings 47"
   },
   "devDependencies": {

--- a/scripts/ui_benchmark_runner.cjs
+++ b/scripts/ui_benchmark_runner.cjs
@@ -1,0 +1,423 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+const { chromium, expect } = require('@playwright/test');
+
+const rootDir = path.resolve(__dirname, '..');
+const wideParquet = path.join(rootDir, 'tests/fixtures/parquet/wide.parquet');
+const longParquet = path.join(rootDir, 'tests/fixtures/parquet/long.parquet');
+const defaultOutputDir = path.join(rootDir, 'artifacts/ui-benchmarks/latest');
+const defaultBaselinePath = path.join(rootDir, 'benchmarks/ui/baseline_metrics.json');
+const serverUrl = 'http://127.0.0.1:8765';
+
+function parseArgs(argv) {
+  const args = {
+    outputDir: defaultOutputDir,
+    baseline: defaultBaselinePath,
+    browser: 'chromium',
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    switch (arg) {
+      case '--output-dir':
+        args.outputDir = path.resolve(rootDir, argv[++i]);
+        break;
+      case '--baseline':
+        args.baseline = path.resolve(rootDir, argv[++i]);
+        break;
+      case '--browser':
+        args.browser = argv[++i];
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return args;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForServer(url, timeoutMs) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) {
+        return;
+      }
+    } catch (_error) {
+      // server not ready yet
+    }
+    await sleep(1000);
+  }
+  throw new Error(`Timed out waiting for benchmark server at ${url}`);
+}
+
+function startServer(logPath) {
+  const child = spawn('node', ['scripts/playwright-web-server.cjs'], {
+    cwd: rootDir,
+    env: {
+      ...process.env,
+      PLAYWRIGHT_WEB_SERVER_LOG_PATH: logPath,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  child.stdout.on('data', (chunk) => {
+    process.stdout.write(chunk);
+  });
+  child.stderr.on('data', (chunk) => {
+    process.stderr.write(chunk);
+  });
+  return child;
+}
+
+async function stopServer(child) {
+  if (!child || child.killed) {
+    return;
+  }
+  child.kill('SIGTERM');
+  await new Promise((resolve) => {
+    child.once('exit', () => resolve());
+    setTimeout(resolve, 5000);
+  });
+}
+
+function classifySql(text) {
+  if (text.includes('DESCRIBE SELECT *')) return 'schema';
+  if (text.includes('WITH __huey_cells')) return 'cells';
+  if (text.includes('COUNT(*) OVER ()')) return 'tuples';
+  return 'other';
+}
+
+function createSqlRecorder(page) {
+  const entries = [];
+  page.on('console', (message) => {
+    const text = message.text();
+    if (!text.includes('Executing ')) {
+      return;
+    }
+    const timeMatch = text.match(/: ([0-9.]+) ms$/);
+    entries.push({
+      text,
+      timeMs: timeMatch ? Number.parseFloat(timeMatch[1]) : null,
+      kind: classifySql(text),
+      recordedAt: Date.now(),
+    });
+  });
+  return {
+    mark() {
+      return entries.length;
+    },
+    getSlice(mark) {
+      return entries.slice(mark);
+    },
+  };
+}
+
+async function waitForAppReady(page) {
+  await page.setViewportSize({ width: 1600, height: 1400 });
+  const response = await page.goto('/index.html', { waitUntil: 'domcontentloaded' });
+  expect(response && response.ok()).toBe(true);
+  await expect(page.locator('body')).toHaveAttribute('aria-busy', 'false', { timeout: 60000 });
+  await expect(page.locator('#layout')).toBeVisible({ timeout: 60000 });
+  await expect(page.locator('#uploader')).toBeAttached({ timeout: 20000 });
+}
+
+async function openAttributesTab(page) {
+  await page.locator('label[for="attributesTab"]').click();
+  await expect(page.locator('#attributeUi')).toBeVisible({ timeout: 15000 });
+}
+
+async function ensureAutoRunDisabled(page) {
+  const autoRun = page.locator('#autoRunQuery');
+  await expect(autoRun).toBeAttached({ timeout: 10000 });
+  if (await autoRun.isChecked()) {
+    await page.locator('label[for="autoRunQuery"]').click();
+    await expect(autoRun).not.toBeChecked({ timeout: 10000 });
+  }
+}
+
+async function uploadParquetAndWaitForAttribute(page, fixturePath, expectedColumn) {
+  await waitForAppReady(page);
+  await page.locator('#uploader').setInputFiles(fixturePath);
+  await expect(page.locator('#attributeUi')).toBeVisible({ timeout: 60000 });
+  await expect(page.locator(`#attributeUi details[data-column_name="${expectedColumn}"]`)).toBeVisible({ timeout: 60000 });
+}
+
+async function addToAxis(page, columnName, axis) {
+  await openAttributesTab(page);
+  const toggle = page.locator(
+    `#attributeUi details[data-column_name="${columnName}"] summary label.attributeUiAxisButton[data-axis="${axis}"]`
+  );
+  await expect(toggle).toBeVisible({ timeout: 15000 });
+  await toggle.click();
+}
+
+async function runQueryAndWaitForPivot(page) {
+  const runButton = page.locator('#runQueryButton');
+  const pivot = page.locator('#pivotTableUi');
+  const needsUpdateBefore = await pivot.getAttribute('data-needs-update');
+  if (await runButton.isVisible()) {
+    await runButton.evaluate((button) => button.click());
+  }
+  await expect(pivot).toBeVisible({ timeout: 60000 });
+  if (needsUpdateBefore === 'true') {
+    await expect(pivot).toHaveAttribute('data-needs-update', 'false', { timeout: 60000 });
+  }
+  await expect(pivot).toHaveAttribute('aria-busy', 'false', { timeout: 60000 });
+  await expect(page.locator('#pivotTableUi .pivotTableUiValueCell').first()).toBeVisible({ timeout: 60000 });
+}
+
+async function clearPerformanceMetrics(page) {
+  await page.evaluate(() => {
+    window.__hueyLastPerformanceMetrics = null;
+    window.__hueyPerformanceHistory = [];
+  });
+}
+
+async function getLastPerformanceMetrics(page) {
+  return await page.evaluate(() => {
+    return window.__hueyLastPerformanceMetrics || null;
+  });
+}
+
+function summarizeSql(entries) {
+  const summary = {
+    count: entries.length,
+    totalTimeMs: 0,
+    byKind: {},
+  };
+  entries.forEach((entry) => {
+    if (entry.timeMs) {
+      summary.totalTimeMs += entry.timeMs;
+    }
+    summary.byKind[entry.kind] = (summary.byKind[entry.kind] || 0) + 1;
+  });
+  summary.totalTimeMs = Math.round(summary.totalTimeMs);
+  return summary;
+}
+
+function buildScenarioResult(name, wallTimeMs, sqlEntries, uiMetrics, extra) {
+  return {
+    name,
+    wallTimeMs: Math.round(wallTimeMs),
+    uiMetrics: uiMetrics || null,
+    sql: summarizeSql(sqlEntries),
+    extra: extra || {},
+  };
+}
+
+async function runScenarios(browserType) {
+  const browser = await browserType.launch({ headless: true });
+  const results = [];
+
+  try {
+    {
+      const context = await browser.newContext({ baseURL: serverUrl });
+      const page = await context.newPage();
+      const recorder = createSqlRecorder(page);
+      const start = Date.now();
+      const mark = recorder.mark();
+      await waitForAppReady(page);
+      results.push(buildScenarioResult('app_ready', Date.now() - start, recorder.getSlice(mark), null, {}));
+      await context.close();
+    }
+
+    {
+      const context = await browser.newContext({ baseURL: serverUrl });
+      const page = await context.newPage();
+      const recorder = createSqlRecorder(page);
+      const start = Date.now();
+      const mark = recorder.mark();
+      await uploadParquetAndWaitForAttribute(page, wideParquet, 'id');
+      results.push(buildScenarioResult('upload_wide_schema', Date.now() - start, recorder.getSlice(mark), null, {
+        fixture: path.relative(rootDir, wideParquet),
+      }));
+      await context.close();
+    }
+
+    {
+      const context = await browser.newContext({ baseURL: serverUrl });
+      const page = await context.newPage();
+      const recorder = createSqlRecorder(page);
+
+      await uploadParquetAndWaitForAttribute(page, longParquet, 'symbol');
+      await ensureAutoRunDisabled(page);
+      await addToAxis(page, 'symbol', 'rows');
+      await addToAxis(page, 'price', 'cells');
+
+      await clearPerformanceMetrics(page);
+      let mark = recorder.mark();
+      let start = Date.now();
+      await runQueryAndWaitForPivot(page);
+      let metrics = await getLastPerformanceMetrics(page);
+      results.push(buildScenarioResult('long_pivot_first_run', Date.now() - start, recorder.getSlice(mark), metrics, {
+        fixture: path.relative(rootDir, longParquet),
+      }));
+
+      await clearPerformanceMetrics(page);
+      mark = recorder.mark();
+      start = Date.now();
+      await runQueryAndWaitForPivot(page);
+      metrics = await getLastPerformanceMetrics(page);
+      results.push(buildScenarioResult('long_pivot_rerun', Date.now() - start, recorder.getSlice(mark), metrics, {
+        fixture: path.relative(rootDir, longParquet),
+      }));
+
+      const innerContainer = page.locator('#pivotTableUi .pivotTableUiInnerContainer');
+      mark = recorder.mark();
+      start = Date.now();
+      await innerContainer.evaluate((element) => {
+        element.scrollTop += 2000;
+      });
+      await page.waitForTimeout(500);
+      await expect(page.locator('#pivotTableUi')).toHaveAttribute('aria-busy', 'false', { timeout: 30000 });
+      results.push(buildScenarioResult('long_pivot_scroll', Date.now() - start, recorder.getSlice(mark), null, {
+        fixture: path.relative(rootDir, longParquet),
+      }));
+
+      await context.close();
+    }
+  }
+  finally {
+    await browser.close();
+  }
+
+  return results;
+}
+
+function compareToBaseline(results, baseline) {
+  if (!baseline || !Array.isArray(baseline.scenarios)) {
+    return null;
+  }
+  const baselineByName = new Map(baseline.scenarios.map((scenario) => [scenario.name, scenario]));
+  return results.map((scenario) => {
+    const base = baselineByName.get(scenario.name);
+    if (!base) {
+      return { name: scenario.name };
+    }
+    const uiTotal = scenario.uiMetrics && scenario.uiMetrics.totalTimeMs;
+    const baseUiTotal = base.uiMetrics && base.uiMetrics.totalTimeMs;
+    return {
+      name: scenario.name,
+      wallTimeMsDelta: scenario.wallTimeMs - base.wallTimeMs,
+      sqlTotalTimeMsDelta: scenario.sql.totalTimeMs - base.sql.totalTimeMs,
+      uiTotalTimeMsDelta: (typeof uiTotal === 'number' && typeof baseUiTotal === 'number')
+        ? uiTotal - baseUiTotal
+        : null,
+    };
+  });
+}
+
+function writeCsv(filePath, results, comparison) {
+  const comparisonByName = new Map((comparison || []).map((entry) => [entry.name, entry]));
+  const lines = [
+    [
+      'scenario',
+      'wall_time_ms',
+      'ui_query_ms',
+      'ui_render_ms',
+      'ui_total_ms',
+      'sql_count',
+      'sql_total_time_ms',
+      'sql_schema_count',
+      'sql_tuples_count',
+      'sql_cells_count',
+      'wall_time_delta_ms',
+      'ui_total_delta_ms',
+      'sql_total_delta_ms',
+    ].join(','),
+  ];
+
+  results.forEach((scenario) => {
+    const delta = comparisonByName.get(scenario.name) || {};
+    lines.push([
+      scenario.name,
+      scenario.wallTimeMs,
+      scenario.uiMetrics ? scenario.uiMetrics.queryTimeMs : '',
+      scenario.uiMetrics ? scenario.uiMetrics.renderTimeMs : '',
+      scenario.uiMetrics ? scenario.uiMetrics.totalTimeMs : '',
+      scenario.sql.count,
+      scenario.sql.totalTimeMs,
+      scenario.sql.byKind.schema || 0,
+      scenario.sql.byKind.tuples || 0,
+      scenario.sql.byKind.cells || 0,
+      delta.wallTimeMsDelta ?? '',
+      delta.uiTotalTimeMsDelta ?? '',
+      delta.sqlTotalTimeMsDelta ?? '',
+    ].join(','));
+  });
+
+  fs.writeFileSync(filePath, `${lines.join('\n')}\n`, 'utf8');
+}
+
+function writeMarkdown(filePath, results, comparison, baselinePath) {
+  const comparisonByName = new Map((comparison || []).map((entry) => [entry.name, entry]));
+  const lines = [
+    '# UI benchmark summary',
+    '',
+    `Generated: ${new Date().toISOString()}`,
+    '',
+    baselinePath ? `Baseline: \`${path.relative(rootDir, baselinePath)}\`` : 'Baseline: none',
+    '',
+    '| Scenario | Wall (ms) | UI Query | UI Render | UI Total | SQL Count | SQL Total | Schema | Tuples | Cells | Wall Δ | UI Total Δ | SQL Total Δ |',
+    '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |',
+  ];
+
+  results.forEach((scenario) => {
+    const delta = comparisonByName.get(scenario.name) || {};
+    lines.push(
+      `| ${scenario.name} | ${scenario.wallTimeMs} | ${scenario.uiMetrics ? scenario.uiMetrics.queryTimeMs : ''} | ${scenario.uiMetrics ? scenario.uiMetrics.renderTimeMs : ''} | ${scenario.uiMetrics ? scenario.uiMetrics.totalTimeMs : ''} | ${scenario.sql.count} | ${scenario.sql.totalTimeMs} | ${scenario.sql.byKind.schema || 0} | ${scenario.sql.byKind.tuples || 0} | ${scenario.sql.byKind.cells || 0} | ${delta.wallTimeMsDelta ?? ''} | ${delta.uiTotalTimeMsDelta ?? ''} | ${delta.sqlTotalTimeMsDelta ?? ''} |`
+    );
+  });
+
+  fs.writeFileSync(filePath, `${lines.join('\n')}\n`, 'utf8');
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  fs.mkdirSync(args.outputDir, { recursive: true });
+  const webServerLogPath = path.join(args.outputDir, 'webserver.log');
+
+  let baseline = null;
+  if (fs.existsSync(args.baseline)) {
+    baseline = JSON.parse(fs.readFileSync(args.baseline, 'utf8'));
+  }
+
+  const server = startServer(webServerLogPath);
+  try {
+    await waitForServer(serverUrl, 240000);
+    const results = await runScenarios(chromium);
+    const comparison = compareToBaseline(results, baseline);
+    const report = {
+      generatedAt: new Date().toISOString(),
+      browser: args.browser,
+      baseUrl: serverUrl,
+      scenarios: results,
+      comparison,
+      baselinePath: fs.existsSync(args.baseline) ? path.relative(rootDir, args.baseline) : null,
+    };
+
+    const jsonPath = path.join(args.outputDir, 'ui-benchmark-report.json');
+    const csvPath = path.join(args.outputDir, 'ui-benchmark-report.csv');
+    const mdPath = path.join(args.outputDir, 'ui-benchmark-summary.md');
+
+    fs.writeFileSync(jsonPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+    writeCsv(csvPath, results, comparison);
+    writeMarkdown(mdPath, results, comparison, report.baselinePath ? args.baseline : null);
+
+    console.log(`UI benchmark report written to ${jsonPath}`);
+    console.log(`UI benchmark summary written to ${mdPath}`);
+  }
+  finally {
+    await stopServer(server);
+  }
+}
+
+main().catch((error) => {
+  console.error(error.stack || error);
+  process.exit(1);
+});

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -228,6 +228,19 @@ export function initApplication(){
 
     const metrics = eventData.metrics;
     if (metrics) {
+      if (typeof window !== 'undefined') {
+        const entry = {
+          queryTimeMs: metrics.queryTimeMs,
+          renderTimeMs: metrics.renderTimeMs,
+          totalTimeMs: metrics.totalTimeMs,
+          recordedAt: Date.now(),
+        };
+        window.__hueyLastPerformanceMetrics = entry;
+        if (!Array.isArray(window.__hueyPerformanceHistory)) {
+          window.__hueyPerformanceHistory = [];
+        }
+        window.__hueyPerformanceHistory.push(entry);
+      }
       byId('queryPerformanceInfo').textContent = `Query: ${metrics.queryTimeMs}ms | Render: ${metrics.renderTimeMs}ms`;
       if (location.hostname === 'localhost' || location.hostname === '127.0.0.1') {
         console.log('[Performance]', {
@@ -238,6 +251,9 @@ export function initApplication(){
       }
     }
     else {
+      if (typeof window !== 'undefined') {
+        window.__hueyLastPerformanceMetrics = null;
+      }
       byId('queryPerformanceInfo').textContent = '';
     }
   });

--- a/src/App/analyzeDatasource.js
+++ b/src/App/analyzeDatasource.js
@@ -5,7 +5,7 @@ import { queryModel } from '../QueryModel/QueryModel.js';
 import { attributeUi } from '../AttributeUi/AttributeUi.js';
 import { showErrorDialog } from '../ErrorDialog/ErrorDialog.js';
 
-export function analyzeDatasource(datasource){
+export async function analyzeDatasource(datasource){
   try {
     TabUi.setSelectedTab('#sidebar', '#attributesTab');
     clearSearch();


### PR DESCRIPTION
## Summary
- add a reproducible frontend benchmark runner for representative local-mode workflows
- record structured Huey query/render metrics on `window` for benchmark collection
- check in a reference baseline and document how to run and compare frontend benchmarks

Closes #386

## Validation
- npm run perf:ui
- npm run test:unit -- tests/unit/app-core-coverage.test.js tests/unit/analyze-datasource.test.js
- npm run lint:js
