### PR TITLE
Add datasource reuse benchmark scenarios

### DIFF
--- a/benchmarks/ui/baseline_metrics.json
+++ b/benchmarks/ui/baseline_metrics.json
@@ -62,6 +62,37 @@
         "totalTimeMs": 0,
         "byKind": {}
       }
+    },
+    {
+      "name": "long_pivot_second_shape",
+      "wallTimeMs": 172,
+      "uiMetrics": null,
+      "sql": {
+        "count": 2,
+        "totalTimeMs": 19,
+        "byKind": {
+          "tuple_counts": 1,
+          "other": 1
+        }
+      }
+    },
+    {
+      "name": "long_reopen_same_file_first_run",
+      "wallTimeMs": 403,
+      "uiMetrics": {
+        "queryTimeMs": 44,
+        "renderTimeMs": 127,
+        "totalTimeMs": 170
+      },
+      "sql": {
+        "count": 3,
+        "totalTimeMs": 124,
+        "byKind": {
+          "tuple_counts": 1,
+          "other": 1,
+          "cells": 1
+        }
+      }
     }
   ]
 }

--- a/benchmarks/ui/baseline_metrics.json
+++ b/benchmarks/ui/baseline_metrics.json
@@ -65,28 +65,33 @@
     },
     {
       "name": "long_pivot_second_shape",
-      "wallTimeMs": 172,
-      "uiMetrics": null,
+      "wallTimeMs": 803,
+      "uiMetrics": {
+        "queryTimeMs": 59,
+        "renderTimeMs": 664,
+        "totalTimeMs": 724
+      },
       "sql": {
-        "count": 2,
-        "totalTimeMs": 19,
+        "count": 5,
+        "totalTimeMs": 388,
         "byKind": {
-          "tuple_counts": 1,
-          "other": 1
+          "tuple_counts": 2,
+          "other": 2,
+          "cells": 1
         }
       }
     },
     {
       "name": "long_reopen_same_file_first_run",
-      "wallTimeMs": 403,
+      "wallTimeMs": 418,
       "uiMetrics": {
-        "queryTimeMs": 44,
-        "renderTimeMs": 127,
-        "totalTimeMs": 170
+        "queryTimeMs": 48,
+        "renderTimeMs": 139,
+        "totalTimeMs": 187
       },
       "sql": {
         "count": 3,
-        "totalTimeMs": 124,
+        "totalTimeMs": 138,
         "byKind": {
           "tuple_counts": 1,
           "other": 1,

--- a/docs/frontend-performance-benchmarks.md
+++ b/docs/frontend-performance-benchmarks.md
@@ -36,6 +36,8 @@ The benchmark runner currently measures:
 - `long_pivot_first_run`: upload `tests/fixtures/parquet/long.parquet`, build a pivot, and run the first query
 - `long_pivot_rerun`: re-run the same pivot to observe cache behavior
 - `long_pivot_scroll`: scroll an already-run tall pivot and measure viewport update latency
+- `long_pivot_second_shape`: change the query shape on the already-open long parquet datasource and measure the next run
+- `long_reopen_same_file_first_run`: reopen the same long parquet file in a fresh browser context and measure the first run again
 
 ## Metrics
 

--- a/scripts/ui_benchmark_runner.cjs
+++ b/scripts/ui_benchmark_runner.cjs
@@ -151,8 +151,8 @@ async function uploadParquetAndWaitForAttribute(page, fixturePath, expectedColum
 async function addToAxis(page, columnName, axis) {
   await openAttributesTab(page);
   const toggle = page.locator(
-    `#attributeUi details[data-column_name="${columnName}"] summary label.attributeUiAxisButton[data-axis="${axis}"]`
-  ).first();
+    `#attributeUi details[data-nodetype="column"][data-column_name="${columnName}"] > summary label.attributeUiAxisButton[data-axis="${axis}"]`
+  );
   await expect(toggle).toBeVisible({ timeout: 15000 });
   await toggle.click();
 }
@@ -190,6 +190,22 @@ async function getLastPerformanceMetrics(page) {
   return await page.evaluate(() => {
     return window.__hueyLastPerformanceMetrics || null;
   });
+}
+
+async function setupLongPivot(page) {
+  await uploadParquetAndWaitForAttribute(page, longParquet, 'symbol');
+  await ensureAutoRunDisabled(page);
+  await addToAxis(page, 'symbol', 'rows');
+  await addToAxis(page, 'price', 'cells');
+}
+
+async function runAndRecordPivotScenario(page, recorder, name, extra) {
+  await clearPerformanceMetrics(page);
+  const mark = recorder.mark();
+  const start = Date.now();
+  await runQueryAndWaitForPivot(page);
+  const metrics = await getLastPerformanceMetrics(page);
+  return buildScenarioResult(name, Date.now() - start, recorder.getSlice(mark), metrics, extra);
 }
 
 function summarizeSql(entries) {
@@ -252,32 +268,18 @@ async function runScenarios(browserType) {
       const page = await context.newPage();
       const recorder = createSqlRecorder(page);
 
-      await uploadParquetAndWaitForAttribute(page, longParquet, 'symbol');
-      await ensureAutoRunDisabled(page);
-      await addToAxis(page, 'symbol', 'rows');
-      await addToAxis(page, 'price', 'cells');
-
-      await clearPerformanceMetrics(page);
-      let mark = recorder.mark();
-      let start = Date.now();
-      await runQueryAndWaitForPivot(page);
-      let metrics = await getLastPerformanceMetrics(page);
-      results.push(buildScenarioResult('long_pivot_first_run', Date.now() - start, recorder.getSlice(mark), metrics, {
+      await setupLongPivot(page);
+      results.push(await runAndRecordPivotScenario(page, recorder, 'long_pivot_first_run', {
         fixture: path.relative(rootDir, longParquet),
       }));
 
-      await clearPerformanceMetrics(page);
-      mark = recorder.mark();
-      start = Date.now();
-      await runQueryAndWaitForPivot(page);
-      metrics = await getLastPerformanceMetrics(page);
-      results.push(buildScenarioResult('long_pivot_rerun', Date.now() - start, recorder.getSlice(mark), metrics, {
+      results.push(await runAndRecordPivotScenario(page, recorder, 'long_pivot_rerun', {
         fixture: path.relative(rootDir, longParquet),
       }));
 
       const innerContainer = page.locator('#pivotTableUi .pivotTableUiInnerContainer');
-      mark = recorder.mark();
-      start = Date.now();
+      const mark = recorder.mark();
+      const start = Date.now();
       await innerContainer.evaluate((element) => {
         element.scrollTop += 2000;
       });
@@ -294,12 +296,7 @@ async function runScenarios(browserType) {
       await addToAxis(page, 'symbol', 'columns');
       await addToAxis(page, 'price', 'cells');
 
-      await clearPerformanceMetrics(page);
-      mark = recorder.mark();
-      start = Date.now();
-      await runQueryAndWaitForPivot(page);
-      metrics = await getLastPerformanceMetrics(page);
-      results.push(buildScenarioResult('long_pivot_second_shape', Date.now() - start, recorder.getSlice(mark), metrics, {
+      results.push(await runAndRecordPivotScenario(page, recorder, 'long_pivot_second_shape', {
         fixture: path.relative(rootDir, longParquet),
       }));
 
@@ -311,17 +308,8 @@ async function runScenarios(browserType) {
       const page = await context.newPage();
       const recorder = createSqlRecorder(page);
 
-      await uploadParquetAndWaitForAttribute(page, longParquet, 'symbol');
-      await ensureAutoRunDisabled(page);
-      await addToAxis(page, 'symbol', 'rows');
-      await addToAxis(page, 'price', 'cells');
-
-      await clearPerformanceMetrics(page);
-      const mark = recorder.mark();
-      const start = Date.now();
-      await runQueryAndWaitForPivot(page);
-      const metrics = await getLastPerformanceMetrics(page);
-      results.push(buildScenarioResult('long_reopen_same_file_first_run', Date.now() - start, recorder.getSlice(mark), metrics, {
+      await setupLongPivot(page);
+      results.push(await runAndRecordPivotScenario(page, recorder, 'long_reopen_same_file_first_run', {
         fixture: path.relative(rootDir, longParquet),
       }));
 
@@ -370,6 +358,7 @@ function writeCsv(filePath, results, comparison) {
       'sql_count',
       'sql_total_time_ms',
       'sql_schema_count',
+      'sql_tuple_count_queries',
       'sql_tuples_count',
       'sql_cells_count',
       'wall_time_delta_ms',
@@ -389,6 +378,7 @@ function writeCsv(filePath, results, comparison) {
       scenario.sql.count,
       scenario.sql.totalTimeMs,
       scenario.sql.byKind.schema || 0,
+      scenario.sql.byKind.tuple_counts || 0,
       scenario.sql.byKind.tuples || 0,
       scenario.sql.byKind.cells || 0,
       delta.wallTimeMsDelta ?? '',
@@ -409,14 +399,14 @@ function writeMarkdown(filePath, results, comparison, baselinePath) {
     '',
     baselinePath ? `Baseline: \`${path.relative(rootDir, baselinePath)}\`` : 'Baseline: none',
     '',
-    '| Scenario | Wall (ms) | UI Query | UI Render | UI Total | SQL Count | SQL Total | Schema | Tuples | Cells | Wall Δ | UI Total Δ | SQL Total Δ |',
-    '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |',
+    '| Scenario | Wall (ms) | UI Query | UI Render | UI Total | SQL Count | SQL Total | Schema | Tuple Count Queries | Tuples | Cells | Wall Δ | UI Total Δ | SQL Total Δ |',
+    '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |',
   ];
 
   results.forEach((scenario) => {
     const delta = comparisonByName.get(scenario.name) || {};
     lines.push(
-      `| ${scenario.name} | ${scenario.wallTimeMs} | ${scenario.uiMetrics ? scenario.uiMetrics.queryTimeMs : ''} | ${scenario.uiMetrics ? scenario.uiMetrics.renderTimeMs : ''} | ${scenario.uiMetrics ? scenario.uiMetrics.totalTimeMs : ''} | ${scenario.sql.count} | ${scenario.sql.totalTimeMs} | ${scenario.sql.byKind.schema || 0} | ${scenario.sql.byKind.tuples || 0} | ${scenario.sql.byKind.cells || 0} | ${delta.wallTimeMsDelta ?? ''} | ${delta.uiTotalTimeMsDelta ?? ''} | ${delta.sqlTotalTimeMsDelta ?? ''} |`
+      `| ${scenario.name} | ${scenario.wallTimeMs} | ${scenario.uiMetrics ? scenario.uiMetrics.queryTimeMs : ''} | ${scenario.uiMetrics ? scenario.uiMetrics.renderTimeMs : ''} | ${scenario.uiMetrics ? scenario.uiMetrics.totalTimeMs : ''} | ${scenario.sql.count} | ${scenario.sql.totalTimeMs} | ${scenario.sql.byKind.schema || 0} | ${scenario.sql.byKind.tuple_counts || 0} | ${scenario.sql.byKind.tuples || 0} | ${scenario.sql.byKind.cells || 0} | ${delta.wallTimeMsDelta ?? ''} | ${delta.uiTotalTimeMsDelta ?? ''} | ${delta.sqlTotalTimeMsDelta ?? ''} |`
     );
   });
 

--- a/scripts/ui_benchmark_runner.cjs
+++ b/scripts/ui_benchmark_runner.cjs
@@ -88,6 +88,7 @@ async function stopServer(child) {
 function classifySql(text) {
   if (text.includes('DESCRIBE SELECT *')) return 'schema';
   if (text.includes('WITH __huey_cells')) return 'cells';
+  if (text.includes('SELECT COUNT(*) AS "__huey_count"')) return 'tuple_counts';
   if (text.includes('COUNT(*) OVER ()')) return 'tuples';
   return 'other';
 }
@@ -151,9 +152,16 @@ async function addToAxis(page, columnName, axis) {
   await openAttributesTab(page);
   const toggle = page.locator(
     `#attributeUi details[data-column_name="${columnName}"] summary label.attributeUiAxisButton[data-axis="${axis}"]`
-  );
+  ).first();
   await expect(toggle).toBeVisible({ timeout: 15000 });
   await toggle.click();
+}
+
+async function clearAxis(page, axis) {
+  const button = page.locator(`#queryUi section[data-axis="${axis}"] button[id$="-clear-axis"]`);
+  await expect(button).toBeVisible({ timeout: 15000 });
+  await button.evaluate((element) => element.click());
+  await expect(page.locator(`#queryUi section[data-axis="${axis}"] > ol > li`)).toHaveCount(0, { timeout: 30000 });
 }
 
 async function runQueryAndWaitForPivot(page) {
@@ -276,6 +284,44 @@ async function runScenarios(browserType) {
       await page.waitForTimeout(500);
       await expect(page.locator('#pivotTableUi')).toHaveAttribute('aria-busy', 'false', { timeout: 30000 });
       results.push(buildScenarioResult('long_pivot_scroll', Date.now() - start, recorder.getSlice(mark), null, {
+        fixture: path.relative(rootDir, longParquet),
+      }));
+
+      await clearAxis(page, 'rows');
+      await clearAxis(page, 'columns');
+      await clearAxis(page, 'cells');
+      await addToAxis(page, 'trade_date', 'rows');
+      await addToAxis(page, 'symbol', 'columns');
+      await addToAxis(page, 'price', 'cells');
+
+      await clearPerformanceMetrics(page);
+      mark = recorder.mark();
+      start = Date.now();
+      await runQueryAndWaitForPivot(page);
+      metrics = await getLastPerformanceMetrics(page);
+      results.push(buildScenarioResult('long_pivot_second_shape', Date.now() - start, recorder.getSlice(mark), metrics, {
+        fixture: path.relative(rootDir, longParquet),
+      }));
+
+      await context.close();
+    }
+
+    {
+      const context = await browser.newContext({ baseURL: serverUrl });
+      const page = await context.newPage();
+      const recorder = createSqlRecorder(page);
+
+      await uploadParquetAndWaitForAttribute(page, longParquet, 'symbol');
+      await ensureAutoRunDisabled(page);
+      await addToAxis(page, 'symbol', 'rows');
+      await addToAxis(page, 'price', 'cells');
+
+      await clearPerformanceMetrics(page);
+      const mark = recorder.mark();
+      const start = Date.now();
+      await runQueryAndWaitForPivot(page);
+      const metrics = await getLastPerformanceMetrics(page);
+      results.push(buildScenarioResult('long_reopen_same_file_first_run', Date.now() - start, recorder.getSlice(mark), metrics, {
         fixture: path.relative(rootDir, longParquet),
       }));
 


### PR DESCRIPTION
## Summary
- extend the frontend benchmark harness with repeated-open and second-query-shape scenarios
- classify tuple count queries separately in the benchmark report
- update the checked-in UI baseline so datasource reuse/materialization work has representative targets

Related to #390

## Validation
- npm run perf:ui
