### PR TITLE
Expose additional read_parquet parameters in datasource settings

### DIFF
--- a/src/DatasourceSettingsDialog/DatasourceSettings.js
+++ b/src/DatasourceSettingsDialog/DatasourceSettings.js
@@ -93,9 +93,9 @@ export class DatasourceSettings extends SettingsBase {
       "parquetReaderFilename": false,
       "parquetReaderBinaryAsString": false,
       "parquetReaderHivePartitioning": false,
+      "parquetReaderHiveTypesAutocast": true,
       "parquetReaderUnionByName": false,
-      "parquetReaderFileRowNumber": false,
-      "parquetReaderHiveTypesAutocast": true
+      "parquetReaderFileRowNumber": false
     }
   };
 

--- a/src/DatasourceSettingsDialog/DatasourceSettings.js
+++ b/src/DatasourceSettingsDialog/DatasourceSettings.js
@@ -92,7 +92,10 @@ export class DatasourceSettings extends SettingsBase {
     "parquetReader": {
       "parquetReaderFilename": false,
       "parquetReaderBinaryAsString": false,
-      "parquetReaderHivePartitioning": false
+      "parquetReaderHivePartitioning": false,
+      "parquetReaderUnionByName": false,
+      "parquetReaderFileRowNumber": false,
+      "parquetReaderHiveTypesAutocast": true
     }
   };
 

--- a/src/index.html
+++ b/src/index.html
@@ -1683,6 +1683,24 @@
                   type="checkbox"
                   title="Infer partition columns from Hive-style key=value path segments."
                 />
+                <label for="parquetReaderHiveTypesAutocast" title="Automatically cast Hive partition column values to their detected types. Only relevant when Hive partitioning is enabled.">Hive types autocast</label>
+                <input
+                  id="parquetReaderHiveTypesAutocast"
+                  type="checkbox"
+                  title="Automatically cast Hive partition column values to their detected types. Only relevant when Hive partitioning is enabled."
+                />
+                <label for="parquetReaderUnionByName" title="When reading multiple Parquet files, unify columns by name rather than position. Useful when files have different but compatible schemas.">Union by name</label>
+                <input
+                  id="parquetReaderUnionByName"
+                  type="checkbox"
+                  title="When reading multiple Parquet files, unify columns by name rather than position. Useful when files have different but compatible schemas."
+                />
+                <label for="parquetReaderFileRowNumber" title="Add a file_row_number column containing the zero-based row index within the source Parquet file.">File row number</label>
+                <input
+                  id="parquetReaderFileRowNumber"
+                  type="checkbox"
+                  title="Add a file_row_number column containing the zero-based row index within the source Parquet file."
+                />
               </fieldset>
             </form>
           </div>

--- a/tests/unit/parquet-support.test.js
+++ b/tests/unit/parquet-support.test.js
@@ -46,6 +46,40 @@ describe('Parquet support settings', () => {
 
     expect(readerArguments).toEqual({ hive_partitioning: true });
   });
+
+  test('maps union_by_name when enabled', () => {
+    const settings = new DatasourceSettings();
+    const nextSettings = settings.getSettings();
+    nextSettings.parquetReader.parquetReaderUnionByName = true;
+    settings.assignSettings([], nextSettings);
+
+    expect(settings.getReaderArguments('read_parquet')).toEqual({ union_by_name: true });
+  });
+
+  test('maps file_row_number when enabled', () => {
+    const settings = new DatasourceSettings();
+    const nextSettings = settings.getSettings();
+    nextSettings.parquetReader.parquetReaderFileRowNumber = true;
+    settings.assignSettings([], nextSettings);
+
+    expect(settings.getReaderArguments('read_parquet')).toEqual({ file_row_number: true });
+  });
+
+  test('hive_types_autocast is omitted when at its default (true)', () => {
+    const settings = new DatasourceSettings();
+    // Default is true — should not appear in reader arguments
+    const readerArguments = settings.getReaderArguments('read_parquet');
+    expect(readerArguments).not.toHaveProperty('hive_types_autocast');
+  });
+
+  test('hive_types_autocast is emitted when set to false', () => {
+    const settings = new DatasourceSettings();
+    const nextSettings = settings.getSettings();
+    nextSettings.parquetReader.parquetReaderHiveTypesAutocast = false;
+    settings.assignSettings([], nextSettings);
+
+    expect(settings.getReaderArguments('read_parquet')).toEqual({ hive_types_autocast: false });
+  });
 });
 
 describe('Upload URL parsing helpers', () => {


### PR DESCRIPTION
## Summary

Adds three new checkboxes to the **Parquet Reader Parameters** tab in the datasource settings dialog, closing #392.

| Setting | DuckDB argument | Default | Notes |
|---|---|---|---|
| Union by name | `union_by_name` | `false` | Unify columns by name when reading multiple files with different schemas. Already exposed for CSV/JSON — this brings Parquet into parity. |
| File row number | `file_row_number` | `false` | Adds a `file_row_number` column with the zero-based row index within the source file. Useful for auditing and deduplication. |
| Hive types autocast | `hive_types_autocast` | `true` (checked) | Controls whether Hive partition column values are automatically cast to their detected types. Only meaningful when Hive partitioning is on. |

## Implementation notes

- **`DatasourceSettings.js`** — three new entries in `#template.parquetReader`. `hive_types_autocast` defaults to `true` (matching DuckDB's default), so it is only emitted as an argument when the user unchecks it.
- **`index.html`** — three `<label>`/`<input type="checkbox">` pairs added to the existing parquet fieldset, following the same pattern as the existing controls.
- **No serialisation changes needed** — the existing `#getDuckDbReaderArgumentName` camelCase→snake_case conversion handles all three keys automatically:
  - `parquetReaderUnionByName` → `union_by_name`
  - `parquetReaderFileRowNumber` → `file_row_number`
  - `parquetReaderHiveTypesAutocast` → `hive_types_autocast`
- **No i18n changes** — the existing parquet field labels are not in the i18n template, so the new ones follow the same convention.

## Test plan
- [ ] Open a single `.parquet` file → settings dialog → Parquet Reader Parameters tab shows all 6 checkboxes
- [ ] Check **Union by name**, save, reopen — verify `union_by_name = true` is present in the generated SQL
- [ ] Check **File row number**, run query — `file_row_number` column appears in results
- [ ] With **Hive partitioning** on, uncheck **Hive types autocast** — verify `hive_types_autocast = false` is passed
- [ ] Restore defaults — all new settings return to their defaults (union_by_name=false, file_row_number=false, hive_types_autocast=true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)