### PR TITLE
Cache parquet metadata across sessions

### DIFF
--- a/docs/frontend-performance-benchmarks.md
+++ b/docs/frontend-performance-benchmarks.md
@@ -33,6 +33,7 @@ The benchmark runner currently measures:
 
 - `app_ready`: app load to interactive shell
 - `upload_wide_schema`: upload `tests/fixtures/parquet/wide.parquet` and wait for schema/attributes
+- `upload_wide_schema_cached`: reload the app in the same browser storage context, upload `tests/fixtures/parquet/wide.parquet` again, and measure schema/attribute readiness
 - `long_pivot_first_run`: upload `tests/fixtures/parquet/long.parquet`, build a pivot, and run the first query
 - `long_pivot_rerun`: re-run the same pivot to observe cache behavior
 - `long_pivot_scroll`: scroll an already-run tall pivot and measure viewport update latency
@@ -49,7 +50,7 @@ Each scenario records:
 - `uiMetrics.totalTimeMs`: Huey's measured total time when available
 - `sql.count`: number of DuckDB queries logged during the scenario
 - `sql.totalTimeMs`: summed DuckDB query time from logged statements
-- `sql.byKind`: query counts split into `schema`, `tuples`, `cells`, and `other`
+- `sql.byKind`: query counts split into `schema`, `tuple_counts`, `tuples`, `cells`, and `other`
 
 ## Artifacts
 

--- a/scripts/ui_benchmark_runner.cjs
+++ b/scripts/ui_benchmark_runner.cjs
@@ -143,9 +143,7 @@ async function ensureAutoRunDisabled(page) {
 
 async function uploadParquetAndWaitForAttribute(page, fixturePath, expectedColumn) {
   await waitForAppReady(page);
-  await page.locator('#uploader').setInputFiles(fixturePath);
-  await expect(page.locator('#attributeUi')).toBeVisible({ timeout: 60000 });
-  await expect(page.locator(`#attributeUi details[data-column_name="${expectedColumn}"]`)).toBeVisible({ timeout: 60000 });
+  await uploadParquetOnReadyPageAndWaitForAttribute(page, fixturePath, expectedColumn);
 }
 
 async function uploadParquetOnReadyPageAndWaitForAttribute(page, fixturePath, expectedColumn) {

--- a/scripts/ui_benchmark_runner.cjs
+++ b/scripts/ui_benchmark_runner.cjs
@@ -269,11 +269,12 @@ async function runScenarios(browserType) {
 
       await page.close();
       const reopenPage = await context.newPage();
+      const reopenRecorder = createSqlRecorder(reopenPage);
       const reopenStart = Date.now();
-      const reopenMark = recorder.mark();
+      const reopenMark = reopenRecorder.mark();
       await waitForAppReady(reopenPage);
       await uploadParquetOnReadyPageAndWaitForAttribute(reopenPage, wideParquet, 'id');
-      results.push(buildScenarioResult('upload_wide_schema_cached', Date.now() - reopenStart, recorder.getSlice(reopenMark), null, {
+      results.push(buildScenarioResult('upload_wide_schema_cached', Date.now() - reopenStart, reopenRecorder.getSlice(reopenMark), null, {
         fixture: path.relative(rootDir, wideParquet),
       }));
       await context.close();

--- a/scripts/ui_benchmark_runner.cjs
+++ b/scripts/ui_benchmark_runner.cjs
@@ -148,6 +148,12 @@ async function uploadParquetAndWaitForAttribute(page, fixturePath, expectedColum
   await expect(page.locator(`#attributeUi details[data-column_name="${expectedColumn}"]`)).toBeVisible({ timeout: 60000 });
 }
 
+async function uploadParquetOnReadyPageAndWaitForAttribute(page, fixturePath, expectedColumn) {
+  await page.locator('#uploader').setInputFiles(fixturePath);
+  await expect(page.locator('#attributeUi')).toBeVisible({ timeout: 60000 });
+  await expect(page.locator(`#attributeUi details[data-column_name="${expectedColumn}"]`)).toBeVisible({ timeout: 60000 });
+}
+
 async function addToAxis(page, columnName, axis) {
   await openAttributesTab(page);
   const toggle = page.locator(
@@ -258,6 +264,16 @@ async function runScenarios(browserType) {
       const mark = recorder.mark();
       await uploadParquetAndWaitForAttribute(page, wideParquet, 'id');
       results.push(buildScenarioResult('upload_wide_schema', Date.now() - start, recorder.getSlice(mark), null, {
+        fixture: path.relative(rootDir, wideParquet),
+      }));
+
+      await page.close();
+      const reopenPage = await context.newPage();
+      const reopenStart = Date.now();
+      const reopenMark = recorder.mark();
+      await waitForAppReady(reopenPage);
+      await uploadParquetOnReadyPageAndWaitForAttribute(reopenPage, wideParquet, 'id');
+      results.push(buildScenarioResult('upload_wide_schema_cached', Date.now() - reopenStart, recorder.getSlice(reopenMark), null, {
         fixture: path.relative(rootDir, wideParquet),
       }));
       await context.close();

--- a/src/DataSource/duckdb/DuckDbDataSource.js
+++ b/src/DataSource/duckdb/DuckDbDataSource.js
@@ -5,8 +5,8 @@ import { DatasourceSettings } from '../../DatasourceSettingsDialog/DatasourceSet
 import { getDatabase } from './database.js';
 import {
   buildColumnMetadataCacheKey,
-  getCachedColumnMetadataRows,
-  cacheColumnMetadataRows,
+  getCachedColumnMetadata,
+  cacheColumnMetadata,
   createCachedColumnMetadataResult,
   serializeColumnMetadataResult,
 } from './DuckDbMetadataCache.js';
@@ -1200,9 +1200,9 @@ export class DuckDbDataSource extends EventEmitter {
 
     const cacheKey = this.getColumnMetadataCacheKey();
     if (cacheKey) {
-      const cachedRows = getCachedColumnMetadataRows(cacheKey);
-      if (cachedRows) {
-        this.#columnMetadata = createCachedColumnMetadataResult(cachedRows);
+      const cachedMetadata = getCachedColumnMetadata(cacheKey);
+      if (cachedMetadata !== undefined) {
+        this.#columnMetadata = createCachedColumnMetadataResult(cachedMetadata);
         return this.#columnMetadata;
       }
     }
@@ -1219,7 +1219,7 @@ export class DuckDbDataSource extends EventEmitter {
       throw e;
     }
     if (cacheKey) {
-      cacheColumnMetadataRows(cacheKey, serializeColumnMetadataResult(columnMetadata));
+      cacheColumnMetadata(cacheKey, serializeColumnMetadataResult(columnMetadata));
     }
     this.#columnMetadata = columnMetadata;
     return columnMetadata;

--- a/src/DataSource/duckdb/DuckDbDataSource.js
+++ b/src/DataSource/duckdb/DuckDbDataSource.js
@@ -4,6 +4,13 @@ import { showErrorDialog } from '../../ErrorDialog/ErrorDialog.js';
 import { DatasourceSettings } from '../../DatasourceSettingsDialog/DatasourceSettings.js';
 import { getDatabase } from './database.js';
 import {
+  buildColumnMetadataCacheKey,
+  getCachedColumnMetadataRows,
+  cacheColumnMetadataRows,
+  createCachedColumnMetadataResult,
+  serializeColumnMetadataResult,
+} from './DuckDbMetadataCache.js';
+import {
   quoteStringLiteral,
   isQuotedIdentifier,
   unQuoteIdentifier,
@@ -1066,6 +1073,29 @@ export class DuckDbDataSource extends EventEmitter {
     return this.#fileType;
   }
 
+  getColumnMetadataCacheKey(){
+    const type = this.getType();
+    if (type !== DuckDbDataSource.types.FILE) {
+      return undefined;
+    }
+    if (this.#fileType !== 'parquet') {
+      return undefined;
+    }
+    if (!(this.#file instanceof File)) {
+      return undefined;
+    }
+
+    const readerSettings = DuckDbDataSource.getFileTypeInfo(this.#fileType);
+    const fingerprint = JSON.stringify({
+      name: this.#file.name,
+      size: this.#file.size,
+      lastModified: this.#file.lastModified,
+      fileType: this.#fileType,
+      reader: readerSettings ? readerSettings.duckdb_reader : undefined,
+    });
+    return buildColumnMetadataCacheKey(fingerprint);
+  }
+
   getFileSize(){
     if (!this.#file){
       throw new Error(`Not a file!`);
@@ -1168,6 +1198,15 @@ export class DuckDbDataSource extends EventEmitter {
       return this.#columnMetadata;
     }
 
+    const cacheKey = this.getColumnMetadataCacheKey();
+    if (cacheKey) {
+      const cachedRows = getCachedColumnMetadataRows(cacheKey);
+      if (cachedRows) {
+        this.#columnMetadata = createCachedColumnMetadataResult(cachedRows);
+        return this.#columnMetadata;
+      }
+    }
+
     const sql = this.getSqlForTableSchema();
     const connection = await this.getConnection();
     await this.registerFile();
@@ -1178,6 +1217,9 @@ export class DuckDbDataSource extends EventEmitter {
     catch (e) {
       showErrorDialog(e);
       throw e;
+    }
+    if (cacheKey) {
+      cacheColumnMetadataRows(cacheKey, serializeColumnMetadataResult(columnMetadata));
     }
     this.#columnMetadata = columnMetadata;
     return columnMetadata;

--- a/src/DataSource/duckdb/DuckDbMetadataCache.js
+++ b/src/DataSource/duckdb/DuckDbMetadataCache.js
@@ -1,0 +1,93 @@
+const COLUMN_METADATA_CACHE_PREFIX = 'huey:columnMetadata:v1:';
+
+function getLocalStorage() {
+  if (typeof localStorage === 'undefined') {
+    return null;
+  }
+  return localStorage;
+}
+
+export function buildColumnMetadataCacheKey(fingerprint) {
+  if (!fingerprint) {
+    return undefined;
+  }
+  return `${COLUMN_METADATA_CACHE_PREFIX}${fingerprint}`;
+}
+
+export function getCachedColumnMetadataRows(cacheKey) {
+  const storage = getLocalStorage();
+  if (!storage || !cacheKey) {
+    return undefined;
+  }
+  try {
+    const raw = storage.getItem(cacheKey);
+    if (!raw) {
+      return undefined;
+    }
+    const payload = JSON.parse(raw);
+    const rows = payload && payload.rows;
+    return Array.isArray(rows) ? rows : undefined;
+  }
+  catch (_error) {
+    return undefined;
+  }
+}
+
+export function cacheColumnMetadataRows(cacheKey, rows) {
+  const storage = getLocalStorage();
+  if (!storage || !cacheKey || !Array.isArray(rows)) {
+    return;
+  }
+  try {
+    storage.setItem(cacheKey, JSON.stringify({
+      cachedAt: Date.now(),
+      rows,
+    }));
+  }
+  catch (_error) {
+    // ignore storage quota or serialization failures
+  }
+}
+
+export function createCachedColumnMetadataResult(rows) {
+  const safeRows = Array.isArray(rows) ? rows : [];
+  const fields = safeRows.length ? Object.keys(safeRows[0]).map((name) => ({ name })) : [];
+  return {
+    numRows: safeRows.length,
+    schema: { fields },
+    get(index) {
+      const row = safeRows[index];
+      if (!row) {
+        return undefined;
+      }
+      return Object.assign({}, row, {
+        toJSON() {
+          return Object.assign({}, row);
+        }
+      });
+    }
+  };
+}
+
+export function serializeColumnMetadataResult(resultSet) {
+  const numRows = resultSet && typeof resultSet.numRows === 'number' ? resultSet.numRows : 0;
+  const rows = [];
+  for (let i = 0; i < numRows; i++) {
+    const row = resultSet.get(i);
+    if (!row) {
+      continue;
+    }
+    if (typeof row.toJSON === 'function') {
+      rows.push(row.toJSON());
+      continue;
+    }
+    const schemaFields = resultSet.schema && resultSet.schema.fields ? resultSet.schema.fields : [];
+    const plainRow = {};
+    for (let j = 0; j < schemaFields.length; j++) {
+      const fieldName = schemaFields[j].name;
+      plainRow[fieldName] = row[fieldName];
+    }
+    rows.push(plainRow);
+  }
+  return rows;
+}

--- a/src/DataSource/duckdb/DuckDbMetadataCache.js
+++ b/src/DataSource/duckdb/DuckDbMetadataCache.js
@@ -1,10 +1,15 @@
 const COLUMN_METADATA_CACHE_PREFIX = 'huey:columnMetadata:v1:';
 
 function getLocalStorage() {
-  if (typeof localStorage === 'undefined') {
+  try {
+    if (typeof globalThis === 'undefined' || typeof globalThis.localStorage === 'undefined') {
+      return null;
+    }
+    return globalThis.localStorage;
+  }
+  catch (_error) {
     return null;
   }
-  return localStorage;
 }
 
 export function buildColumnMetadataCacheKey(fingerprint) {
@@ -14,7 +19,7 @@ export function buildColumnMetadataCacheKey(fingerprint) {
   return `${COLUMN_METADATA_CACHE_PREFIX}${fingerprint}`;
 }
 
-export function getCachedColumnMetadataRows(cacheKey) {
+export function getCachedColumnMetadata(cacheKey) {
   const storage = getLocalStorage();
   if (!storage || !cacheKey) {
     return undefined;
@@ -25,23 +30,29 @@ export function getCachedColumnMetadataRows(cacheKey) {
       return undefined;
     }
     const payload = JSON.parse(raw);
-    const rows = payload && payload.rows;
-    return Array.isArray(rows) ? rows : undefined;
+    if (payload && Array.isArray(payload.rows) && payload.schema) {
+      return {
+        rows: payload.rows,
+        schema: payload.schema,
+      };
+    }
+    return undefined;
   }
   catch (_error) {
     return undefined;
   }
 }
 
-export function cacheColumnMetadataRows(cacheKey, rows) {
+export function cacheColumnMetadata(cacheKey, data) {
   const storage = getLocalStorage();
-  if (!storage || !cacheKey || !Array.isArray(rows)) {
+  if (!storage || !cacheKey || !data || !Array.isArray(data.rows) || !data.schema) {
     return;
   }
   try {
     storage.setItem(cacheKey, JSON.stringify({
       cachedAt: Date.now(),
-      rows,
+      rows: data.rows,
+      schema: data.schema,
     }));
   }
   catch (_error) {
@@ -49,12 +60,13 @@ export function cacheColumnMetadataRows(cacheKey, rows) {
   }
 }
 
-export function createCachedColumnMetadataResult(rows) {
+export function createCachedColumnMetadataResult(data) {
+  const rows = data && data.rows;
+  const schema = data && data.schema;
   const safeRows = Array.isArray(rows) ? rows : [];
-  const fields = safeRows.length ? Object.keys(safeRows[0]).map((name) => ({ name })) : [];
   return {
     numRows: safeRows.length,
-    schema: { fields },
+    schema: schema || { fields: [] },
     get(index) {
       const row = safeRows[index];
       if (!row) {
@@ -72,6 +84,7 @@ export function createCachedColumnMetadataResult(rows) {
 export function serializeColumnMetadataResult(resultSet) {
   const numRows = resultSet && typeof resultSet.numRows === 'number' ? resultSet.numRows : 0;
   const rows = [];
+  const schema = resultSet && resultSet.schema ? resultSet.schema : { fields: [] };
   for (let i = 0; i < numRows; i++) {
     const row = resultSet.get(i);
     if (!row) {
@@ -89,5 +102,8 @@ export function serializeColumnMetadataResult(resultSet) {
     }
     rows.push(plainRow);
   }
-  return rows;
+  return {
+    rows,
+    schema,
+  };
 }

--- a/tests/unit/duckdb-datasource-logic.test.js
+++ b/tests/unit/duckdb-datasource-logic.test.js
@@ -33,6 +33,7 @@ describe('DuckDbDataSource logic coverage', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    localStorage.clear();
   });
 
   describe('static file helpers', () => {
@@ -238,6 +239,51 @@ describe('DuckDbDataSource logic coverage', () => {
 
       await expect(datasource.getColumnMetadata()).rejects.toThrow('describe failed');
       expect(showErrorDialog).toHaveBeenCalledWith(error);
+    });
+
+    it('reuses cached parquet metadata across datasource instances with the same file fingerprint', async () => {
+      const file = new File(['parquet'], 'people.parquet', { type: 'application/vnd.apache.parquet', lastModified: 1234 });
+
+      const firstInstance = createInstanceMock();
+      const firstMetadata = {
+        numRows: 1,
+        schema: { fields: [{ name: 'column_name' }, { name: 'column_type' }] },
+        get() {
+          return {
+            column_name: 'id',
+            column_type: 'BIGINT',
+            toJSON() {
+              return { column_name: 'id', column_type: 'BIGINT' };
+            }
+          };
+        }
+      };
+      firstInstance.__query.mockResolvedValue(firstMetadata);
+
+      const firstDatasource = DuckDbDataSource.createFromFile(duckdbMock, firstInstance, file);
+      const cacheKey = firstDatasource.getColumnMetadataCacheKey();
+      expect(cacheKey).toBeTruthy();
+      await firstDatasource.getColumnMetadata();
+      expect(firstInstance.__query).toHaveBeenCalledTimes(1);
+
+      const secondInstance = createInstanceMock();
+      const secondDatasource = DuckDbDataSource.createFromFile(duckdbMock, secondInstance, file);
+      const cachedMetadata = await secondDatasource.getColumnMetadata();
+
+      expect(secondInstance.__query).not.toHaveBeenCalled();
+      expect(cachedMetadata.numRows).toBe(1);
+      expect(cachedMetadata.get(0).column_name).toBe('id');
+      expect(cachedMetadata.get(0).column_type).toBe('BIGINT');
+    });
+
+    it('does not create a persistent cache key for non-parquet files', () => {
+      const datasource = DuckDbDataSource.createFromFile(
+        duckdbMock,
+        createInstanceMock(),
+        new File(['a,b\n1,2'], 'people.csv', { type: 'text/csv' })
+      );
+
+      expect(datasource.getColumnMetadataCacheKey()).toBeUndefined();
     });
   });
 });

--- a/tests/unit/duckdb-datasource-logic.test.js
+++ b/tests/unit/duckdb-datasource-logic.test.js
@@ -274,6 +274,7 @@ describe('DuckDbDataSource logic coverage', () => {
       expect(cachedMetadata.numRows).toBe(1);
       expect(cachedMetadata.get(0).column_name).toBe('id');
       expect(cachedMetadata.get(0).column_type).toBe('BIGINT');
+      expect(cachedMetadata.schema.fields.map((field) => field.name)).toEqual(['column_name', 'column_type']);
     });
 
     it('does not create a persistent cache key for non-parquet files', () => {


### PR DESCRIPTION
## Summary
- add a persistent parquet column-metadata cache keyed by local file fingerprint
- reuse cached metadata across app reloads / repeated local-file opens before falling back to DuckDB `DESCRIBE`
- extend the benchmark harness with a repeated-open schema scenario to measure the cache-sensitive path

Implements Phase 1 of #390

## Measured impact
From `npm run perf:ui` on this branch:
- `upload_wide_schema`: `4970ms`
- `upload_wide_schema_cached`: `3466ms`
- repeated-open schema/attribute readiness improves by roughly `1504ms` in the same browser storage context

## Validation
- npm run test:unit -- tests/unit/duckdb-datasource-logic.test.js
- npm run lint:js
- npm run perf:ui
