### PR TITLE
Optimize tuple count fetches

### DIFF
--- a/src/DataSet/TupleSet.js
+++ b/src/DataSet/TupleSet.js
@@ -76,6 +76,48 @@ export class TupleSet extends DataSetComponent {
     return sql;
   }
 
+  /**
+   * Build a count query for the current axis without ORDER BY so total tuple
+   * counts are obtained separately from tuple page fetches.
+   *
+   * @param {import('../QueryModel/QueryModel.js').QueryModel} queryModel
+   * @param {string} axisId
+   * @param {'FIRST'|'LAST'} nullsSortOrder
+   * @param {'AFTER'|'BEFORE'} totalsPosition
+   * @returns {string|undefined}
+   */
+  static getSqlCountStatement(queryModel, axisId, nullsSortOrder, totalsPosition){
+    const datasource = queryModel.getDatasource();
+
+    const queryAxis = queryModel.getQueryAxis(axisId);
+    const queryAxisItems = queryAxis.getItems();
+    if (!queryAxisItems.length) {
+      return undefined;
+    }
+
+    const filterAxis = queryModel.getFiltersAxis();
+    const filterAxisItems = filterAxis.getItems();
+    const samplingConfig = queryModel.getSampling(axisId);
+
+    const axisSql = SqlQueryGenerator.getSqlSelectStatementForAxisItems({
+      datasource: datasource,
+      queryAxisItems: queryAxisItems,
+      filterAxisItems: filterAxisItems,
+      includeCountAll: false,
+      nullsSortOrder: nullsSortOrder,
+      totalsPosition: totalsPosition,
+      samplingConfig: samplingConfig,
+      includeOrderBy: false,
+    });
+    if (!axisSql) {
+      return undefined;
+    }
+    return [
+      'SELECT COUNT(*) AS "__huey_count"',
+      `FROM (${axisSql}) AS "__huey_axis_count"`
+    ].join('\n');
+  }
+
   #queryAxisId = undefined;
 
   #tuples = [];
@@ -190,6 +232,21 @@ export class TupleSet extends DataSetComponent {
       totalsPosition
     );
     return sql;
+  }
+
+  #getSqlCountStatement(){
+    const queryModel = this.getQueryModel();
+    if (!queryModel) {
+      return undefined;
+    }
+    const nullsSortOrder = this.#getNullsSortOrder();
+    const totalsPosition = this.#getTotalsPosition();
+    return TupleSet.getSqlCountStatement(
+      queryModel,
+      this.#queryAxisId,
+      nullsSortOrder,
+      totalsPosition
+    );
   }
 
   clear(){
@@ -335,7 +392,7 @@ export class TupleSet extends DataSetComponent {
     return Promise.resolve(this.#tupleCount);
   }
 
-  #loadTuples(resultSet, offset) {
+  #loadTuples(resultSet, offset, totalCount) {
     const numRows = resultSet.numRows;
 
     const fields = resultSet.schema.fields;
@@ -350,6 +407,10 @@ export class TupleSet extends DataSetComponent {
 
     // if the offset is 0 we should have included an expression that computes the total count as last
     if (offset === 0) {
+      if (totalCount !== undefined) {
+        this.#tupleCount = totalCount;
+      }
+      else
       if (numRows === 0){
         this.#tupleCount = 0;
       }
@@ -441,12 +502,12 @@ export class TupleSet extends DataSetComponent {
   }
 
   async #executeAxisQuery(limit, offset){
-    const includeCountExpression = offset === 0;
     const queryModel = this.getQueryModel();
     const datasource = queryModel.getDatasource();
     const isRemote = datasource && datasource.getType && datasource.getType() === 'remote';
 
     if (isRemote && datasource.getManagedConnection().fetchTuples) {
+      const includeCountExpression = offset === 0;
       const query = this.#buildRemoteTuplesQuery(limit, offset);
       if (!query) return 0;
       const dateRange = RemoteQueryAdapter.getDateRange(queryModel);
@@ -461,11 +522,23 @@ export class TupleSet extends DataSetComponent {
       if (connection.getState() === 'canceled') return 0;
       const axisItems = this.getQueryAxisItems();
       const resultSet = this.#remoteResponseToResultSet(apiResponse, axisItems, includeCountExpression);
-      this.#loadTuples(resultSet, offset);
+      this.#loadTuples(resultSet, offset, apiResponse.total_count);
       return resultSet.numRows;
     }
 
-    let axisSql = this.#getSqlSelectStatement(includeCountExpression);
+    let totalCount;
+    if (offset === 0 && this.#tupleCount === undefined) {
+      const countSql = this.#getSqlCountStatement();
+      if (!countSql) {
+        return 0;
+      }
+      const connection = await this.getManagedConnection();
+      const countResultSet = await connection.query(countSql);
+      const countRow = countResultSet.numRows ? countResultSet.get(0) : undefined;
+      totalCount = countRow ? parseInt(String(countRow.__huey_count), 10) : 0;
+    }
+
+    let axisSql = this.#getSqlSelectStatement(false);
     if (!axisSql){
       return 0;
     }
@@ -477,7 +550,7 @@ export class TupleSet extends DataSetComponent {
     if (connection.getState() === 'canceled') {
       return 0;
     }
-    this.#loadTuples(resultset, offset);
+    this.#loadTuples(resultset, offset, totalCount);
 
     return resultset.numRows;
   }

--- a/tests/unit/tupleset-core.test.js
+++ b/tests/unit/tupleset-core.test.js
@@ -192,4 +192,78 @@ describe('TupleSet pagination', () => {
     expect(tupleSet.getTupleSync(0).values).toEqual(['A']);
     expect(tupleSet.getTupleSync(5).values).toEqual(['F']);
   });
+
+  test('local tuple fetch separates total count query from page fetch query', async () => {
+    const axisItems = [{ axis: 'rows', columnName: 'city', columnType: 'VARCHAR' }];
+    const queryCalls = [];
+    const connection = {
+      async query(sql) {
+        queryCalls.push(sql);
+        if (sql.includes('SELECT COUNT(*) AS "__huey_count"')) {
+          return {
+            numRows: 1,
+            schema: { fields: [{ name: '__huey_count' }] },
+            get() {
+              return { __huey_count: 3 };
+            },
+          };
+        }
+        return {
+          numRows: 3,
+          schema: { fields: [{ name: 'city' }] },
+          get(index) {
+            return [
+              { city: 'A' },
+              { city: 'B' },
+              { city: 'C' },
+            ][index];
+          },
+        };
+      },
+      getState() {
+        return 'open';
+      },
+    };
+    const datasource = {
+      getType() {
+        return 'file';
+      },
+      getManagedConnection() {
+        return connection;
+      },
+      getFromClauseSql() {
+        return 'FROM test_relation';
+      },
+      async getRejects() {
+        return undefined;
+      },
+    };
+    const queryModel = {
+      getDatasource() {
+        return datasource;
+      },
+      getQueryAxis() {
+        return { getItems: () => axisItems };
+      },
+      getFiltersAxis() {
+        return { getItems: () => [] };
+      },
+      getSampling() {
+        return undefined;
+      },
+    };
+
+    const tupleSet = new TupleSet(queryModel, 'rows', createSettings());
+    tupleSet.setPageSize(10);
+
+    const tuples = await tupleSet.getTuples(3, 0);
+
+    expect(queryCalls).toHaveLength(2);
+    expect(queryCalls[0]).toContain('SELECT COUNT(*) AS "__huey_count"');
+    expect(queryCalls[0]).not.toContain('COUNT(*) OVER ()');
+    expect(queryCalls[1]).not.toContain('COUNT(*) OVER ()');
+    expect(queryCalls[1]).toContain('LIMIT 3 OFFSET 0');
+    expect(tupleSet.getTupleCountSync()).toBe(3);
+    expect(tuples.map((tuple) => tuple.values[0])).toEqual(['A', 'B', 'C']);
+  });
 });


### PR DESCRIPTION
## Summary
- split local tuple count retrieval from tuple page fetches in TupleSet
- remove COUNT(*) OVER() from local tuple page SQL and fetch the total count separately without ORDER BY
- add a regression test for the local tuple count/query split

Closes #386

## Measured impact
From `npm run perf:ui` against the checked-in baseline:
- `long_pivot_first_run` wall time: `455ms -> 413ms` (`-42ms`)
- `long_pivot_first_run` UI total: `191ms -> 168ms` (`-23ms`)
- `long_pivot_first_run` total SQL time: `148ms -> 123ms` (`-25ms`)

## Validation
- npm run perf:ui
- npm run test:unit -- tests/unit/tupleset-core.test.js tests/unit/pivot-table-ui-lifecycle.test.js tests/unit/cellset-fetch.test.js tests/unit/cellset-core.test.js
- npm run lint:js
