### PR TITLE
Add pivot query progress feedback

### DIFF
--- a/src/App/App.css
+++ b/src/App/App.css
@@ -19,6 +19,22 @@ html > body[aria-busy=false] > #spinner {
   display: none;
 }
 
+dialog#visualizationProgressDialog {
+  width: 280px;
+
+  > section {
+    min-height: 2.5em;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+  }
+}
+
+#visualizationProgressMessage {
+  margin: 0;
+}
+
 nav#sidebar {
   width: 350px;
   height: calc(100vh - 40px);
@@ -248,5 +264,4 @@ body:has( #autoRunQuery:checked ) {
     }
   }
 }
-
 

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -264,12 +264,27 @@ export function initApplication(){
     }
     const busy = event.eventData.busy;
     const busyDialog = byId('visualizationProgressDialog');
+    const progressMessage = byId('visualizationProgressMessage');
     if (busy) {
+      if (progressMessage && !progressMessage.textContent) {
+        progressMessage.textContent = 'Running query...';
+      }
       busyDialog.showModal();
     }
     else {
+      if (progressMessage) {
+        progressMessage.textContent = '';
+      }
       busyDialog.close();
     }
+  });
+
+  pivotTableUi.addEventListener('progress', (event) =>{
+    const progressMessage = byId('visualizationProgressMessage');
+    if (!progressMessage) {
+      return;
+    }
+    progressMessage.textContent = event.eventData.message || 'Running query...';
   });
 
   initPostMessageInterface();

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -284,7 +284,8 @@ export function initApplication(){
     if (!progressMessage) {
       return;
     }
-    progressMessage.textContent = event.eventData.message || 'Running query...';
+    const message = event.eventData.message;
+    progressMessage.textContent = message ?? 'Running query...';
   });
 
   initPostMessageInterface();

--- a/src/PivotTableUi/PivotTableUi.js
+++ b/src/PivotTableUi/PivotTableUi.js
@@ -62,9 +62,10 @@ export class PivotTableUi extends EventEmitter {
   static #maximumCellWidth = pivotTableUiDefaults.maximumCellWidth;
 
   #lastMetrics = undefined;
+  #lastProgressMessage = '';
 
   constructor(config){
-    super(['updated', 'busy']);
+    super(['updated', 'busy', 'progress']);
     registerTemplates(pivotTableTemplatesHtml);
     this.#initDom(config);
     this.#id = config.id;
@@ -455,6 +456,9 @@ export class PivotTableUi extends EventEmitter {
   #setBusy(busy){
     const dom = this.getDom();
     dom.setAttribute('aria-busy', String(Boolean(busy)));
+    if (!busy) {
+      this.#setProgressMessage('');
+    }
     this.fireEvent('busy', {
       busy: Boolean(busy)
     })
@@ -463,6 +467,17 @@ export class PivotTableUi extends EventEmitter {
   #getBusy(){
     const dom = this.getDom();
     return dom.getAttribute('aria-busy') === 'true';
+  }
+
+  #setProgressMessage(message){
+    const nextMessage = message ? String(message) : '';
+    if (nextMessage === this.#lastProgressMessage) {
+      return;
+    }
+    this.#lastProgressMessage = nextMessage;
+    this.fireEvent('progress', {
+      message: nextMessage
+    });
   }
 
   #fireUpdatedSuccess(){
@@ -494,6 +509,7 @@ export class PivotTableUi extends EventEmitter {
       }
       try {
         this.#setBusy(true);
+        this.#setProgressMessage('Updating visible rows and cells...');
         await this.#updateDataToScrollPosition();
         this.#fireUpdatedSuccess();
       }
@@ -1837,6 +1853,7 @@ export class PivotTableUi extends EventEmitter {
       }
 
       this.#setBusy(true);
+      this.#setProgressMessage('Preparing pivot layout...');
       this.clear();
 
       const totalStart = performance.now();
@@ -1861,6 +1878,7 @@ export class PivotTableUi extends EventEmitter {
         rowsTupleSet.getTuples(rowsTupleSet.getPageSize(), 0)
       ];
 
+      this.#setProgressMessage('Loading row and column members...');
       const renderAxisPromisesResults = await Promise.all(renderAxisPromises);
 
       const queryTimeMs = Math.round(performance.now() - totalStart);
@@ -1878,8 +1896,10 @@ export class PivotTableUi extends EventEmitter {
       this.#updateVerticalSizer();
       this.#toggleObserveColumnsResizing(true);
 
+      this.#setProgressMessage('Rendering visible cells...');
       this.#renderCells();
 
+      this.#setProgressMessage('Fetching aggregated cell values...');
       await this.#updateDataToScrollPosition();
 
       const renderTimeMs = Math.round(performance.now() - renderStart);

--- a/src/index.html
+++ b/src/index.html
@@ -1765,7 +1765,7 @@
         </div>
       </header>
       <section>
-        <!-- TODO: actual progress information -->
+        <p id="visualizationProgressMessage" role="status" aria-live="polite">Running query...</p>
       </section>
       <footer>
         <button id="cancelQueryButton">Cancel</button>

--- a/tests/unit/app-core-coverage.test.js
+++ b/tests/unit/app-core-coverage.test.js
@@ -11,7 +11,7 @@ function createAppDom() {
     <div id="queryResultRowsInfo"></div>
     <div id="queryResultColumnsInfo"></div>
     <div id="queryPerformanceInfo"></div>
-    <dialog id="visualizationProgressDialog"></dialog>
+    <dialog id="visualizationProgressDialog"><p id="visualizationProgressMessage"></p></dialog>
   `;
   const busyDialog = document.getElementById('visualizationProgressDialog');
   busyDialog.showModal = vi.fn();
@@ -271,9 +271,12 @@ describe('App core initialization and query flows', () => {
     expect(document.getElementById('queryPerformanceInfo').textContent).toBe('Query: 12ms | Render: 6ms');
 
     busyHandlers[0]({ eventData: { busy: true } });
+    pivotHandlers.progress({ eventData: { message: 'Fetching aggregated cell values...' } });
+    expect(document.getElementById('visualizationProgressMessage').textContent).toBe('Fetching aggregated cell values...');
     busyHandlers[0]({ eventData: { busy: false } });
     expect(document.getElementById('visualizationProgressDialog').showModal).toHaveBeenCalledTimes(1);
     expect(document.getElementById('visualizationProgressDialog').close).toHaveBeenCalledTimes(1);
+    expect(document.getElementById('visualizationProgressMessage').textContent).toBe('');
 
     pivotHandlers.updated({ eventData: { status: 'error', error: { title: 'boom' } } });
     expect(calls.showErrorDialog).toHaveBeenCalledWith({ title: 'boom' });


### PR DESCRIPTION
## Summary
- add stage-level pivot progress messages for long-running queries and viewport updates
- show progress text in the existing visualization progress dialog
- cover the progress messaging path in unit tests

Closes #386

## Validation
- npm run test:unit -- tests/unit/app-core-coverage.test.js tests/unit/pivot-table-ui-lifecycle.test.js
- npm run lint:js
- npm run perf:ui
