### PR TITLE
Expand backend benchmark workloads

### DIFF
--- a/scripts/backend_benchmark_runner.py
+++ b/scripts/backend_benchmark_runner.py
@@ -33,6 +33,7 @@ class RequestResult:
 
 
 def _endpoint_category(endpoint: str) -> str:
+    """Map a scenario name back to the base endpoint threshold bucket."""
     if endpoint.startswith("tuples"):
         return "tuples"
     if endpoint.startswith("cells"):
@@ -126,7 +127,7 @@ def _run(
     timeout: float,
 ) -> tuple[dict[str, list[RequestResult]], float]:
     by_endpoint: dict[str, list[RequestResult]] = {w["name"]: [] for w in workloads}
-    started = time.perf_counter()
+    measured_started = None
     with ThreadPoolExecutor(max_workers=max(1, workers)) as executor:
         for workload in workloads:
             warmup_requests = max(0, int(workload.get("warmup_requests", 0)))
@@ -136,8 +137,16 @@ def _run(
                     for _ in range(warmup_requests)
                 ]
                 for future in as_completed(warmup_futures):
-                    future.result()
+                    warmup_result = future.result()
+                    if not warmup_result.ok:
+                        print(
+                            f"WARMUP WARN: endpoint={warmup_result.endpoint} status={warmup_result.status_code} "
+                            f"timed_out={warmup_result.timed_out}",
+                            file=sys.stderr,
+                        )
 
+            if measured_started is None:
+                measured_started = time.perf_counter()
             futures = [
                 executor.submit(_request, base_url, workload, timeout)
                 for _ in range(requests_per_endpoint)
@@ -145,7 +154,9 @@ def _run(
             for future in as_completed(futures):
                 result = future.result()
                 by_endpoint[result.endpoint].append(result)
-    duration = max(time.perf_counter() - started, 1e-6)
+    if measured_started is None:
+        measured_started = time.perf_counter()
+    duration = max(time.perf_counter() - measured_started, 1e-6)
     return by_endpoint, duration
 
 

--- a/scripts/backend_benchmark_runner.py
+++ b/scripts/backend_benchmark_runner.py
@@ -32,6 +32,18 @@ class RequestResult:
     timed_out: bool
 
 
+def _endpoint_category(endpoint: str) -> str:
+    if endpoint.startswith("tuples"):
+        return "tuples"
+    if endpoint.startswith("cells"):
+        return "cells"
+    if endpoint.startswith("picklist"):
+        return "picklist"
+    if endpoint.startswith("export"):
+        return "export"
+    return endpoint
+
+
 def _percentile(values: list[float], q: float) -> float:
     if not values:
         return 0.0
@@ -114,13 +126,25 @@ def _run(
     timeout: float,
 ) -> tuple[dict[str, list[RequestResult]], float]:
     by_endpoint: dict[str, list[RequestResult]] = {w["name"]: [] for w in workloads}
-    tasks = [w for w in workloads for _ in range(requests_per_endpoint)]
     started = time.perf_counter()
     with ThreadPoolExecutor(max_workers=max(1, workers)) as executor:
-        futures = [executor.submit(_request, base_url, workload, timeout) for workload in tasks]
-        for future in as_completed(futures):
-            result = future.result()
-            by_endpoint[result.endpoint].append(result)
+        for workload in workloads:
+            warmup_requests = max(0, int(workload.get("warmup_requests", 0)))
+            if warmup_requests:
+                warmup_futures = [
+                    executor.submit(_request, base_url, workload, timeout)
+                    for _ in range(warmup_requests)
+                ]
+                for future in as_completed(warmup_futures):
+                    future.result()
+
+            futures = [
+                executor.submit(_request, base_url, workload, timeout)
+                for _ in range(requests_per_endpoint)
+            ]
+            for future in as_completed(futures):
+                result = future.result()
+                by_endpoint[result.endpoint].append(result)
     duration = max(time.perf_counter() - started, 1e-6)
     return by_endpoint, duration
 
@@ -159,7 +183,7 @@ def _summarize(
         }
         summary[endpoint] = metrics
 
-        endpoint_threshold = thresholds.get("endpoints", {}).get(endpoint, {})
+        endpoint_threshold = thresholds.get("endpoints", {}).get(_endpoint_category(endpoint), {})
         max_p95 = endpoint_threshold.get("max_p95_ms")
         max_timeout_error_rate = endpoint_threshold.get("max_timeout_error_rate")
         if max_p95 is not None and metrics["latency_ms"]["p95"] > max_p95:

--- a/server/benchmarks/workloads.json
+++ b/server/benchmarks/workloads.json
@@ -1,9 +1,10 @@
 {
   "workloads": [
     {
-      "name": "tuples",
+      "name": "tuples_symbol",
       "method": "POST",
       "path": "/query/tuples",
+      "warmup_requests": 2,
       "body": {
         "query": {
           "fields": [{"field": "symbol"}],
@@ -12,9 +13,23 @@
       }
     },
     {
-      "name": "cells",
+      "name": "tuples_symbol_filtered",
+      "method": "POST",
+      "path": "/query/tuples",
+      "warmup_requests": 2,
+      "body": {
+        "query": {
+          "fields": [{"field": "symbol"}],
+          "filters": [{"field": "symbol", "operator": "EXCLUDE", "values": ["AAPL"]}],
+          "paging": {"limit": 50, "offset": 0}
+        }
+      }
+    },
+    {
+      "name": "cells_symbol_sum_volume",
       "method": "POST",
       "path": "/query/cells",
+      "warmup_requests": 2,
       "body": {
         "query": {
           "axes": {
@@ -26,9 +41,25 @@
       }
     },
     {
-      "name": "picklist",
+      "name": "cells_date_symbol_sum_volume",
+      "method": "POST",
+      "path": "/query/cells",
+      "warmup_requests": 2,
+      "body": {
+        "query": {
+          "axes": {
+            "rows": [{"field": "date"}],
+            "columns": [{"field": "symbol"}],
+            "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}]
+          }
+        }
+      }
+    },
+    {
+      "name": "picklist_symbol",
       "method": "POST",
       "path": "/query/picklist",
+      "warmup_requests": 2,
       "body": {
         "query": {
           "field": "symbol",
@@ -39,9 +70,24 @@
       }
     },
     {
-      "name": "export",
+      "name": "picklist_symbol_search",
+      "method": "POST",
+      "path": "/query/picklist",
+      "warmup_requests": 2,
+      "body": {
+        "query": {
+          "field": "symbol",
+          "search": "A*",
+          "filters": [],
+          "paging": {"limit": 100, "offset": 0}
+        }
+      }
+    },
+    {
+      "name": "export_csv_symbol_volume",
       "method": "POST",
       "path": "/export",
+      "warmup_requests": 1,
       "body": {
         "query": {
           "export_type": "pivot_results",

--- a/server/benchmarks/workloads.json
+++ b/server/benchmarks/workloads.json
@@ -87,7 +87,6 @@
       "name": "export_csv_symbol_volume",
       "method": "POST",
       "path": "/export",
-      "warmup_requests": 1,
       "body": {
         "query": {
           "export_type": "pivot_results",

--- a/tests/test_backend_benchmark_runner.py
+++ b/tests/test_backend_benchmark_runner.py
@@ -47,6 +47,18 @@ def test_benchmark_runner_smoke(tmp_path: Path) -> None:
     thread = Thread(target=server.serve_forever, daemon=True)
     thread.start()
 
+    thresholds = {
+        "mode": "warn",
+        "endpoints": {
+            "tuples": {"max_p95_ms": 0},
+            "cells": {},
+            "picklist": {},
+            "export": {},
+        },
+    }
+    thresholds_path = tmp_path / "thresholds.json"
+    thresholds_path.write_text(json.dumps(thresholds), encoding="utf-8")
+
     try:
         result = subprocess.run(
             [
@@ -58,6 +70,8 @@ def test_benchmark_runner_smoke(tmp_path: Path) -> None:
                 "1",
                 "--workers",
                 "1",
+                "--thresholds",
+                str(thresholds_path),
                 "--output-dir",
                 str(output_dir),
             ],
@@ -88,6 +102,9 @@ def test_benchmark_runner_smoke(tmp_path: Path) -> None:
         "picklist_symbol_search",
         "export_csv_symbol_volume",
     }
+    for metrics in report["summary"].values():
+        assert metrics["requests"] == 1
+    assert any("tuples_symbol" in warning for warning in report["warnings"])
 
 
 def test_benchmark_workflow_upload_path() -> None:

--- a/tests/test_backend_benchmark_runner.py
+++ b/tests/test_backend_benchmark_runner.py
@@ -79,7 +79,15 @@ def test_benchmark_runner_smoke(tmp_path: Path) -> None:
     assert summary_md.exists()
 
     report = json.loads(report_json.read_text(encoding="utf-8"))
-    assert set(report["summary"]) == {"tuples", "cells", "picklist", "export"}
+    assert set(report["summary"]) == {
+        "tuples_symbol",
+        "tuples_symbol_filtered",
+        "cells_symbol_sum_volume",
+        "cells_date_symbol_sum_volume",
+        "picklist_symbol",
+        "picklist_symbol_search",
+        "export_csv_symbol_volume",
+    }
 
 
 def test_benchmark_workflow_upload_path() -> None:


### PR DESCRIPTION
## Summary
- expand backend benchmark workloads with warmup-aware tuples, cells, picklist, and export scenarios
- classify scenario names under endpoint threshold categories so richer workloads still use the existing threshold model
- update benchmark smoke coverage to the new workload set

Implements #400

## Validation
- ./.venv-server/bin/pytest tests/test_backend_benchmark_runner.py -q
- python3 scripts/backend_benchmark_runner.py --base-url http://127.0.0.1:8000 --requests-per-endpoint 5 --workers 2 --timeout 30 --output-dir artifacts/backend-benchmarks/workload-expansion
