### PR TITLE
Add v1 routing infrastructure

### DIFF
--- a/docs/backend-load-testing.md
+++ b/docs/backend-load-testing.md
@@ -4,7 +4,7 @@ This document describes how to run load tests against the QueryService API (C3.1
 
 ## Scope
 
-- Concurrent requests to `/schema`, `/query/tuples`, `/query/cells`, `/query/picklist`.
+- Concurrent requests to `/api/v1/datasets/{dataset_id}/schema`, `/api/v1/datasets/{dataset_id}/query/tuples`, `/api/v1/datasets/{dataset_id}/query/cells`, `/api/v1/datasets/{dataset_id}/query/picklist`.
 - Metrics: request count, success rate, latency percentiles (p50, p90, p99).
 
 ## Prerequisites

--- a/docs/backend-performance-benchmarks.md
+++ b/docs/backend-performance-benchmarks.md
@@ -9,10 +9,10 @@ python scripts/backend_benchmark_runner.py \
 ```
 
 This runs benchmark workloads for:
-- `POST /query/tuples`
-- `POST /query/cells`
-- `POST /query/picklist`
-- `POST /export`
+- `POST /api/v1/datasets/{dataset_id}/query/tuples`
+- `POST /api/v1/datasets/{dataset_id}/query/cells`
+- `POST /api/v1/datasets/{dataset_id}/query/picklist`
+- `POST /api/v1/exports`
 
 Outputs:
 - `benchmark-report.json` (machine-readable full report)

--- a/docs/huey-large-scale-olap-architecture.md
+++ b/docs/huey-large-scale-olap-architecture.md
@@ -55,7 +55,7 @@ At a high level:
 High-level sequence:
 
 1. User configures a pivot in Huey (dataset, date_range, rows, columns, measures, filters).
-2. Huey sends a `/query/tuples` request to QueryService to fetch row and column headers.
+2. Huey sends a `/api/v1/datasets/{dataset_id}/query/tuples` request to QueryService to fetch row and column headers.
 3. QueryService builds or validates an engine query:
    - Enforces `WHERE date BETWEEN ...` based on date_range.
    - Applies filter predicates.
@@ -63,7 +63,7 @@ High-level sequence:
    - Reads only the relevant date partition(s) from S3.
    - Computes grouped tuples and, optionally, grouping IDs for totals.
 5. QueryService returns a tuple window to Huey.
-6. Huey sends `/query/cells` to obtain cell values for a given window of row and column tuples.
+6. Huey sends `/api/v1/datasets/{dataset_id}/query/cells` to obtain cell values for a given window of row and column tuples.
 7. QueryEngine runs an aggregate query to compute cell values.
 8. QueryService returns cells; Huey renders the pivot.
 9. On scroll, Huey requests additional windows; QueryService reuses engine and data paths.
@@ -123,14 +123,14 @@ sequenceDiagram
   participant X as S3Parquet
 
   U->>H: Configure pivot (dataset, date_range, axes, filters)
-  H->>S: POST /query/tuples
+  H->>S: POST /api/v1/datasets/{dataset_id}/query/tuples
   S->>E: Build/execute tuple query (with date predicates)
   E->>X: Read partitioned parquet
   X-->>E: Columnar data
   E-->>S: Tuple result set
   S-->>H: Tuple window
 
-  H->>S: POST /query/cells (rows x columns window)
+  H->>S: POST /api/v1/datasets/{dataset_id}/query/cells (rows x columns window)
   S->>E: Build/execute cell aggregate query
   E->>X: Read necessary columns
   X-->>E: Data
@@ -202,7 +202,7 @@ Deliverables:
 
 **Epic 3: Tuple queries**
 
-- Implement `POST /query/tuples`:
+- Implement `POST /api/v1/datasets/{dataset_id}/query/tuples`:
   - Support single-dimension grouping, day-scoped queries, limit/offset.
   - Apply filters and date predicates.
 - Add tests using synthetic data approximating 50 GB/day partitions.
@@ -215,14 +215,14 @@ Deliverables:
   - API base URL.
   - Dataset IDs.
 - Implement `RemoteDatasource` in Huey:
-  - Calls `/schema` for attribute lists.
-  - Calls `/query/tuples` and `/query/cells` to drive the pivot table.
+  - Calls `/api/v1/datasets/{dataset_id}/schema` for attribute lists.
+  - Calls `/api/v1/datasets/{dataset_id}/query/tuples` and `/api/v1/datasets/{dataset_id}/query/cells` to drive the pivot table.
 - Feature flag:
   - Allow switching between local/WASM and remote modes per dataset.
 
 **Epic 5: Filter UI integration**
 
-- Wire Filter UI picklists to `/query/picklist`.
+- Wire Filter UI picklists to `/api/v1/datasets/{dataset_id}/query/picklist`.
 - Ensure global filters are propagated to all tuple and cell requests.
 - Optimize picklist paging, search behavior, and user feedback.
 
@@ -240,7 +240,7 @@ Deliverables:
 
 **Epic 7: Exports and saved views**
 
-- Implement `/export` endpoint and background export jobs.
+- Implement `/api/v1/exports` endpoint and background export jobs.
 - Wire Huey’s export capabilities to remote exports:
   - Respect row/size limits.
   - Avoid overloading the browser with large downloads.
@@ -275,4 +275,3 @@ Deliverables:
   - Backup and recovery strategies for configuration and logs.
   - Observability practices (dashboards and alerts).
 - Roll out to broader user base and treat feature as generally available.
-

--- a/docs/server/README.md
+++ b/docs/server/README.md
@@ -15,7 +15,7 @@ QueryService is a Python FastAPI service that runs analytical SQL against DuckDB
 
 - Dataset schema discovery (`/schema`)
 - Distinct tuples, picklists, and aggregated cells (`/query/*`)
-- Async export jobs (`/export*`) with durable job state in SQLite
+- Async export jobs (`/api/v1/exports*`) with durable job state in SQLite
 - Health probes (`/health/*`)
 
 In the Huey architecture, this service is the backend execution layer behind the frontend query UI.
@@ -37,9 +37,9 @@ Typical users:
 
 Typical workflows:
 
-1. Discover dataset schema with `GET /schema`.
-2. Build interactive queries with `POST /query/tuples`, `POST /query/cells`, `POST /query/picklist`.
-3. Trigger async export with `POST /export`, poll with `GET /export/{export_id}`, then download.
+1. Discover dataset schema with `GET /api/v1/datasets/{dataset_id}/schema`.
+2. Build interactive queries with `POST /api/v1/datasets/{dataset_id}/query/tuples`, `POST /api/v1/datasets/{dataset_id}/query/cells`, `POST /api/v1/datasets/{dataset_id}/query/picklist`.
+3. Trigger async export with `POST /api/v1/exports`, poll with `GET /api/v1/exports/{export_id}`, then download.
 
 ## 3. Installation and Setup
 
@@ -163,9 +163,9 @@ See [API Reference](./api-reference.md) for full endpoint-by-endpoint request/re
 
 Built-in interactive docs:
 
-- `/docs` (Swagger UI)
-- `/redoc`
-- `/openapi.json`
+- `/api/v1/docs` (Swagger UI)
+- `/api/v1/redoc`
+- `/api/v1/openapi.json`
 
 ## 7. Examples and Recipes
 
@@ -180,13 +180,13 @@ Start service:
 Check schema:
 
 ```bash
-curl 'http://localhost:8000/schema?dataset_id=trades_v1'
+curl 'http://localhost:8000/api/v1/datasets/trades_v1/schema'
 ```
 
 Run tuples query:
 
 ```bash
-curl -X POST 'http://localhost:8000/query/tuples' \
+curl -X POST 'http://localhost:8000/api/v1/datasets/trades_v1/query/tuples' \
   -H 'Content-Type: application/json' \
   -d '{
     "dataset_id": "trades_v1",
@@ -198,7 +198,7 @@ curl -X POST 'http://localhost:8000/query/tuples' \
 Create export (default format is parquet):
 
 ```bash
-curl -X POST 'http://localhost:8000/export' \
+curl -X POST 'http://localhost:8000/api/v1/exports' \
   -H 'Content-Type: application/json' \
   -d '{
     "dataset_id": "trades_v1",
@@ -216,8 +216,8 @@ curl -X POST 'http://localhost:8000/export' \
 Poll + download:
 
 ```bash
-curl 'http://localhost:8000/export/<export_id>'
-curl -OJ 'http://localhost:8000/export/<export_id>/download'
+curl 'http://localhost:8000/api/v1/exports/<export_id>'
+curl -OJ 'http://localhost:8000/api/v1/exports/<export_id>/download'
 ```
 
 ### Example environment profiles

--- a/docs/server/README.md
+++ b/docs/server/README.md
@@ -13,8 +13,8 @@ This documentation set covers the Huey backend service (`server/`), called **Que
 
 QueryService is a Python FastAPI service that runs analytical SQL against DuckDB and exposes HTTP endpoints for:
 
-- Dataset schema discovery (`/schema`)
-- Distinct tuples, picklists, and aggregated cells (`/query/*`)
+- Dataset schema discovery (`/api/v1/datasets/{dataset_id}/schema`)
+- Distinct tuples, picklists, and aggregated cells (`/api/v1/datasets/{dataset_id}/query/*`)
 - Async export jobs (`/api/v1/exports*`) with durable job state in SQLite
 - Health probes (`/health/*`)
 

--- a/docs/server/api-reference.md
+++ b/docs/server/api-reference.md
@@ -282,7 +282,7 @@ Error statuses:
 - `401` auth failure when auth enabled
 - `429` if rate limiting enabled and exceeded
 
-## `POST /export`
+## `POST /api/v1/exports`
 
 Submits async export job and returns job id immediately.
 
@@ -329,7 +329,7 @@ Error statuses:
 - `401` auth failure when auth enabled
 - `429` if rate limiting enabled and exceeded
 
-## `GET /export/{export_id}`
+## `GET /api/v1/exports/{export_id}`
 
 Returns export job status.
 
@@ -345,7 +345,7 @@ Success `200` example:
 {
   "export_id": "exp-1234abcd",
   "status": "complete",
-  "download_url": "/export/exp-1234abcd/download"
+  "download_url": "/api/v1/exports/exp-1234abcd/download"
 }
 ```
 
@@ -356,7 +356,7 @@ Error statuses:
 - `404` `EXPORT_NOT_FOUND`
 - `401` auth failure when auth enabled
 
-## `GET /export/{export_id}/download`
+## `GET /api/v1/exports/{export_id}/download`
 
 Downloads completed export artifact.
 

--- a/docs/server/api-reference.md
+++ b/docs/server/api-reference.md
@@ -88,20 +88,20 @@ Responses:
 {"status": "unavailable"}
 ```
 
-## `GET /schema`
+## `GET /api/v1/datasets/{dataset_id}/schema`
 
 Returns schema metadata for a configured dataset.
 
 Authentication: conditional API key.
 
-Query parameters:
+Path parameters:
 
 - `dataset_id` (required, string)
 
 Example:
 
 ```bash
-curl 'http://localhost:8000/schema?dataset_id=trades_v1'
+curl 'http://localhost:8000/api/v1/datasets/trades_v1/schema'
 ```
 
 Success `200` example:
@@ -122,7 +122,7 @@ Error statuses:
 - `404` `DATASET_NOT_FOUND`
 - `401` auth failure when auth enabled
 
-## `POST /query/tuples`
+## `POST /api/v1/datasets/{dataset_id}/query/tuples`
 
 Returns distinct tuple values for selected fields.
 
@@ -177,7 +177,7 @@ Error statuses:
 - `401` auth failure when auth enabled
 - `429` if rate limiting enabled and exceeded
 
-## `POST /query/cells`
+## `POST /api/v1/datasets/{dataset_id}/query/cells`
 
 Returns aggregated cells grouped by row/column axes.
 
@@ -235,7 +235,7 @@ Error statuses:
 - `401` auth failure when auth enabled
 - `429` if rate limiting enabled and exceeded
 
-## `POST /query/picklist`
+## `POST /api/v1/datasets/{dataset_id}/query/picklist`
 
 Returns distinct values for one field, typically used for filter UIs.
 

--- a/docs/server/api-reference.md
+++ b/docs/server/api-reference.md
@@ -7,9 +7,9 @@ Base URL examples:
 
 Interactive OpenAPI:
 
-- `/docs`
-- `/redoc`
-- `/openapi.json`
+- `/api/v1/docs`
+- `/api/v1/redoc`
+- `/api/v1/openapi.json`
 
 ## Conventions
 

--- a/docs/server/configuration-reference.md
+++ b/docs/server/configuration-reference.md
@@ -103,16 +103,16 @@ Rate-limit identity resolution:
 
 Query cache keys use two deterministic version tokens:
 
-- **`fact_version_token`** (for `/query/tuples` and `/query/cells`)
+- **`fact_version_token`** (for `/api/v1/datasets/{dataset_id}/query/tuples` and `/api/v1/datasets/{dataset_id}/query/cells`)
   - Derived from partition metadata fingerprints for the requested `date_range`.
   - Only partitions intersecting the requested date scope contribute to the token.
   - This preserves cache entries for closed historical ranges when a new COBDATE is published outside the requested scope.
-- **`dim_version_token`** (for `/query/picklist`)
+- **`dim_version_token`** (for `/api/v1/datasets/{dataset_id}/query/picklist`)
   - Derived from dataset config identity + field definitions, with optional external override via `QUERYSERVICE_DIM_VERSION_TOKEN`.
 
 These tokens align with the WORM invariants: fact changes occur at COBDATE boundaries, historical partitions are immutable once finalized, and dimension/reference updates are infrequent.
 
-## Dimension Dictionary Cache (`/query/picklist`)
+## Dimension Dictionary Cache (`/api/v1/datasets/{dataset_id}/query/picklist`)
 
 Picklist / filter-dropdown queries are backed by a dedicated dimension cache
 with a longer default TTL and optional stale-while-revalidate behaviour,
@@ -153,9 +153,9 @@ on a fresh computation.
 
 ## Endpoint cache policy
 
-- `/query/picklist`: aggressive cache policy (long TTL + optional stale-while-revalidate).
-- `/query/tuples`: moderate/aggressive fact cache policy using `fact_version_token`.
-- `/query/cells`: conservative policy (effective TTL and item-size caps are stricter than tuples).
+- `/api/v1/datasets/{dataset_id}/query/picklist`: aggressive cache policy (long TTL + optional stale-while-revalidate).
+- `/api/v1/datasets/{dataset_id}/query/tuples`: moderate/aggressive fact cache policy using `fact_version_token`.
+- `/api/v1/datasets/{dataset_id}/query/cells`: conservative policy (effective TTL and item-size caps are stricter than tuples).
 
 ## Invalidation matrix
 

--- a/scripts/create-olap-issues.sh
+++ b/scripts/create-olap-issues.sh
@@ -44,8 +44,8 @@ issue "A2.1" "Dataset configuration loader" \
 
 $(body_brd)" "area:backend"
 
-issue "A2.2" "Implement GET /schema endpoint" \
-"Implement \`GET /schema?dataset_id=...\` returning field names, types, dimension/measure flags. Unit tests for valid and unknown dataset IDs.
+issue "A2.2" "Implement GET /api/v1/datasets/{dataset_id}/schema endpoint" \
+"Implement \`GET /api/v1/datasets/{dataset_id}/schema\` returning field names, types, dimension/measure flags. Unit tests for valid and unknown dataset IDs.
 
 $(body_brd)" "area:backend"
 
@@ -59,22 +59,22 @@ issue "A3.2" "S3 connectivity" \
 
 $(body_brd)" "area:backend"
 
-issue "A4.1" "Implement POST /query/tuples (basic)" \
+issue "A4.1" "Implement POST /api/v1/datasets/{dataset_id}/query/tuples (basic)" \
 "Accept single axis (rows/columns), single field, simple IN filters, single-day date_range. Translate to GROUP BY + LIMIT/OFFSET; return values and total_count. Unit tests for happy path and unknown fields/datasets.
 
 $(body_brd)" "area:backend"
 
-issue "A4.2" "Implement POST /query/cells (basic)" \
+issue "A4.2" "Implement POST /api/v1/datasets/{dataset_id}/query/cells (basic)" \
 "Support single row field, single column field, 1–2 measures (SUM/COUNT). Grouped aggregate; map results to row/column indexes. Tests with deterministic sample data.
 
 $(body_brd)" "area:backend"
 
-issue "A5.1" "Implement POST /query/picklist" \
+issue "A5.1" "Implement POST /api/v1/datasets/{dataset_id}/query/picklist" \
 "Distinct values for a field with date_range + filters, paging (limit/offset), optional search. Tests for high-cardinality and filter interaction.
 
 $(body_brd)" "area:backend"
 
-issue "A5.2" "Implement POST /export (MVP)" \
+issue "A5.2" "Implement POST /api/v1/exports (MVP)" \
 "Synchronous export for small result sets, CSV output. Refactor to async jobs later.
 
 $(body_brd)" "area:backend"
@@ -110,23 +110,23 @@ issue "B1.2" "RemoteDatasource abstraction" \
 
 $(body_brd)" "area:frontend"
 
-issue "B2.1" "Attribute UI backed by /schema" \
-"Integrate Attribute UI with RemoteDataSource: fetch fields from /schema, display dimension/measure metadata. Consistent derived attributes/aggregations (subset ok initially).
+issue "B2.1" "Attribute UI backed by /api/v1/datasets/{dataset_id}/schema" \
+"Integrate Attribute UI with RemoteDataSource: fetch fields from /api/v1/datasets/{dataset_id}/schema, display dimension/measure metadata. Consistent derived attributes/aggregations (subset ok initially).
 
 $(body_brd)" "area:frontend"
 
-issue "B3.1" "Tuple fetching via /query/tuples" \
-"Update TupleSet (or equivalent) to fetch tuples from RemoteDataSource for remote datasets. Map axis definitions to /query/tuples request body. Scrolling requests appropriate windows.
+issue "B3.1" "Tuple fetching via /api/v1/datasets/{dataset_id}/query/tuples" \
+"Update TupleSet (or equivalent) to fetch tuples from RemoteDataSource for remote datasets. Map axis definitions to /api/v1/datasets/{dataset_id}/query/tuples request body. Scrolling requests appropriate windows.
 
 $(body_brd)" "area:frontend"
 
-issue "B3.2" "Cell fetching via /query/cells" \
-"Update CellSet to request cells via /query/cells. Scrolling and viewport-based fetching work with correct row/column windows.
+issue "B3.2" "Cell fetching via /api/v1/datasets/{dataset_id}/query/cells" \
+"Update CellSet to request cells via /api/v1/datasets/{dataset_id}/query/cells. Scrolling and viewport-based fetching work with correct row/column windows.
 
 $(body_brd)" "area:frontend"
 
-issue "B4.1" "Filter picklists via /query/picklist" \
-"Wire filter dialog to /query/picklist for remote datasets. Global filters included in picklist queries.
+issue "B4.1" "Filter picklists via /api/v1/datasets/{dataset_id}/query/picklist" \
+"Wire filter dialog to /api/v1/datasets/{dataset_id}/query/picklist for remote datasets. Global filters included in picklist queries.
 
 $(body_brd)" "area:frontend"
 
@@ -152,7 +152,7 @@ issue "C1.1" "Backend unit tests" \
 $(body_brd)" "area:backend"
 
 issue "C1.2" "Backend integration tests" \
-"E2E tests with local S3-compatible store or fixtures. Verify /schema, /query/tuples, /query/cells on synthetic data.
+"E2E tests with local S3-compatible store or fixtures. Verify /api/v1/datasets/{dataset_id}/schema, /api/v1/datasets/{dataset_id}/query/tuples, /api/v1/datasets/{dataset_id}/query/cells on synthetic data.
 
 $(body_brd)" "area:backend"
 

--- a/scripts/load_test_query_service.py
+++ b/scripts/load_test_query_service.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Load test script for QueryService (schema, tuples, cells, picklist).
+Load test script for QueryService v1 (schema, tuples, cells, picklist).
 Uses stdlib only. Run with the server up: python scripts/load_test_query_service.py --base-url http://127.0.0.1:8000
 """
 
@@ -31,13 +31,13 @@ def request(base_url: str, path: str, method: str = "GET", body: dict | None = N
 
 def run_one(base_url: str, dataset_id: str, date_range: dict) -> list[tuple[str, bool, float]]:
     results = []
-    # GET /schema
-    ok, lat = request(base_url, f"/schema?dataset_id={dataset_id}")
+    # GET /api/v1/datasets/{dataset_id}/schema
+    ok, lat = request(base_url, f"/api/v1/datasets/{dataset_id}/schema")
     results.append(("schema", ok, lat))
-    # POST /query/tuples
+    # POST /api/v1/datasets/{dataset_id}/query/tuples
     ok, lat = request(
         base_url,
-        "/query/tuples",
+        f"/api/v1/datasets/{dataset_id}/query/tuples",
         method="POST",
         body={
             "dataset_id": dataset_id,
@@ -46,10 +46,10 @@ def run_one(base_url: str, dataset_id: str, date_range: dict) -> list[tuple[str,
         },
     )
     results.append(("tuples", ok, lat))
-    # POST /query/cells
+    # POST /api/v1/datasets/{dataset_id}/query/cells
     ok, lat = request(
         base_url,
-        "/query/cells",
+        f"/api/v1/datasets/{dataset_id}/query/cells",
         method="POST",
         body={
             "dataset_id": dataset_id,
@@ -63,10 +63,10 @@ def run_one(base_url: str, dataset_id: str, date_range: dict) -> list[tuple[str,
         },
     )
     results.append(("cells", ok, lat))
-    # POST /query/picklist
+    # POST /api/v1/datasets/{dataset_id}/query/picklist
     ok, lat = request(
         base_url,
-        "/query/picklist",
+        f"/api/v1/datasets/{dataset_id}/query/picklist",
         method="POST",
         body={
             "dataset_id": dataset_id,

--- a/server/README.md
+++ b/server/README.md
@@ -27,7 +27,7 @@ Smoke checks:
 
 ```bash
 curl http://localhost:8000/health/liveness
-curl 'http://localhost:8000/schema?dataset_id=trades_v1'
+curl 'http://localhost:8000/api/v1/datasets/trades_v1/schema'
 ```
 
 Run tests:

--- a/server/benchmarks/workloads.json
+++ b/server/benchmarks/workloads.json
@@ -3,7 +3,7 @@
     {
       "name": "tuples_symbol",
       "method": "POST",
-      "path": "/query/tuples",
+      "path": "/api/v1/datasets/trades_v1/query/tuples",
       "warmup_requests": 2,
       "body": {
         "query": {
@@ -15,7 +15,7 @@
     {
       "name": "tuples_symbol_filtered",
       "method": "POST",
-      "path": "/query/tuples",
+      "path": "/api/v1/datasets/trades_v1/query/tuples",
       "warmup_requests": 2,
       "body": {
         "query": {
@@ -28,7 +28,7 @@
     {
       "name": "cells_symbol_sum_volume",
       "method": "POST",
-      "path": "/query/cells",
+      "path": "/api/v1/datasets/trades_v1/query/cells",
       "warmup_requests": 2,
       "body": {
         "query": {
@@ -43,7 +43,7 @@
     {
       "name": "cells_date_symbol_sum_volume",
       "method": "POST",
-      "path": "/query/cells",
+      "path": "/api/v1/datasets/trades_v1/query/cells",
       "warmup_requests": 2,
       "body": {
         "query": {
@@ -58,7 +58,7 @@
     {
       "name": "picklist_symbol",
       "method": "POST",
-      "path": "/query/picklist",
+      "path": "/api/v1/datasets/trades_v1/query/picklist",
       "warmup_requests": 2,
       "body": {
         "query": {
@@ -72,7 +72,7 @@
     {
       "name": "picklist_symbol_search",
       "method": "POST",
-      "path": "/query/picklist",
+      "path": "/api/v1/datasets/trades_v1/query/picklist",
       "warmup_requests": 2,
       "body": {
         "query": {
@@ -86,7 +86,7 @@
     {
       "name": "export_csv_symbol_volume",
       "method": "POST",
-      "path": "/export",
+      "path": "/api/v1/exports",
       "body": {
         "query": {
           "export_type": "pivot_results",

--- a/server/docs/architecture.md
+++ b/server/docs/architecture.md
@@ -32,7 +32,7 @@ Exports follow a sibling path:
 
 ## Export system
 
-- **Lifecycle**: `POST /export` creates a pending job in the SQLite-backed `ExportJobStore`, enforces `export_max_concurrent`, and schedules background processing. Status moves `pending → processing → complete/failed → expired`.
+- **Lifecycle**: `POST /api/v1/exports` creates a pending job in the SQLite-backed `ExportJobStore`, enforces `export_max_concurrent`, and schedules background processing. Status moves `pending → processing → complete/failed → expired`.
 - **Processing**: `ExportService.process` runs the export query, writes CSV to `export_output_dir`, and updates the job record with download URL and row count.
 - **Store**: `ExportJobStore` persists job metadata in SQLite (`export_db_path`), using WAL mode for file-backed DBs.
 - **TTL cleanup**: `cleanup_expired` removes jobs older than `export_ttl_seconds` and deletes their files.

--- a/server/export_service.py
+++ b/server/export_service.py
@@ -175,7 +175,7 @@ class ExportService:
             self._store.update_status(
                 job_id, "complete",
                 file_path=str(file_path),
-                download_url=f"/export/{job_id}/download",
+                download_url=f"/api/v1/exports/{job_id}/download",
                 row_count=row_count,
             )
             logger.info(

--- a/server/main.py
+++ b/server/main.py
@@ -139,7 +139,7 @@ async def api_root() -> dict[str, object]:
         "build": build,
         "links": {
             "datasets": "/api/v1/datasets",
-            "exports": "/api/v1/export",
+            "exports": "/api/v1/exports",
             "openapi": "/api/v1/openapi.json",
             "docs": "/api/v1/docs",
         },

--- a/server/main.py
+++ b/server/main.py
@@ -15,7 +15,7 @@ from server.runtime import ensure_supported_python
 
 ensure_supported_python()
 
-from fastapi import FastAPI
+from fastapi import APIRouter, FastAPI
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
@@ -120,10 +120,13 @@ app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
 from server.routers import export, health, query, schema  # noqa: E402
 
+v1_router = APIRouter(prefix="/api/v1")
+v1_router.include_router(export.router)
+v1_router.include_router(query.router, prefix="/datasets/{dataset_id}")
+v1_router.include_router(schema.router, prefix="/datasets/{dataset_id}")
+
 app.include_router(health.router)
-app.include_router(export.router, prefix="/api/v1", include_in_schema=True)
-app.include_router(query.router, prefix="/api/v1/datasets/{dataset_id}", include_in_schema=True)
-app.include_router(schema.router, prefix="/api/v1/datasets/{dataset_id}", include_in_schema=True)
+app.include_router(v1_router)
 
 
 @app.get("/api/v1", include_in_schema=False)

--- a/server/main.py
+++ b/server/main.py
@@ -5,6 +5,7 @@ FastAPI application with health endpoints, config loader, and structured logging
 """
 # ruff: noqa: E402
 
+import os
 import asyncio
 import logging
 from contextlib import asynccontextmanager
@@ -36,6 +37,7 @@ from server.prewarm import prewarm_dim_fields
 from server.query_budget import get_query_budget
 from server.rate_limit import limiter
 from server.request_context import get_request_id
+from server.routers.health import mark_startup_complete, reset_startup_complete
 
 settings = get_settings()
 setup_logging(settings.log_level, settings.log_format)
@@ -46,12 +48,21 @@ logger = logging.getLogger("query_service")
 async def lifespan(app: FastAPI):
     """Initialize engine and export store on startup, cleanly shut them down on exit."""
     logger.info("QueryService starting", extra={"host": settings.host, "port": settings.port})
+    reset_startup_complete()
     db_manager.initialize()
     load_sample_data(db_manager)
 
     # Prewarm dimension cache for configured hot fields (fire-and-forget).
     if getattr(settings, "cache_enabled", False) and getattr(settings, "dim_prewarm_fields", None):
-        asyncio.create_task(prewarm_dim_fields())
+        async def _prewarm_and_mark_ready() -> None:
+            try:
+                await prewarm_dim_fields()
+            finally:
+                mark_startup_complete()
+
+        asyncio.create_task(_prewarm_and_mark_ready())
+    else:
+        mark_startup_complete()
 
     export_store = ExportJobStore(settings.export_db_path)
     export_store.initialize()
@@ -87,8 +98,11 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="QueryService",
     description="Huey OLAP query service for S3-backed parquet datasets. Set X-API-Key header when authentication is enabled.",
-    version="0.1.0",
+    version="1.0.0",
     lifespan=lifespan,
+    openapi_url="/api/v1/openapi.json",
+    docs_url="/api/v1/docs",
+    redoc_url="/api/v1/redoc",
 )
 
 app.add_middleware(AccessLogMiddleware)
@@ -98,7 +112,7 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.cors_origins,
     allow_credentials=True,
-    allow_methods=["GET", "POST"],
+    allow_methods=["GET", "POST", "DELETE"],
     allow_headers=["*"],
 )
 app.state.limiter = limiter
@@ -106,10 +120,30 @@ app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
 from server.routers import export, health, query, schema  # noqa: E402
 
-app.include_router(export.router)
+app.include_router(export.router, include_in_schema=False)
 app.include_router(health.router)
-app.include_router(query.router)
-app.include_router(schema.router)
+app.include_router(query.router, include_in_schema=False)
+app.include_router(schema.router, include_in_schema=False)
+app.include_router(export.router, prefix="/api/v1", include_in_schema=True)
+app.include_router(query.router, prefix="/api/v1/datasets/{dataset_id}", include_in_schema=True)
+app.include_router(schema.router, prefix="/api/v1/datasets/{dataset_id}", include_in_schema=True)
+
+
+@app.get("/api/v1", include_in_schema=False)
+async def api_root() -> dict[str, object]:
+    """Service root for the versioned v1 API."""
+    build = os.getenv("QUERYSERVICE_BUILD", "dev")
+    return {
+        "service": "huey-queryservice",
+        "api_version": "1",
+        "build": build,
+        "links": {
+            "datasets": "/api/v1/datasets",
+            "exports": "/api/v1/export",
+            "openapi": "/api/v1/openapi.json",
+            "docs": "/api/v1/docs",
+        },
+    }
 
 
 @app.exception_handler(AppError)

--- a/server/main.py
+++ b/server/main.py
@@ -135,7 +135,6 @@ async def api_root() -> dict[str, object]:
         "api_version": "1",
         "build": build,
         "links": {
-            "datasets": "/api/v1/datasets",
             "exports": "/api/v1/exports",
             "openapi": "/api/v1/openapi.json",
             "docs": "/api/v1/docs",

--- a/server/main.py
+++ b/server/main.py
@@ -5,9 +5,9 @@ FastAPI application with health endpoints, config loader, and structured logging
 """
 # ruff: noqa: E402
 
-import os
 import asyncio
 import logging
+import os
 from contextlib import asynccontextmanager
 
 # Fail fast with a clear message before importing modules that require modern syntax.
@@ -120,10 +120,7 @@ app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
 from server.routers import export, health, query, schema  # noqa: E402
 
-app.include_router(export.router, include_in_schema=False)
 app.include_router(health.router)
-app.include_router(query.router, include_in_schema=False)
-app.include_router(schema.router, include_in_schema=False)
 app.include_router(export.router, prefix="/api/v1", include_in_schema=True)
 app.include_router(query.router, prefix="/api/v1/datasets/{dataset_id}", include_in_schema=True)
 app.include_router(schema.router, prefix="/api/v1/datasets/{dataset_id}", include_in_schema=True)

--- a/server/models.py
+++ b/server/models.py
@@ -242,7 +242,7 @@ class PicklistQueryBody(BaseModel):
 
 
 class ExportQueryBody(BaseModel):
-    """Body for /export, describing export format, filters, and bounds."""
+    """Body for /exports, describing export format, filters, and bounds."""
 
     export_type: str | None = None
     axes: AxesSpec | None = None
@@ -280,7 +280,7 @@ class QueryPicklistRequest(BaseModel):
 
 
 class ExportRequest(BaseModel):
-    """POST /export body (envelope)."""
+    """POST /exports body (envelope)."""
 
     dataset_id: str
     date_range: DateRange

--- a/server/models.py
+++ b/server/models.py
@@ -242,7 +242,7 @@ class PicklistQueryBody(BaseModel):
 
 
 class ExportQueryBody(BaseModel):
-    """Body for /exports, describing export format, filters, and bounds."""
+    """Body for POST /api/v1/exports."""
 
     export_type: str | None = None
     axes: AxesSpec | None = None
@@ -280,7 +280,7 @@ class QueryPicklistRequest(BaseModel):
 
 
 class ExportRequest(BaseModel):
-    """POST /exports body (envelope)."""
+    """Request body for POST /api/v1/exports."""
 
     dataset_id: str
     date_range: DateRange

--- a/server/models.py
+++ b/server/models.py
@@ -215,7 +215,7 @@ class AxesSpec(BaseModel):
 
 # --- Typed query bodies ---
 class TuplesQueryBody(BaseModel):
-    """Body for /query/tuples supporting optional fields, filters, and paging."""
+    """Body for /api/v1/datasets/{dataset_id}/query/tuples."""
 
     axis: str | None = None  # reserved: tech spec multi-axis support
     fields: list[TupleFieldSpec] | None = None
@@ -224,7 +224,7 @@ class TuplesQueryBody(BaseModel):
 
 
 class CellsQueryBody(BaseModel):
-    """Body for /query/cells, driving aggregation axes and filters."""
+    """Body for /api/v1/datasets/{dataset_id}/query/cells."""
 
     rows: WindowSpec | None = None  # virtualized row window (start/count)
     columns: WindowSpec | None = None  # virtualized column window (start/count)
@@ -233,7 +233,7 @@ class CellsQueryBody(BaseModel):
 
 
 class PicklistQueryBody(BaseModel):
-    """Body for /query/picklist, selecting a field and optional search/paging."""
+    """Body for /api/v1/datasets/{dataset_id}/query/picklist."""
 
     field: str | None = None
     search: str | None = ""
@@ -253,7 +253,7 @@ class ExportQueryBody(BaseModel):
 
 # --- Request models ---
 class QueryTuplesRequest(BaseModel):
-    """POST /query/tuples body (envelope)."""
+    """POST /api/v1/datasets/{dataset_id}/query/tuples body."""
 
     dataset_id: str
     date_range: DateRange
@@ -262,7 +262,7 @@ class QueryTuplesRequest(BaseModel):
 
 
 class QueryCellsRequest(BaseModel):
-    """POST /query/cells body (envelope)."""
+    """POST /api/v1/datasets/{dataset_id}/query/cells body."""
 
     dataset_id: str
     date_range: DateRange
@@ -271,7 +271,7 @@ class QueryCellsRequest(BaseModel):
 
 
 class QueryPicklistRequest(BaseModel):
-    """POST /query/picklist body (envelope)."""
+    """POST /api/v1/datasets/{dataset_id}/query/picklist body."""
 
     dataset_id: str
     date_range: DateRange
@@ -290,14 +290,14 @@ class ExportRequest(BaseModel):
 
 # --- Response models ---
 class TupleItem(BaseModel):
-    """Single tuple row returned by /query/tuples."""
+    """Single tuple row returned by the v1 tuples endpoint."""
 
     values: list[Any]
     grouping_id: int | None = None  # reserved: tech spec grouping sets
 
 
 class TuplesResponse(BaseModel):
-    """Response envelope for /query/tuples including paging metadata."""
+    """Response envelope for the v1 tuples endpoint."""
 
     total_count: int
     items: list[TupleItem]
@@ -305,13 +305,13 @@ class TuplesResponse(BaseModel):
 
 
 class CellsResponse(BaseModel):
-    """Response envelope for /query/cells."""
+    """Response envelope for the v1 cells endpoint."""
 
     cells: list[dict[str, Any]]
 
 
 class PicklistResponse(BaseModel):
-    """Response envelope for /query/picklist including paging metadata."""
+    """Response envelope for the v1 picklist endpoint."""
 
     total_count: int
     values: list[dict[str, str]]

--- a/server/routers/export.py
+++ b/server/routers/export.py
@@ -1,5 +1,5 @@
 """
-Export endpoint: POST /export, GET /export/{id}, GET /export/{id}/download.
+Export endpoints: POST /exports, GET /exports/{id}, GET /exports/{id}/download.
 
 Delegates to ExportService for durable job management backed by SQLite.
 Background processing is dispatched via FastAPI BackgroundTasks.
@@ -24,7 +24,7 @@ from server.request_context import set_request_id
 
 logger = logging.getLogger("query_service.export")
 
-router = APIRouter(prefix="/export", tags=["export"])
+router = APIRouter(prefix="/exports", tags=["export"])
 
 
 @router.post("", response_model=ExportResponse)
@@ -36,7 +36,7 @@ async def post_export(
     background_tasks: BackgroundTasks,
     _api_key: str = Depends(require_api_key),
 ) -> ExportResponse:
-    """POST /export: submit export job with background processing."""
+    """POST /exports: submit export job with background processing."""
     if body.client_context and body.client_context.request_id:
         rid = body.client_context.request_id
         set_request_id(rid)
@@ -56,7 +56,7 @@ async def post_export(
 
 @router.get("/{export_id}", response_model=ExportStatusResponse)
 async def get_export_status(export_id: str, _api_key: str = Depends(require_api_key)) -> ExportStatusResponse:
-    """GET /export/{id}: return export job status (and download_url when complete)."""
+    """GET /exports/{id}: return export job status (and download_url when complete)."""
     service = get_export_service()
     job = service.get_status(export_id)
     return ExportStatusResponse(
@@ -69,7 +69,7 @@ async def get_export_status(export_id: str, _api_key: str = Depends(require_api_
 
 @router.get("/{export_id}/download")
 async def download_export(export_id: str, _api_key: str = Depends(require_api_key)) -> FileResponse:
-    """GET /export/{id}/download: download the completed export file."""
+    """GET /exports/{id}/download: download the completed export file."""
     service = get_export_service()
     file_path = service.get_download_path(export_id)
     suffix = Path(file_path).suffix.lower()

--- a/server/routers/export.py
+++ b/server/routers/export.py
@@ -1,5 +1,5 @@
 """
-Export endpoints: POST /exports, GET /exports/{id}, GET /exports/{id}/download.
+Export endpoints under /api/v1/exports.
 
 Delegates to ExportService for durable job management backed by SQLite.
 Background processing is dispatched via FastAPI BackgroundTasks.
@@ -36,7 +36,7 @@ async def post_export(
     background_tasks: BackgroundTasks,
     _api_key: str = Depends(require_api_key),
 ) -> ExportResponse:
-    """POST /exports: submit export job with background processing."""
+    """POST /api/v1/exports."""
     if body.client_context and body.client_context.request_id:
         rid = body.client_context.request_id
         set_request_id(rid)
@@ -56,7 +56,7 @@ async def post_export(
 
 @router.get("/{export_id}", response_model=ExportStatusResponse)
 async def get_export_status(export_id: str, _api_key: str = Depends(require_api_key)) -> ExportStatusResponse:
-    """GET /exports/{id}: return export job status (and download_url when complete)."""
+    """GET /api/v1/exports/{export_id}."""
     service = get_export_service()
     job = service.get_status(export_id)
     return ExportStatusResponse(
@@ -69,7 +69,7 @@ async def get_export_status(export_id: str, _api_key: str = Depends(require_api_
 
 @router.get("/{export_id}/download")
 async def download_export(export_id: str, _api_key: str = Depends(require_api_key)) -> FileResponse:
-    """GET /exports/{id}/download: download the completed export file."""
+    """GET /api/v1/exports/{export_id}/download."""
     service = get_export_service()
     file_path = service.get_download_path(export_id)
     suffix = Path(file_path).suffix.lower()

--- a/server/routers/health.py
+++ b/server/routers/health.py
@@ -6,12 +6,25 @@ Health check endpoints for QueryService.
 - /health/ready: alias for /health/readiness (Docker HEALTHCHECK, K8s, etc.).
 """
 
+import asyncio
+
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 
 from server.engine import db_manager
 
 router = APIRouter(prefix="/health", tags=["health"])
+startup_complete_event = asyncio.Event()
+
+
+def mark_startup_complete() -> None:
+    """Mark startup prewarm state as complete."""
+    startup_complete_event.set()
+
+
+def reset_startup_complete() -> None:
+    """Reset startup prewarm state."""
+    startup_complete_event.clear()
 
 
 @router.get("/liveness")
@@ -32,3 +45,11 @@ async def readiness() -> JSONResponse:
 async def ready() -> JSONResponse:
     """Alias for /health/readiness (e.g. Docker HEALTHCHECK, Kubernetes)."""
     return await readiness()
+
+
+@router.get("/startup")
+async def startup() -> JSONResponse:
+    """Startup probe: 200 when prewarm is complete, 503 otherwise."""
+    if startup_complete_event.is_set():
+        return JSONResponse(status_code=200, content={"status": "ok"})
+    return JSONResponse(status_code=503, content={"status": "starting"})

--- a/server/routers/query.py
+++ b/server/routers/query.py
@@ -44,6 +44,12 @@ def _resolve_dataset_id(path_dataset_id: str | None, body_dataset_id: str) -> st
     return path_dataset_id or body_dataset_id
 
 
+def _get_path_dataset_id(request: Request) -> str | None:
+    """Return the dataset id from the versioned path when present."""
+    value = request.path_params.get("dataset_id")
+    return value if isinstance(value, str) and value else None
+
+
 def _apply_client_request_id(body, request: Request) -> None:
     """Override correlation ID with client_context.request_id when provided."""
     if body.client_context and body.client_context.request_id:
@@ -79,12 +85,12 @@ async def post_query_tuples(
     request: Request,
     body: QueryTuplesRequest,
     response: Response,
-    dataset_id: str | None = None,
     _api_key: str = Depends(require_api_key),
 ) -> TuplesResponse:
     """POST /query/tuples: fetch distinct dimension values for one axis."""
     _apply_client_request_id(body, request)
-    dataset_id = _resolve_dataset_id(dataset_id, body.dataset_id)
+    dataset_id = _resolve_dataset_id(_get_path_dataset_id(request), body.dataset_id)
+    body.dataset_id = dataset_id
     settings = get_settings()
     if datasets.get_schema(dataset_id) is None:
         raise DatasetNotFoundError(dataset_id)
@@ -196,12 +202,12 @@ async def post_query_cells(
     request: Request,
     body: QueryCellsRequest,
     response: Response,
-    dataset_id: str | None = None,
     _api_key: str = Depends(require_api_key),
 ) -> CellsResponse:
     """POST /query/cells: fetch aggregated cell values grouped by dimensions."""
     _apply_client_request_id(body, request)
-    dataset_id = _resolve_dataset_id(dataset_id, body.dataset_id)
+    dataset_id = _resolve_dataset_id(_get_path_dataset_id(request), body.dataset_id)
+    body.dataset_id = dataset_id
     settings = get_settings()
     if datasets.get_schema(dataset_id) is None:
         raise DatasetNotFoundError(dataset_id)
@@ -343,12 +349,12 @@ async def post_query_picklist(
     request: Request,
     body: QueryPicklistRequest,
     response: Response,
-    dataset_id: str | None = None,
     _api_key: str = Depends(require_api_key),
 ) -> PicklistResponse:
     """POST /query/picklist: fetch distinct values for a field (filter UI)."""
     _apply_client_request_id(body, request)
-    dataset_id = _resolve_dataset_id(dataset_id, body.dataset_id)
+    dataset_id = _resolve_dataset_id(_get_path_dataset_id(request), body.dataset_id)
+    body.dataset_id = dataset_id
     settings = get_settings()
     if datasets.get_schema(dataset_id) is None:
         raise DatasetNotFoundError(dataset_id)

--- a/server/routers/query.py
+++ b/server/routers/query.py
@@ -1,5 +1,5 @@
 """
-Query endpoints: /query/tuples, /query/cells, /query/picklist (tech spec).
+Query endpoints under /api/v1/datasets/{dataset_id}/query/*.
 """
 
 import logging
@@ -39,15 +39,12 @@ logger = logging.getLogger("query_service.query")
 router = APIRouter(prefix="/query", tags=["query"])
 
 
-def _resolve_dataset_id(path_dataset_id: str | None, body_dataset_id: str) -> str:
-    """Prefer the versioned path dataset id when present."""
-    return path_dataset_id or body_dataset_id
-
-
-def _get_path_dataset_id(request: Request) -> str | None:
-    """Return the dataset id from the versioned path when present."""
+def _path_dataset_id(request: Request) -> str:
+    """Return the required dataset id from the v1 route path."""
     value = request.path_params.get("dataset_id")
-    return value if isinstance(value, str) and value else None
+    if isinstance(value, str) and value:
+        return value
+    raise RuntimeError("v1 query routes require a dataset_id path parameter")
 
 
 def _apply_client_request_id(body, request: Request) -> None:
@@ -87,9 +84,9 @@ async def post_query_tuples(
     response: Response,
     _api_key: str = Depends(require_api_key),
 ) -> TuplesResponse:
-    """POST /query/tuples: fetch distinct dimension values for one axis."""
+    """POST /api/v1/datasets/{dataset_id}/query/tuples."""
     _apply_client_request_id(body, request)
-    dataset_id = _resolve_dataset_id(_get_path_dataset_id(request), body.dataset_id)
+    dataset_id = _path_dataset_id(request)
     body.dataset_id = dataset_id
     settings = get_settings()
     if datasets.get_schema(dataset_id) is None:
@@ -204,9 +201,9 @@ async def post_query_cells(
     response: Response,
     _api_key: str = Depends(require_api_key),
 ) -> CellsResponse:
-    """POST /query/cells: fetch aggregated cell values grouped by dimensions."""
+    """POST /api/v1/datasets/{dataset_id}/query/cells."""
     _apply_client_request_id(body, request)
-    dataset_id = _resolve_dataset_id(_get_path_dataset_id(request), body.dataset_id)
+    dataset_id = _path_dataset_id(request)
     body.dataset_id = dataset_id
     settings = get_settings()
     if datasets.get_schema(dataset_id) is None:
@@ -351,9 +348,9 @@ async def post_query_picklist(
     response: Response,
     _api_key: str = Depends(require_api_key),
 ) -> PicklistResponse:
-    """POST /query/picklist: fetch distinct values for a field (filter UI)."""
+    """POST /api/v1/datasets/{dataset_id}/query/picklist."""
     _apply_client_request_id(body, request)
-    dataset_id = _resolve_dataset_id(_get_path_dataset_id(request), body.dataset_id)
+    dataset_id = _path_dataset_id(request)
     body.dataset_id = dataset_id
     settings = get_settings()
     if datasets.get_schema(dataset_id) is None:

--- a/server/routers/query.py
+++ b/server/routers/query.py
@@ -12,7 +12,7 @@ from server.auth import require_api_key
 from server.cache import build_cache_key, get_query_cache
 from server.config import get_settings
 from server.engine import QueryCancelHandle, db_manager
-from server.errors import CellsWindowTooLargeError, DatasetNotFoundError
+from server.errors import CellsWindowTooLargeError, DatasetNotFoundError, ValidationAppError
 from server.models import (
     CellsResponse,
     PagingResponse,
@@ -45,6 +45,26 @@ def _path_dataset_id(request: Request) -> str:
     if isinstance(value, str) and value:
         return value
     raise RuntimeError("v1 query routes require a dataset_id path parameter")
+
+
+def _canonical_dataset_id(request: Request, body_dataset_id: str) -> str:
+    """Require the request body dataset id to match the v1 path dataset id."""
+    path_dataset_id = _path_dataset_id(request)
+    if body_dataset_id != path_dataset_id:
+        raise ValidationAppError(
+            [
+                {
+                    "loc": ["body", "dataset_id"],
+                    "msg": "dataset_id must match the dataset_id path parameter",
+                    "type": "value_error.dataset_id_mismatch",
+                    "ctx": {
+                        "path_dataset_id": path_dataset_id,
+                        "body_dataset_id": body_dataset_id,
+                    },
+                }
+            ]
+        )
+    return path_dataset_id
 
 
 def _apply_client_request_id(body, request: Request) -> None:
@@ -86,7 +106,7 @@ async def post_query_tuples(
 ) -> TuplesResponse:
     """POST /api/v1/datasets/{dataset_id}/query/tuples."""
     _apply_client_request_id(body, request)
-    dataset_id = _path_dataset_id(request)
+    dataset_id = _canonical_dataset_id(request, body.dataset_id)
     body.dataset_id = dataset_id
     settings = get_settings()
     if datasets.get_schema(dataset_id) is None:
@@ -203,7 +223,7 @@ async def post_query_cells(
 ) -> CellsResponse:
     """POST /api/v1/datasets/{dataset_id}/query/cells."""
     _apply_client_request_id(body, request)
-    dataset_id = _path_dataset_id(request)
+    dataset_id = _canonical_dataset_id(request, body.dataset_id)
     body.dataset_id = dataset_id
     settings = get_settings()
     if datasets.get_schema(dataset_id) is None:
@@ -350,7 +370,7 @@ async def post_query_picklist(
 ) -> PicklistResponse:
     """POST /api/v1/datasets/{dataset_id}/query/picklist."""
     _apply_client_request_id(body, request)
-    dataset_id = _path_dataset_id(request)
+    dataset_id = _canonical_dataset_id(request, body.dataset_id)
     body.dataset_id = dataset_id
     settings = get_settings()
     if datasets.get_schema(dataset_id) is None:

--- a/server/routers/query.py
+++ b/server/routers/query.py
@@ -39,6 +39,11 @@ logger = logging.getLogger("query_service.query")
 router = APIRouter(prefix="/query", tags=["query"])
 
 
+def _resolve_dataset_id(path_dataset_id: str | None, body_dataset_id: str) -> str:
+    """Prefer the versioned path dataset id when present."""
+    return path_dataset_id or body_dataset_id
+
+
 def _apply_client_request_id(body, request: Request) -> None:
     """Override correlation ID with client_context.request_id when provided."""
     if body.client_context and body.client_context.request_id:
@@ -74,15 +79,17 @@ async def post_query_tuples(
     request: Request,
     body: QueryTuplesRequest,
     response: Response,
+    dataset_id: str | None = None,
     _api_key: str = Depends(require_api_key),
 ) -> TuplesResponse:
     """POST /query/tuples: fetch distinct dimension values for one axis."""
     _apply_client_request_id(body, request)
+    dataset_id = _resolve_dataset_id(dataset_id, body.dataset_id)
     settings = get_settings()
-    if datasets.get_schema(body.dataset_id) is None:
-        raise DatasetNotFoundError(body.dataset_id)
+    if datasets.get_schema(dataset_id) is None:
+        raise DatasetNotFoundError(dataset_id)
 
-    schema_fields = datasets.get_schema_field_names(body.dataset_id)
+    schema_fields = datasets.get_schema_field_names(dataset_id)
     paging = body.query.paging or PagingSpec(limit=settings.tuples_default_limit, offset=0)
 
     cache_status = "disabled"
@@ -92,13 +99,13 @@ async def post_query_tuples(
 
     async def _execute() -> dict[str, object]:
         start = time.perf_counter()
-        sql, params = build_tuples_sql(body.dataset_id, body.query, body.date_range, schema_fields)
+        sql, params = build_tuples_sql(dataset_id, body.query, body.date_range, schema_fields)
 
         async def _run_query():
             return await db_manager.execute_sql_async(
                 sql,
                 tuple(params) if params else None,
-                dataset_id=body.dataset_id,
+                dataset_id=dataset_id,
                 cancel_handle=cancel_handle,
             )
 
@@ -111,12 +118,12 @@ async def post_query_tuples(
             items = []
 
         if total_count == 0 and paging.offset > 0:
-            count_sql, count_params = build_tuples_count_sql(body.dataset_id, body.query, body.date_range, schema_fields)
+            count_sql, count_params = build_tuples_count_sql(dataset_id, body.query, body.date_range, schema_fields)
             count_cancel_handle = QueryCancelHandle()
             count_rows = await db_manager.execute_sql_async(
                 count_sql,
                 tuple(count_params) if count_params else None,
-                dataset_id=body.dataset_id,
+                dataset_id=dataset_id,
                 cancel_handle=count_cancel_handle,
             )
             if count_rows:
@@ -137,10 +144,10 @@ async def post_query_tuples(
 
     if getattr(settings, "cache_enabled", False):
         cache = await get_query_cache()
-        data_version_token = datasets.get_data_version_token(body.dataset_id, body.date_range)
+        data_version_token = datasets.get_data_version_token(dataset_id, body.date_range)
         cache_key = build_cache_key(
             "tuples",
-            body.dataset_id,
+            dataset_id,
             body.date_range.model_dump(),
             body.query.model_dump(),
             fact_version_token=data_version_token,
@@ -158,11 +165,11 @@ async def post_query_tuples(
         result = await _execute()
 
     resp_body = result["response"]
-    time_filter_applied, time_filter_column = _time_filter_metadata(body.dataset_id)
+    time_filter_applied, time_filter_column = _time_filter_metadata(dataset_id)
     logger.info(
         "tuples query executed",
         extra={
-            "dataset_id": body.dataset_id,
+            "dataset_id": dataset_id,
             "endpoint": "tuples",
             "duration_ms": round(result.get("duration_ms", 0.0), 2),
             "row_count": result.get("row_count", 0),
@@ -189,15 +196,17 @@ async def post_query_cells(
     request: Request,
     body: QueryCellsRequest,
     response: Response,
+    dataset_id: str | None = None,
     _api_key: str = Depends(require_api_key),
 ) -> CellsResponse:
     """POST /query/cells: fetch aggregated cell values grouped by dimensions."""
     _apply_client_request_id(body, request)
+    dataset_id = _resolve_dataset_id(dataset_id, body.dataset_id)
     settings = get_settings()
-    if datasets.get_schema(body.dataset_id) is None:
-        raise DatasetNotFoundError(body.dataset_id)
+    if datasets.get_schema(dataset_id) is None:
+        raise DatasetNotFoundError(dataset_id)
 
-    schema_fields = datasets.get_schema_field_names(body.dataset_id)
+    schema_fields = datasets.get_schema_field_names(dataset_id)
     row_window = body.query.rows
     col_window = body.query.columns
 
@@ -243,14 +252,14 @@ async def post_query_cells(
         start = time.perf_counter()
         effective_max = settings.max_cells_per_response
         sql, params = build_cells_sql(
-            body.dataset_id, body.query, body.date_range, schema_fields, max_cells=effective_max + 1
+            dataset_id, body.query, body.date_range, schema_fields, max_cells=effective_max + 1
         )
 
         async def _run_query():
             return await db_manager.execute_sql_async(
                 sql,
                 tuple(params) if params else None,
-                dataset_id=body.dataset_id,
+                dataset_id=dataset_id,
                 cancel_handle=cancel_handle,
             )
 
@@ -286,10 +295,10 @@ async def post_query_cells(
 
     if getattr(settings, "cache_enabled", False):
         cache = await get_query_cache()
-        data_version_token = datasets.get_data_version_token(body.dataset_id, body.date_range)
+        data_version_token = datasets.get_data_version_token(dataset_id, body.date_range)
         cache_key = build_cache_key(
             "cells",
-            body.dataset_id,
+            dataset_id,
             body.date_range.model_dump(),
             body.query.model_dump(),
             fact_version_token=data_version_token,
@@ -308,11 +317,11 @@ async def post_query_cells(
     else:
         result = await _execute()
 
-    time_filter_applied, time_filter_column = _time_filter_metadata(body.dataset_id)
+    time_filter_applied, time_filter_column = _time_filter_metadata(dataset_id)
     logger.info(
         "cells query executed",
         extra={
-            "dataset_id": body.dataset_id,
+            "dataset_id": dataset_id,
             "endpoint": "cells",
             "duration_ms": round(result.get("duration_ms", 0.0), 2),
             "row_count": result.get("row_count", 0),
@@ -334,15 +343,17 @@ async def post_query_picklist(
     request: Request,
     body: QueryPicklistRequest,
     response: Response,
+    dataset_id: str | None = None,
     _api_key: str = Depends(require_api_key),
 ) -> PicklistResponse:
     """POST /query/picklist: fetch distinct values for a field (filter UI)."""
     _apply_client_request_id(body, request)
+    dataset_id = _resolve_dataset_id(dataset_id, body.dataset_id)
     settings = get_settings()
-    if datasets.get_schema(body.dataset_id) is None:
-        raise DatasetNotFoundError(body.dataset_id)
+    if datasets.get_schema(dataset_id) is None:
+        raise DatasetNotFoundError(dataset_id)
 
-    schema_fields = datasets.get_schema_field_names(body.dataset_id)
+    schema_fields = datasets.get_schema_field_names(dataset_id)
     paging = body.query.paging or PagingSpec(limit=settings.picklist_default_limit, offset=0)
 
     cache_status = "disabled"
@@ -353,13 +364,13 @@ async def post_query_picklist(
 
     async def _execute() -> dict[str, object]:
         start = time.perf_counter()
-        sql, params = build_picklist_sql(body.dataset_id, body.query, body.date_range, schema_fields)
+        sql, params = build_picklist_sql(dataset_id, body.query, body.date_range, schema_fields)
 
         async def _run_query():
             return await db_manager.execute_sql_async(
                 sql,
                 tuple(params) if params else None,
-                dataset_id=body.dataset_id,
+                dataset_id=dataset_id,
                 cancel_handle=cancel_handle,
             )
 
@@ -372,12 +383,12 @@ async def post_query_picklist(
             values = []
 
         if total_count == 0 and paging.offset > 0:
-            count_sql, count_params = build_picklist_count_sql(body.dataset_id, body.query, body.date_range, schema_fields)
+            count_sql, count_params = build_picklist_count_sql(dataset_id, body.query, body.date_range, schema_fields)
             count_cancel_handle = QueryCancelHandle()
             count_rows = await db_manager.execute_sql_async(
                 count_sql,
                 tuple(count_params) if count_params else None,
-                dataset_id=body.dataset_id,
+                dataset_id=dataset_id,
                 cancel_handle=count_cancel_handle,
             )
             if count_rows:
@@ -398,10 +409,10 @@ async def post_query_picklist(
 
     if getattr(settings, "cache_enabled", False):
         cache = await get_query_cache()
-        dim_version_token = datasets.get_dim_version_token(body.dataset_id)
+        dim_version_token = datasets.get_dim_version_token(dataset_id)
         cache_key = build_cache_key(
             "picklist",
-            body.dataset_id,
+            dataset_id,
             body.date_range.model_dump(),
             body.query.model_dump(),
             dim_version_token=dim_version_token,
@@ -420,11 +431,11 @@ async def post_query_picklist(
         result = await _execute()
 
     resp_body = result["response"]
-    time_filter_applied, time_filter_column = _time_filter_metadata(body.dataset_id)
+    time_filter_applied, time_filter_column = _time_filter_metadata(dataset_id)
     logger.info(
         "picklist query executed",
         extra={
-            "dataset_id": body.dataset_id,
+            "dataset_id": dataset_id,
             "endpoint": "picklist",
             "duration_ms": round(result.get("duration_ms", 0.0), 2),
             "row_count": result.get("row_count", 0),

--- a/server/routers/schema.py
+++ b/server/routers/schema.py
@@ -1,5 +1,5 @@
 """
-Schema endpoint: GET /schema per tech spec.
+Schema endpoint under /api/v1/datasets/{dataset_id}/schema.
 """
 
 from fastapi import APIRouter, Depends
@@ -15,7 +15,7 @@ router = APIRouter(tags=["schema"])
 async def get_schema(dataset_id: str, _api_key: str = Depends(require_api_key)) -> dict:
     """
     Fetch schema metadata for a dataset.
-    GET /schema?dataset_id=trades_v1
+    GET /api/v1/datasets/{dataset_id}/schema
     """
     schema = datasets.get_schema(dataset_id)
     if schema is None:

--- a/server/tests/test_api_v1_routing.py
+++ b/server/tests/test_api_v1_routing.py
@@ -1,0 +1,61 @@
+"""Tests for v1 routing infrastructure and startup probe."""
+
+from fastapi.testclient import TestClient
+
+from server.routers import health
+
+
+def test_api_v1_root(client: TestClient) -> None:
+    r = client.get("/api/v1")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["service"] == "huey-queryservice"
+    assert data["api_version"] == "1"
+    assert data["links"]["datasets"] == "/api/v1/datasets"
+    assert data["links"]["openapi"] == "/api/v1/openapi.json"
+
+
+def test_api_v1_openapi_and_docs(client: TestClient) -> None:
+    openapi = client.get("/api/v1/openapi.json")
+    docs = client.get("/api/v1/docs")
+    redoc = client.get("/api/v1/redoc")
+
+    assert openapi.status_code == 200
+    assert docs.status_code == 200
+    assert redoc.status_code == 200
+    assert openapi.json()["info"]["version"] == "1.0.0"
+
+
+def test_health_startup_probe(client: TestClient) -> None:
+    health.reset_startup_complete()
+    try:
+        r_starting = client.get("/health/startup")
+        assert r_starting.status_code == 503
+        assert r_starting.json() == {"status": "starting"}
+
+        health.mark_startup_complete()
+        r_ready = client.get("/health/startup")
+        assert r_ready.status_code == 200
+        assert r_ready.json() == {"status": "ok"}
+    finally:
+        health.mark_startup_complete()
+
+
+def test_versioned_schema_route(client: TestClient) -> None:
+    r = client.get("/api/v1/datasets/trades_v1/schema")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["dataset_id"] == "trades_v1"
+
+
+def test_versioned_query_route_alias(client: TestClient) -> None:
+    body = {
+        "dataset_id": "trades_v1",
+        "date_range": {"type": "single", "date": "2026-03-01"},
+        "query": {"fields": [{"field": "symbol"}], "paging": {"limit": 10, "offset": 0}},
+    }
+    r = client.post("/api/v1/datasets/trades_v1/query/tuples", json=body)
+    assert r.status_code == 200
+    data = r.json()
+    assert data["total_count"] > 0
+    assert len(data["items"]) > 0

--- a/server/tests/test_api_v1_routing.py
+++ b/server/tests/test_api_v1_routing.py
@@ -11,7 +11,7 @@ def test_api_v1_root(client: TestClient) -> None:
     data = r.json()
     assert data["service"] == "huey-queryservice"
     assert data["api_version"] == "1"
-    assert data["links"]["datasets"] == "/api/v1/datasets"
+    assert "datasets" not in data["links"]
     assert data["links"]["openapi"] == "/api/v1/openapi.json"
 
 

--- a/server/tests/test_auth.py
+++ b/server/tests/test_auth.py
@@ -8,23 +8,23 @@ INVALID_KEY = "wrong-key"
 
 # (method, path, minimal_body) for every protected endpoint
 _PROTECTED_ENDPOINTS = [
-    ("GET", "/schema", None, {"dataset_id": "trades_v1"}),
-    ("POST", "/query/tuples", {
+    ("GET", "/api/v1/datasets/trades_v1/schema", None, {"dataset_id": "trades_v1"}),
+    ("POST", "/api/v1/datasets/trades_v1/query/tuples", {
         "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
         "query": {"axes": {"rows": [{"field": "symbol"}], "columns": [], "measures": []}},
     }, {}),
-    ("POST", "/query/cells", {
+    ("POST", "/api/v1/datasets/trades_v1/query/cells", {
         "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
         "query": {"axes": {"rows": [{"field": "symbol"}], "columns": [], "measures": [{"field": "volume", "aggregation": "SUM", "alias": "v"}]}},
     }, {}),
-    ("POST", "/query/picklist", {
+    ("POST", "/api/v1/datasets/trades_v1/query/picklist", {
         "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
         "field": "symbol",
     }, {}),
-    ("POST", "/export", {
+    ("POST", "/api/v1/exports", {
         "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
         "query": {
@@ -35,8 +35,8 @@ _PROTECTED_ENDPOINTS = [
             "format": "csv",
         },
     }, {}),
-    ("GET", "/export/nonexistent", None, {}),
-    ("GET", "/export/nonexistent/download", None, {}),
+    ("GET", "/api/v1/exports/nonexistent", None, {}),
+    ("GET", "/api/v1/exports/nonexistent/download", None, {}),
 ]
 
 
@@ -66,7 +66,7 @@ def test_invalid_key_returns_401_envelope(auth_client: TestClient, method, path,
 
 
 def test_valid_key_schema_returns_200(auth_client: TestClient):
-    r = auth_client.get("/schema", params={"dataset_id": "trades_v1"}, headers={"X-API-Key": VALID_KEY})
+    r = auth_client.get("/api/v1/datasets/trades_v1/schema", params={"dataset_id": "trades_v1"}, headers={"X-API-Key": VALID_KEY})
     assert r.status_code == 200
 
 

--- a/server/tests/test_auth.py
+++ b/server/tests/test_auth.py
@@ -8,7 +8,7 @@ INVALID_KEY = "wrong-key"
 
 # (method, path, minimal_body) for every protected endpoint
 _PROTECTED_ENDPOINTS = [
-    ("GET", "/api/v1/datasets/trades_v1/schema", None, {"dataset_id": "trades_v1"}),
+    ("GET", "/api/v1/datasets/trades_v1/schema", None, {}),
     ("POST", "/api/v1/datasets/trades_v1/query/tuples", {
         "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
@@ -66,7 +66,7 @@ def test_invalid_key_returns_401_envelope(auth_client: TestClient, method, path,
 
 
 def test_valid_key_schema_returns_200(auth_client: TestClient):
-    r = auth_client.get("/api/v1/datasets/trades_v1/schema", params={"dataset_id": "trades_v1"}, headers={"X-API-Key": VALID_KEY})
+    r = auth_client.get("/api/v1/datasets/trades_v1/schema", headers={"X-API-Key": VALID_KEY})
     assert r.status_code == 200
 
 

--- a/server/tests/test_correlation.py
+++ b/server/tests/test_correlation.py
@@ -59,7 +59,8 @@ class TestCorrelationIdMiddleware:
         assert r1.headers["X-Request-ID"] != r2.headers["X-Request-ID"]
 
     def test_post_endpoint_gets_correlation_id(self, client: TestClient) -> None:
-        r = client.post("/query/tuples", json=_query_body())
+        body = _query_body()
+        r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
         assert "X-Request-ID" in r.headers
         assert len(r.headers["X-Request-ID"]) > 0
 
@@ -67,7 +68,7 @@ class TestCorrelationIdMiddleware:
 class TestClientContextOverride:
     def test_client_context_request_id_overrides(self, client: TestClient) -> None:
         body = _query_body(client_context={"request_id": "frontend-456"})
-        r = client.post("/query/tuples", json=body)
+        r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
         assert r.headers["X-Request-ID"] == "frontend-456"
 
     def test_client_context_on_cells(self, client: TestClient) -> None:
@@ -82,7 +83,7 @@ class TestClientContextOverride:
             },
             "client_context": {"request_id": "cells-trace-789"},
         }
-        r = client.post("/query/cells", json=body)
+        r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
         assert r.headers["X-Request-ID"] == "cells-trace-789"
 
     def test_client_context_on_picklist(self, client: TestClient) -> None:
@@ -92,7 +93,7 @@ class TestClientContextOverride:
             "query": {"field": "symbol"},
             "client_context": {"request_id": "picklist-trace-abc"},
         }
-        r = client.post("/query/picklist", json=body)
+        r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
         assert r.headers["X-Request-ID"] == "picklist-trace-abc"
 
     def test_client_context_on_export(self, client: TestClient) -> None:
@@ -102,13 +103,13 @@ class TestClientContextOverride:
             "query": {"axes": {}, "format": "csv"},
             "client_context": {"request_id": "export-trace-def"},
         }
-        r = client.post("/export", json=body)
+        r = client.post("/api/v1/exports", json=body)
         assert r.headers["X-Request-ID"] == "export-trace-def"
 
     def test_no_client_context_uses_header(self, client: TestClient) -> None:
         body = _query_body()
         r = client.post(
-            "/query/tuples",
+            f"/api/v1/datasets/{body['dataset_id']}/query/tuples",
             json=body,
             headers={"X-Request-ID": "header-id-999"},
         )
@@ -121,7 +122,7 @@ class TestLoggingIncludesRequestId:
     ) -> None:
         with caplog.at_level(logging.INFO, logger="query_service"):
             client.post(
-                "/query/tuples",
+                "/api/v1/datasets/trades_v1/query/tuples",
                 json=_query_body(client_context={"request_id": "log-check-42"}),
             )
         matching = [r for r in caplog.records if hasattr(r, "request_id")]

--- a/server/tests/test_error_contract.py
+++ b/server/tests/test_error_contract.py
@@ -50,12 +50,28 @@ def _export_body(dataset_id: str = "trades_v1") -> dict:
     }
 
 
+QUERY_ENDPOINTS = ("tuples", "cells", "picklist")
+EXPORTS_ROOT = "/api/v1/exports"
+
+
+def _query_path(endpoint: str, dataset_id: str = "trades_v1") -> str:
+    return f"/api/v1/datasets/{dataset_id}/query/{endpoint}"
+
+
+def _export_status_path(export_id: str) -> str:
+    return f"{EXPORTS_ROOT}/{export_id}"
+
+
+def _export_download_path(export_id: str) -> str:
+    return f"{EXPORTS_ROOT}/{export_id}/download"
+
+
 class TestErrorResponseSchema:
     """Every error response must contain at least 'code' and 'message'."""
 
-    @pytest.mark.parametrize("endpoint", ["/query/tuples", "/query/cells", "/query/picklist"])
+    @pytest.mark.parametrize("endpoint", QUERY_ENDPOINTS)
     def test_query_404_envelope(self, client: TestClient, endpoint: str) -> None:
-        r = client.post(endpoint, json=_query_body(dataset_id="no_such"))
+        r = client.post(_query_path(endpoint, "no_such"), json=_query_body(dataset_id="no_such"))
         assert r.status_code == 404
         body = r.json()
         assert body["code"] == "DATASET_NOT_FOUND"
@@ -64,27 +80,27 @@ class TestErrorResponseSchema:
         assert body["details"]["dataset_id"] == "no_such"
 
     def test_schema_404_envelope(self, client: TestClient) -> None:
-        r = client.get("/schema?dataset_id=no_such")
+        r = client.get("/api/v1/datasets/no_such/schema")
         assert r.status_code == 404
         body = r.json()
         assert body["code"] == "DATASET_NOT_FOUND"
         assert body["details"]["dataset_id"] == "no_such"
 
     def test_export_post_404_envelope(self, client: TestClient) -> None:
-        r = client.post("/export", json=_export_body(dataset_id="no_such"))
+        r = client.post(EXPORTS_ROOT, json=_export_body(dataset_id="no_such"))
         assert r.status_code == 404
         body = r.json()
         assert body["code"] == "DATASET_NOT_FOUND"
 
     def test_export_status_404_envelope(self, client: TestClient) -> None:
-        r = client.get("/export/exp-nonexistent")
+        r = client.get(_export_status_path("exp-nonexistent"))
         assert r.status_code == 404
         body = r.json()
         assert body["code"] == "EXPORT_NOT_FOUND"
         assert body["details"]["export_id"] == "exp-nonexistent"
 
     def test_export_download_404_envelope(self, client: TestClient) -> None:
-        r = client.get("/export/exp-nonexistent/download")
+        r = client.get(_export_download_path("exp-nonexistent"))
         assert r.status_code == 404
         body = r.json()
         assert body["code"] == "EXPORT_NOT_FOUND"
@@ -93,7 +109,7 @@ class TestErrorResponseSchema:
         store = get_export_service().store
         store.create("exp-pending", "trades_v1")
         store.update_status("exp-pending", "processing")
-        r = client.get("/export/exp-pending/download")
+        r = client.get(_export_download_path("exp-pending"))
         assert r.status_code == 409
         body = r.json()
         assert body["code"] == "EXPORT_NOT_READY"
@@ -106,9 +122,9 @@ class TestErrorResponseSchema:
         store.update_status(
             "exp-gone", "complete",
             file_path="/tmp/nonexistent.csv",
-            download_url="/export/exp-gone/download",
+            download_url=_export_download_path("exp-gone"),
         )
-        r = client.get("/export/exp-gone/download")
+        r = client.get(_export_download_path("exp-gone"))
         assert r.status_code == 404
         body = r.json()
         assert body["code"] == "EXPORT_FILE_NOT_FOUND"
@@ -118,13 +134,13 @@ class TestErrorResponseSchema:
         for i in range(5):
             store.create(f"exp-active-{i}", "trades_v1")
             store.update_status(f"exp-active-{i}", "processing")
-        r = client.post("/export", json=_export_body())
+        r = client.post(EXPORTS_ROOT, json=_export_body())
         assert r.status_code == 429
         body = r.json()
         assert body["code"] == "TOO_MANY_EXPORTS"
         assert body["details"]["max_concurrent"] == 5
 
-    @pytest.mark.parametrize("endpoint", ["/query/tuples", "/query/cells", "/query/picklist"])
+    @pytest.mark.parametrize("endpoint", QUERY_ENDPOINTS)
     def test_query_409_dataset_unavailable_envelope(self, client: TestClient, endpoint: str, monkeypatch) -> None:
         import server.routers.query as query_router
 
@@ -150,9 +166,9 @@ class TestErrorResponseSchema:
         monkeypatch.setattr(query_router.db_manager, "execute_sql_async", execute_raise_unavailable)
 
         body = _query_body(dataset_id="not_materialized_ds")
-        if endpoint == "/query/tuples":
+        if endpoint == "tuples":
             body["query"] = {"fields": [{"field": "symbol"}]}
-        elif endpoint == "/query/picklist":
+        elif endpoint == "picklist":
             body["query"] = {"field": "symbol"}
         else:
             body["query"] = {
@@ -163,7 +179,7 @@ class TestErrorResponseSchema:
                 },
             }
 
-        r = client.post(endpoint, json=body)
+        r = client.post(_query_path(endpoint, body["dataset_id"]), json=body)
         assert r.status_code == 409
         payload = r.json()
         assert payload["code"] == "DATASET_UNAVAILABLE"
@@ -182,7 +198,7 @@ class TestErrorResponseSchema:
             lambda dataset_id: {"dataset_id": dataset_id, "fields": [{"name": "symbol"}]},
         )
         monkeypatch.setattr(export_router.db_manager, "table_exists", lambda _dataset_id: False)
-        r = client.post("/export", json=_export_body(dataset_id="not_materialized_ds"))
+        r = client.post(EXPORTS_ROOT, json=_export_body(dataset_id="not_materialized_ds"))
         get_settings.cache_clear()
         assert r.status_code == 409
         payload = r.json()
@@ -194,7 +210,7 @@ class TestValidationErrorEnvelope:
     """422 validation errors wrap Pydantic details in standard envelope."""
 
     def test_missing_required_field(self, client: TestClient) -> None:
-        r = client.post("/query/tuples", json={"query": {}})
+        r = client.post(_query_path("tuples"), json={"query": {}})
         assert r.status_code == 422
         body = r.json()
         assert body["code"] == "VALIDATION_ERROR"
@@ -204,7 +220,7 @@ class TestValidationErrorEnvelope:
         assert len(body["details"]["errors"]) > 0
 
     def test_invalid_date_format(self, client: TestClient) -> None:
-        r = client.post("/query/tuples", json={
+        r = client.post(_query_path("tuples"), json={
             "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "not-a-date"},
         })
@@ -213,7 +229,7 @@ class TestValidationErrorEnvelope:
         assert body["code"] == "VALIDATION_ERROR"
 
     def test_invalid_filter_operator(self, client: TestClient) -> None:
-        r = client.post("/query/tuples", json={
+        r = client.post(_query_path("tuples"), json={
             "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2024-01-15"},
             "query": {"filters": [{"field": "symbol", "operator": "NOPE", "values": ["X"]}]},
@@ -223,7 +239,7 @@ class TestValidationErrorEnvelope:
         assert body["code"] == "VALIDATION_ERROR"
 
     def test_export_invalid_format(self, client: TestClient) -> None:
-        r = client.post("/export", json={
+        r = client.post(EXPORTS_ROOT, json={
             "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2024-01-15"},
             "query": {"format": "xlsx"},
@@ -238,7 +254,7 @@ class TestRequestIdInErrors:
 
     def test_request_id_from_header(self, client: TestClient) -> None:
         r = client.post(
-            "/query/tuples",
+            _query_path("tuples", "no_such"),
             json=_query_body(dataset_id="no_such"),
             headers={"X-Request-ID": "trace-abc"},
         )
@@ -247,7 +263,7 @@ class TestRequestIdInErrors:
         assert body.get("request_id") == "trace-abc"
 
     def test_request_id_auto_generated(self, client: TestClient) -> None:
-        r = client.post("/query/tuples", json=_query_body(dataset_id="no_such"))
+        r = client.post(_query_path("tuples", "no_such"), json=_query_body(dataset_id="no_such"))
         assert r.status_code == 404
         body = r.json()
         assert "request_id" in body
@@ -313,7 +329,7 @@ class TestInternalErrorEnvelope:
         monkeypatch.setattr(query_router.db_manager, "execute_sql_async", boom)
         # raise_server_exceptions=False so we get the HTTP response instead of the re-raised exception
         no_raise_client = TestClient(app, raise_server_exceptions=False)
-        r = no_raise_client.post("/query/cells", json={
+        r = no_raise_client.post(_query_path("cells"), json={
             "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2026-03-01"},
             "query": {"axes": {"rows": [{"field": "symbol"}], "columns": [], "measures": [{"field": "volume", "aggregation": "SUM", "alias": "v"}]}},
@@ -339,21 +355,21 @@ class TestHappyPathUnchanged:
         assert r.status_code == 200
 
     def test_schema_success(self, client: TestClient) -> None:
-        r = client.get("/schema?dataset_id=trades_v1")
+        r = client.get("/api/v1/datasets/trades_v1/schema")
         assert r.status_code == 200
         assert "fields" in r.json()
 
     def test_query_tuples_success(self, client: TestClient) -> None:
-        r = client.post("/query/tuples", json=_query_body())
+        r = client.post(_query_path("tuples"), json=_query_body())
         assert r.status_code == 200
         assert "items" in r.json()
 
     def test_query_cells_success(self, client: TestClient) -> None:
-        r = client.post("/query/cells", json=_query_body())
+        r = client.post(_query_path("cells"), json=_query_body())
         assert r.status_code == 200
         assert "cells" in r.json()
 
     def test_query_picklist_success(self, client: TestClient) -> None:
-        r = client.post("/query/picklist", json=_query_body())
+        r = client.post(_query_path("picklist"), json=_query_body())
         assert r.status_code == 200
         assert "values" in r.json()

--- a/server/tests/test_export_api.py
+++ b/server/tests/test_export_api.py
@@ -1,4 +1,4 @@
-"""Tests for POST /export, GET /export/{id}, and GET /export/{id}/download."""
+"""Tests for POST /exports, GET /exports/{id}, and GET /exports/{id}/download."""
 
 import csv
 import io
@@ -47,12 +47,12 @@ def _valid_body(**overrides):
 
 def _run_export_and_download(client: TestClient, body: dict) -> tuple[str, list[list[str]]]:
     """Submit an export, wait for completion, download, parse CSV rows."""
-    r = client.post("/export", json=body)
+    r = client.post("/api/v1/exports", json=body)
     assert r.status_code == 200
     export_id = r.json()["export_id"]
 
     for _ in range(20):
-        status_r = client.get(f"/export/{export_id}")
+        status_r = client.get(f"/api/v1/exports/{export_id}")
         assert status_r.status_code == 200
         if status_r.json()["status"] == "complete":
             break
@@ -60,7 +60,7 @@ def _run_export_and_download(client: TestClient, body: dict) -> tuple[str, list[
     else:
         pytest.fail("Export did not complete in time")
 
-    dl = client.get(f"/export/{export_id}/download")
+    dl = client.get(f"/api/v1/exports/{export_id}/download")
     assert dl.status_code == 200
     reader = csv.reader(io.StringIO(dl.text))
     return export_id, list(reader)
@@ -68,7 +68,7 @@ def _run_export_and_download(client: TestClient, body: dict) -> tuple[str, list[
 
 class TestExportLifecycle:
     def test_post_export_returns_pending(self, client: TestClient) -> None:
-        r = client.post("/export", json=_valid_body())
+        r = client.post("/api/v1/exports", json=_valid_body())
         assert r.status_code == 200
         data = r.json()
         assert data["export_id"].startswith("exp-")
@@ -84,11 +84,11 @@ class TestExportLifecycle:
         assert symbols & {"AAPL", "GOOG", "MSFT", "AMZN", "TSLA"}
 
     def test_export_status_row_count_is_nullable(self, client: TestClient) -> None:
-        r = client.post("/export", json=_valid_body())
+        r = client.post("/api/v1/exports", json=_valid_body())
         assert r.status_code == 200
         export_id = r.json()["export_id"]
         for _ in range(20):
-            status_r = client.get(f"/export/{export_id}")
+            status_r = client.get(f"/api/v1/exports/{export_id}")
             assert status_r.status_code == 200
             if status_r.json()["status"] == "complete":
                 break
@@ -107,12 +107,12 @@ class TestExportLifecycle:
         body = _valid_body()
         del body["query"]["format"]
 
-        r = client.post("/export", json=body)
+        r = client.post("/api/v1/exports", json=body)
         assert r.status_code == 200
         export_id = r.json()["export_id"]
 
         for _ in range(20):
-            status_r = client.get(f"/export/{export_id}")
+            status_r = client.get(f"/api/v1/exports/{export_id}")
             assert status_r.status_code == 200
             if status_r.json()["status"] == "complete":
                 break
@@ -120,7 +120,7 @@ class TestExportLifecycle:
         else:
             pytest.fail("Export did not complete in time")
 
-        dl = client.get(f"/export/{export_id}/download")
+        dl = client.get(f"/api/v1/exports/{export_id}/download")
         assert dl.status_code == 200
         assert dl.headers["content-type"].startswith("application/octet-stream")
         assert "filename=\"exp-" in dl.headers.get("content-disposition", "")
@@ -131,12 +131,12 @@ class TestExportLifecycle:
         body = _valid_body()
         body["query"]["format"] = "sqlite"
 
-        r = client.post("/export", json=body)
+        r = client.post("/api/v1/exports", json=body)
         assert r.status_code == 200
         export_id = r.json()["export_id"]
 
         for _ in range(20):
-            status_r = client.get(f"/export/{export_id}")
+            status_r = client.get(f"/api/v1/exports/{export_id}")
             assert status_r.status_code == 200
             if status_r.json()["status"] == "complete":
                 break
@@ -144,7 +144,7 @@ class TestExportLifecycle:
         else:
             pytest.fail("Export did not complete in time")
 
-        dl = client.get(f"/export/{export_id}/download")
+        dl = client.get(f"/api/v1/exports/{export_id}/download")
         assert dl.status_code == 200
         assert dl.headers["content-type"].startswith("application/vnd.sqlite3")
         assert ".sqlite" in dl.headers.get("content-disposition", "")
@@ -159,12 +159,12 @@ class TestExportLifecycle:
         body = _valid_body()
         body["query"]["format"] = "duckdb"
 
-        r = client.post("/export", json=body)
+        r = client.post("/api/v1/exports", json=body)
         assert r.status_code == 200
         export_id = r.json()["export_id"]
 
         for _ in range(20):
-            status_r = client.get(f"/export/{export_id}")
+            status_r = client.get(f"/api/v1/exports/{export_id}")
             assert status_r.status_code == 200
             if status_r.json()["status"] == "complete":
                 break
@@ -172,7 +172,7 @@ class TestExportLifecycle:
         else:
             pytest.fail("Export did not complete in time")
 
-        dl = client.get(f"/export/{export_id}/download")
+        dl = client.get(f"/api/v1/exports/{export_id}/download")
         assert dl.status_code == 200
         assert dl.headers["content-type"].startswith("application/vnd.duckdb")
         assert ".duckdb" in dl.headers.get("content-disposition", "")
@@ -255,7 +255,7 @@ class TestExportCsvFormat:
 
 class TestExportErrors:
     def test_dataset_not_found(self, client: TestClient) -> None:
-        r = client.post("/export", json=_valid_body(dataset_id="nonexistent"))
+        r = client.post("/api/v1/exports", json=_valid_body(dataset_id="nonexistent"))
         assert r.status_code == 404
 
     def test_dataset_unavailable_in_sample_table_mode(self, client: TestClient, monkeypatch) -> None:
@@ -265,7 +265,7 @@ class TestExportErrors:
         from server.config import get_settings
         get_settings.cache_clear()
         monkeypatch.setattr(db_manager, "table_exists", lambda _: False)
-        r = client.post("/export", json=_valid_body())
+        r = client.post("/api/v1/exports", json=_valid_body())
         get_settings.cache_clear()
         assert r.status_code == 409
         assert r.json()["code"] == "DATASET_UNAVAILABLE"
@@ -278,25 +278,25 @@ class TestExportErrors:
         get_settings.cache_clear()
         # Ensure table_exists would return False — should not matter in parquet_partitioned mode.
         monkeypatch.setattr(db_manager, "table_exists", lambda _: False)
-        r = client.post("/export", json=_valid_body())
+        r = client.post("/api/v1/exports", json=_valid_body())
         get_settings.cache_clear()
         # Job is accepted (200) even though no local table exists.
         assert r.status_code == 200
         assert r.json()["status"] == "pending"
 
     def test_get_export_not_found(self, client: TestClient) -> None:
-        r = client.get("/export/exp-nonexistent")
+        r = client.get("/api/v1/exports/exp-nonexistent")
         assert r.status_code == 404
 
     def test_download_not_found(self, client: TestClient) -> None:
-        r = client.get("/export/exp-nonexistent/download")
+        r = client.get("/api/v1/exports/exp-nonexistent/download")
         assert r.status_code == 404
 
     def test_download_not_ready(self, client: TestClient) -> None:
         store = get_export_service().store
         store.create("exp-test", "trades_v1")
         store.update_status("exp-test", "processing")
-        r = client.get("/export/exp-test/download")
+        r = client.get("/api/v1/exports/exp-test/download")
         assert r.status_code == 409
 
     def test_download_for_failed_export(self, client: TestClient) -> None:
@@ -304,7 +304,7 @@ class TestExportErrors:
         store.create("exp-fail", "trades_v1")
         store.update_status("exp-fail", "processing")
         store.update_status("exp-fail", "failed", error_message="boom")
-        r = client.get("/export/exp-fail/download")
+        r = client.get("/api/v1/exports/exp-fail/download")
         assert r.status_code == 409
 
     def test_download_file_missing_on_disk(self, client: TestClient) -> None:
@@ -314,9 +314,9 @@ class TestExportErrors:
         store.update_status(
             "exp-gone", "complete",
             file_path="/tmp/nonexistent-file.csv",
-            download_url="/export/exp-gone/download",
+            download_url="/api/v1/exports/exp-gone/download",
         )
-        r = client.get("/export/exp-gone/download")
+        r = client.get("/api/v1/exports/exp-gone/download")
         assert r.status_code == 404
 
 
@@ -326,7 +326,7 @@ class TestExportConcurrencyAndTtl:
         for i in range(5):
             store.create(f"exp-active-{i}", "trades_v1")
             store.update_status(f"exp-active-{i}", "processing")
-        r = client.post("/export", json=_valid_body())
+        r = client.post("/api/v1/exports", json=_valid_body())
         assert r.status_code == 429
         assert r.json()["code"] == "TOO_MANY_EXPORTS"
 
@@ -347,7 +347,7 @@ class TestExportConcurrencyAndTtl:
             )
             store._conn.commit()
 
-        r = client.post("/export", json=_valid_body())
+        r = client.post("/api/v1/exports", json=_valid_body())
         assert r.status_code == 200
         assert store.get("exp-old").status == "expired"
         assert not expired_file.exists()
@@ -357,13 +357,13 @@ class TestExportConcurrencyAndTtl:
         store.create("exp-recent", "trades_v1")
         store.update_status("exp-recent", "processing")
         store.update_status("exp-recent", "complete", file_path="/tmp/f.csv")
-        r = client.post("/export", json=_valid_body())
+        r = client.post("/api/v1/exports", json=_valid_body())
         assert r.status_code == 200
         job = store.get("exp-recent")
         assert job is not None
         assert job.status == "complete"
 
     def test_multiple_exports_unique_ids(self, client: TestClient) -> None:
-        r1 = client.post("/export", json=_valid_body())
-        r2 = client.post("/export", json=_valid_body())
+        r1 = client.post("/api/v1/exports", json=_valid_body())
+        r2 = client.post("/api/v1/exports", json=_valid_body())
         assert r1.json()["export_id"] != r2.json()["export_id"]

--- a/server/tests/test_export_service.py
+++ b/server/tests/test_export_service.py
@@ -103,7 +103,7 @@ class TestGetDownloadPath:
         store.update_status(
             job.id, "complete",
             file_path=str(csv_file),
-            download_url=f"/export/{job.id}/download",
+            download_url=f"/api/v1/exports/{job.id}/download",
         )
         assert service.get_download_path(job.id) == str(csv_file)
 
@@ -118,7 +118,7 @@ class TestGetDownloadPath:
         store.update_status(
             job.id, "complete",
             file_path="/tmp/nonexistent.csv",
-            download_url=f"/export/{job.id}/download",
+            download_url=f"/api/v1/exports/{job.id}/download",
         )
         with pytest.raises(ExportFileNotFoundError):
             service.get_download_path(job.id)

--- a/server/tests/test_export_store.py
+++ b/server/tests/test_export_store.py
@@ -55,12 +55,12 @@ class TestUpdateStatus:
         job = store.update_status(
             "exp-1", "complete",
             file_path="/tmp/exp-1.csv",
-            download_url="/export/exp-1/download",
+            download_url="/api/v1/exports/exp-1/download",
             row_count=42,
         )
         assert job.status == "complete"
         assert job.file_path == "/tmp/exp-1.csv"
-        assert job.download_url == "/export/exp-1/download"
+        assert job.download_url == "/api/v1/exports/exp-1/download"
         assert job.row_count == 42
 
     def test_transition_to_failed_with_error(self, store: ExportJobStore) -> None:

--- a/server/tests/test_integration.py
+++ b/server/tests/test_integration.py
@@ -13,13 +13,13 @@ def test_full_api_flow(client: TestClient) -> None:
     dataset_id = "trades_v1"
     date_range = {"type": "single", "date": "2026-03-01"}
 
-    r_schema = client.get("/schema", params={"dataset_id": dataset_id})
+    r_schema = client.get(f"/api/v1/datasets/{dataset_id}/schema")
     assert r_schema.status_code == 200
     schema = r_schema.json()
     assert schema["dataset_id"] == dataset_id
     assert len(schema["fields"]) > 0
 
-    r_tuples = client.post("/query/tuples", json={
+    r_tuples = client.post(f"/api/v1/datasets/{dataset_id}/query/tuples", json={
         "dataset_id": dataset_id,
         "date_range": date_range,
         "query": {"fields": [{"field": "symbol"}], "paging": {"limit": 10, "offset": 0}},
@@ -29,7 +29,7 @@ def test_full_api_flow(client: TestClient) -> None:
     assert tuples_data["total_count"] > 0
     assert len(tuples_data["items"]) > 0
 
-    r_cells = client.post("/query/cells", json={
+    r_cells = client.post(f"/api/v1/datasets/{dataset_id}/query/cells", json={
         "dataset_id": dataset_id,
         "date_range": date_range,
         "query": {
@@ -45,7 +45,7 @@ def test_full_api_flow(client: TestClient) -> None:
     assert len(cells_data["cells"]) > 0
     assert "row_index" in cells_data["cells"][0]
 
-    r_picklist = client.post("/query/picklist", json={
+    r_picklist = client.post(f"/api/v1/datasets/{dataset_id}/query/picklist", json={
         "dataset_id": dataset_id,
         "date_range": date_range,
         "query": {"field": "symbol", "paging": {"limit": 100, "offset": 0}},
@@ -55,7 +55,7 @@ def test_full_api_flow(client: TestClient) -> None:
     assert picklist_data["total_count"] > 0
     assert len(picklist_data["values"]) > 0
 
-    r_export = client.post("/export", json={
+    r_export = client.post("/api/v1/exports", json={
         "dataset_id": dataset_id,
         "date_range": date_range,
         "query": {"export_type": "pivot_results", "axes": {}, "filters": [], "max_rows": 1000, "format": "csv"},
@@ -64,6 +64,6 @@ def test_full_api_flow(client: TestClient) -> None:
     export_data = r_export.json()
     assert export_data["status"] == "pending"
 
-    r_status = client.get(f"/export/{export_data['export_id']}")
+    r_status = client.get(f"/api/v1/exports/{export_data['export_id']}")
     assert r_status.status_code == 200
     assert r_status.json()["status"] in ("pending", "processing", "complete")

--- a/server/tests/test_logging.py
+++ b/server/tests/test_logging.py
@@ -92,7 +92,7 @@ class TestAccessLogMiddleware:
 
     def test_logs_post_request(self, client: TestClient, capfd) -> None:
         setup_logging("INFO", "json")
-        client.post("/query/tuples", json={
+        client.post("/api/v1/datasets/trades_v1/query/tuples", json={
             "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2026-03-01"},
             "query": {"fields": [{"field": "symbol"}]},
@@ -104,7 +104,7 @@ class TestAccessLogMiddleware:
         for line in lines:
             try:
                 record = json.loads(line)
-                if record.get("path") == "/query/tuples":
+                if record.get("path") == "/api/v1/datasets/trades_v1/query/tuples":
                     access_records.append(record)
             except json.JSONDecodeError:
                 continue
@@ -117,7 +117,7 @@ class TestAccessLogMiddleware:
 class TestQueryExecutionLogging:
     def test_tuples_query_logged(self, client: TestClient, capfd) -> None:
         setup_logging("INFO", "json")
-        client.post("/query/tuples", json={
+        client.post("/api/v1/datasets/trades_v1/query/tuples", json={
             "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2026-03-01"},
             "query": {"fields": [{"field": "symbol"}]},
@@ -141,7 +141,7 @@ class TestQueryExecutionLogging:
 
     def test_cells_query_logged(self, client: TestClient, capfd) -> None:
         setup_logging("INFO", "json")
-        client.post("/query/cells", json={
+        client.post("/api/v1/datasets/trades_v1/query/cells", json={
             "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2026-03-01"},
             "query": {"axes": {"rows": [{"field": "symbol"}], "columns": [], "measures": []}},
@@ -157,7 +157,7 @@ class TestQueryExecutionLogging:
 
     def test_picklist_query_logged(self, client: TestClient, capfd) -> None:
         setup_logging("INFO", "json")
-        client.post("/query/picklist", json={
+        client.post("/api/v1/datasets/trades_v1/query/picklist", json={
             "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2026-03-01"},
             "query": {"field": "symbol"},

--- a/server/tests/test_query_budget.py
+++ b/server/tests/test_query_budget.py
@@ -56,7 +56,8 @@ def _cells_body():
 def test_query_timeout_response(client: TestClient, settings_override) -> None:
     """Queries exceeding the timeout return a 504 with QUERY_TIMEOUT."""
     settings_override(query_timeout_seconds=0.0001)
-    r = client.post("/query/cells", json=_cells_body())
+    request_body = _cells_body()
+    r = client.post(f"/api/v1/datasets/{request_body['dataset_id']}/query/cells", json=request_body)
     assert r.status_code == 504
     body = r.json()
     assert body["code"] == "QUERY_TIMEOUT"
@@ -90,7 +91,7 @@ def test_queue_depth_rejects_overflow(
     def first_request():
         # Separate clients avoid TestClient internal request serialization,
         # which can make this concurrency test nondeterministic.
-        return first_client.post("/query/cells", json=request_body)
+        return first_client.post(f"/api/v1/datasets/{request_body['dataset_id']}/query/cells", json=request_body)
 
     first_client = None
     second_client = None
@@ -102,7 +103,7 @@ def test_queue_depth_rejects_overflow(
             # Wait until the first request has definitely acquired the budget slot
             # before sending the second, so the queue overflow is guaranteed.
             assert in_execute.wait(timeout=5)
-            second_result = second_client.post("/query/cells", json=request_body)
+            second_result = second_client.post(f"/api/v1/datasets/{request_body['dataset_id']}/query/cells", json=request_body)
             first_result = first.result(timeout=10)
     finally:
         if first_client is not None:
@@ -174,9 +175,13 @@ def test_timing_out_one_request_does_not_break_other_concurrent_requests(
         second_client = TestClient(client.app)
 
         with ThreadPoolExecutor(max_workers=1) as pool:
-            first = pool.submit(first_client.post, "/query/cells", json=request_body)
+            first = pool.submit(
+                first_client.post,
+                f"/api/v1/datasets/{request_body['dataset_id']}/query/cells",
+                json=request_body,
+            )
             assert first_started.wait(timeout=5)
-            second_result = second_client.post("/query/cells", json=request_body)
+            second_result = second_client.post(f"/api/v1/datasets/{request_body['dataset_id']}/query/cells", json=request_body)
             first_result = first.result(timeout=10)
     finally:
         if first_client is not None:

--- a/server/tests/test_query_cache_api.py
+++ b/server/tests/test_query_cache_api.py
@@ -60,8 +60,8 @@ def test_tuples_cache_hit(monkeypatch, client: TestClient) -> None:
         "date_range": {"type": "single", "date": "2026-03-01"},
         "query": {"fields": [{"field": "symbol"}], "paging": {"limit": 10, "offset": 0}},
     }
-    r1 = client.post("/query/tuples", json=body)
-    r2 = client.post("/query/tuples", json=body)
+    r1 = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
+    r2 = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
     assert r1.status_code == 200
     assert r2.status_code == 200
     assert r1.json() == r2.json()
@@ -84,8 +84,8 @@ def test_picklist_cache_hit(monkeypatch, client: TestClient) -> None:
         "date_range": {"type": "single", "date": "2026-03-01"},
         "query": {"field": "symbol", "paging": {"limit": 5, "offset": 0}},
     }
-    r1 = client.post("/query/picklist", json=body)
-    r2 = client.post("/query/picklist", json=body)
+    r1 = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
+    r2 = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
     assert r1.status_code == 200
     assert r2.status_code == 200
     assert r1.json() == r2.json()
@@ -114,8 +114,8 @@ def test_cells_cache_hit(monkeypatch, client: TestClient) -> None:
             }
         },
     }
-    r1 = client.post("/query/cells", json=body)
-    r2 = client.post("/query/cells", json=body)
+    r1 = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
+    r2 = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
     assert r1.status_code == 200
     assert r2.status_code == 200
     assert r1.json()["cells"]
@@ -145,8 +145,8 @@ def test_cells_not_cached_when_too_large(monkeypatch, client: TestClient) -> Non
             }
         },
     }
-    r1 = client.post("/query/cells", json=body)
-    r2 = client.post("/query/cells", json=body)
+    r1 = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
+    r2 = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
     assert r1.status_code == 200
     assert r2.status_code == 200
     assert r1.json()["cells"]
@@ -174,8 +174,8 @@ def test_picklist_dim_version_token_cache_hit(monkeypatch, client: TestClient) -
         "date_range": {"type": "single", "date": "2026-03-01"},
         "query": {"field": "symbol", "paging": {"limit": 5, "offset": 0}},
     }
-    r1 = client.post("/query/picklist", json=body)
-    r2 = client.post("/query/picklist", json=body)
+    r1 = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
+    r2 = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
     assert r1.status_code == 200
     assert r2.status_code == 200
     # Second request must be a cache hit – DB should only be called once.
@@ -202,13 +202,13 @@ def test_cache_miss_when_data_version_token_changes(monkeypatch, client: TestCli
         "trades_v1",
         {"partitions": [{"date": "2026-03-01", "files": [{"path": "p1.parquet", "size": 100, "etag": "e1"}]}]},
     )
-    r1 = client.post("/query/tuples", json=body)
+    r1 = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
 
     datasets.set_partition_metadata(
         "trades_v1",
         {"partitions": [{"date": "2026-03-01", "files": [{"path": "p1.parquet", "size": 101, "etag": "e1"}]}]},
     )
-    r2 = client.post("/query/tuples", json=body)
+    r2 = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
 
     assert r1.status_code == 200
     assert r2.status_code == 200
@@ -237,14 +237,14 @@ def test_picklist_dim_version_token_cache_miss_on_token_change(monkeypatch, clie
     # First request with token v1.
     monkeypatch.setenv("QUERYSERVICE_DIM_VERSION_TOKEN", "token-v1")
     get_settings.cache_clear()
-    r1 = client.post("/query/picklist", json=body)
+    r1 = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
     assert r1.status_code == 200
     assert call_count["n"] == 1
 
     # Change the token – the cache key changes, so this is a miss.
     monkeypatch.setenv("QUERYSERVICE_DIM_VERSION_TOKEN", "token-v2")
     get_settings.cache_clear()
-    r2 = client.post("/query/picklist", json=body)
+    r2 = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
     assert r2.status_code == 200
     assert call_count["n"] == 2  # DB called again due to key change
 
@@ -270,13 +270,13 @@ def test_dim_version_token_change_does_not_invalidate_fact_cache(monkeypatch, cl
 
     monkeypatch.setenv("QUERYSERVICE_DIM_VERSION_TOKEN", "dim-v1")
     get_settings.cache_clear()
-    r1 = client.post("/query/tuples", json=body)
+    r1 = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
     assert r1.status_code == 200
     assert r1.json().get("items")
     assert call_count["n"] == 1
 
     monkeypatch.setenv("QUERYSERVICE_DIM_VERSION_TOKEN", "dim-v2")
     get_settings.cache_clear()
-    r2 = client.post("/query/tuples", json=body)
+    r2 = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
     assert r2.status_code == 200
     assert call_count["n"] == 1

--- a/server/tests/test_query_cells_api.py
+++ b/server/tests/test_query_cells_api.py
@@ -19,7 +19,7 @@ def test_query_cells_returns_aggregated_data(client: TestClient) -> None:
             },
         },
     }
-    r = client.post("/query/cells", json=body)
+    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
     assert r.status_code == 200
     data = r.json()
     assert len(data["cells"]) > 0
@@ -47,7 +47,7 @@ def test_query_cells_multiple_aggregations(client: TestClient) -> None:
             },
         },
     }
-    r = client.post("/query/cells", json=body)
+    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
     assert r.status_code == 200
     cells = r.json()["cells"]
     assert len(cells) > 0
@@ -68,7 +68,7 @@ def test_query_cells_with_filter(client: TestClient) -> None:
             "filters": [{"field": "symbol", "operator": "INCLUDE", "values": ["AAPL"]}],
         },
     }
-    r = client.post("/query/cells", json=body)
+    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
     assert r.status_code == 200
     cells = r.json()["cells"]
     assert len(cells) == 1
@@ -81,14 +81,14 @@ def test_query_cells_empty_axes_returns_empty(client: TestClient) -> None:
         "date_range": {"type": "single", "date": "2026-03-01"},
         "query": {"axes": {"rows": [], "columns": [], "measures": []}},
     }
-    r = client.post("/query/cells", json=body)
+    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
     assert r.status_code == 200
     assert r.json()["cells"] == []
 
 
 def test_query_cells_dataset_not_found(client: TestClient) -> None:
     body = {"dataset_id": "nonexistent", "date_range": {"type": "single", "date": "2026-03-01"}, "query": {}}
-    r = client.post("/query/cells", json=body)
+    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
     assert r.status_code == 404
 
 
@@ -105,7 +105,7 @@ def test_query_cells_row_window_limits_results(client: TestClient) -> None:
             },
         },
     }
-    r = client.post("/query/cells", json=body)
+    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
     assert r.status_code == 200
     cells = r.json()["cells"]
     assert len(cells) == 1
@@ -129,7 +129,7 @@ def test_query_cells_window_too_large_returns_error(client: TestClient, monkeypa
             },
         },
     }
-    r = client.post("/query/cells", json=body)
+    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
     assert r.status_code == 400
     data = r.json()
     assert data["code"] == "CELLS_WINDOW_TOO_LARGE"
@@ -150,7 +150,7 @@ def test_query_cells_no_windows_cap_enforced(client: TestClient, monkeypatch: py
             },
         },
     }
-    r = client.post("/query/cells", json=body)
+    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
     assert r.status_code == 400
     data = r.json()
     assert data["code"] == "CELLS_WINDOW_TOO_LARGE"
@@ -179,7 +179,7 @@ def test_query_cells_row_window_only_cap_enforced(client: TestClient, monkeypatc
             },
         },
     }
-    r = client.post("/query/cells", json=body)
+    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
     assert r.status_code == 400
     assert r.json()["code"] == "CELLS_WINDOW_TOO_LARGE"
 
@@ -205,7 +205,7 @@ def test_query_cells_col_window_only_cap_enforced(client: TestClient, monkeypatc
             },
         },
     }
-    r = client.post("/query/cells", json=body)
+    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
     assert r.status_code == 400
     assert r.json()["code"] == "CELLS_WINDOW_TOO_LARGE"
 
@@ -225,7 +225,7 @@ def test_query_cells_within_cap_succeeds(client: TestClient, monkeypatch: pytest
             },
         },
     }
-    r = client.post("/query/cells", json=body)
+    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
     assert r.status_code == 200
     assert len(r.json()["cells"]) > 0
 
@@ -251,6 +251,6 @@ def test_cells_executes_sql_exactly_once(monkeypatch, client: TestClient) -> Non
             },
         },
     }
-    r = client.post("/query/cells", json=body)
+    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
     assert r.status_code == 200
     assert call_count["n"] == 1, f"Expected exactly 1 SQL execution for /query/cells, got {call_count['n']}"

--- a/server/tests/test_query_cells_api.py
+++ b/server/tests/test_query_cells_api.py
@@ -1,4 +1,4 @@
-"""Tests for POST /query/cells API — functional / happy-path tests."""
+"""Tests for POST /api/v1/datasets/{dataset_id}/query/cells."""
 
 import pytest
 from fastapi.testclient import TestClient
@@ -231,7 +231,7 @@ def test_query_cells_within_cap_succeeds(client: TestClient, monkeypatch: pytest
 
 
 def test_cells_executes_sql_exactly_once(monkeypatch, client: TestClient) -> None:
-    """Regression guard: /query/cells must call execute_sql_async exactly once per request."""
+    """Regression guard: the v1 cells endpoint must call execute_sql_async exactly once per request."""
     call_count = {"n": 0}
     original = db_manager.execute_sql_async
 
@@ -253,4 +253,7 @@ def test_cells_executes_sql_exactly_once(monkeypatch, client: TestClient) -> Non
     }
     r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
     assert r.status_code == 200
-    assert call_count["n"] == 1, f"Expected exactly 1 SQL execution for /query/cells, got {call_count['n']}"
+    assert call_count["n"] == 1, (
+        "Expected exactly 1 SQL execution for /api/v1/datasets/{dataset_id}/query/cells, "
+        f"got {call_count['n']}"
+    )

--- a/server/tests/test_query_partitioned_api.py
+++ b/server/tests/test_query_partitioned_api.py
@@ -101,7 +101,7 @@ def test_partition_config_error_cells_no_bucket_or_path(
     partitioned_no_storage, client: TestClient
 ) -> None:
     """When execution_mode=parquet_partitioned but no bucket/path is set,
-    /query/cells returns 500 PARTITION_CONFIG_ERROR."""
+    the v1 cells endpoint returns 500 PARTITION_CONFIG_ERROR."""
     body = _cells_body()
     r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
     assert r.status_code == 500
@@ -112,7 +112,7 @@ def test_partition_config_error_cells_no_bucket_or_path(
 def test_partition_config_error_tuples_no_bucket_or_path(
     partitioned_no_storage, client: TestClient
 ) -> None:
-    """Same PARTITION_CONFIG_ERROR check for /query/tuples."""
+    """Same PARTITION_CONFIG_ERROR check for the v1 tuples endpoint."""
     body = _tuples_body()
     r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
     assert r.status_code == 500
@@ -123,7 +123,7 @@ def test_partition_config_error_tuples_no_bucket_or_path(
 def test_partition_config_error_picklist_no_bucket_or_path(
     partitioned_no_storage, client: TestClient
 ) -> None:
-    """Same PARTITION_CONFIG_ERROR check for /query/picklist."""
+    """Same PARTITION_CONFIG_ERROR check for the v1 picklist endpoint."""
     body = _picklist_body()
     r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
     assert r.status_code == 500
@@ -135,7 +135,7 @@ def test_partition_not_found_cells_missing_date(
     partitioned_empty_base_path, client: TestClient
 ) -> None:
     """When execution_mode=parquet_partitioned with a base path but the
-    requested date partition directory does not exist, /query/cells returns
+    requested date partition directory does not exist, the v1 cells endpoint returns
     404 PARTITION_NOT_FOUND."""
     body = _cells_body()
     r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
@@ -149,7 +149,7 @@ def test_partition_not_found_cells_missing_date(
 def test_partition_not_found_tuples_missing_date(
     partitioned_empty_base_path, client: TestClient
 ) -> None:
-    """Same PARTITION_NOT_FOUND check for /query/tuples."""
+    """Same PARTITION_NOT_FOUND check for the v1 tuples endpoint."""
     body = _tuples_body()
     r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
     assert r.status_code == 404
@@ -160,7 +160,7 @@ def test_partition_not_found_tuples_missing_date(
 def test_partition_not_found_picklist_missing_date(
     partitioned_empty_base_path, client: TestClient
 ) -> None:
-    """Same PARTITION_NOT_FOUND check for /query/picklist."""
+    """Same PARTITION_NOT_FOUND check for the v1 picklist endpoint."""
     body = _picklist_body()
     r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
     assert r.status_code == 404

--- a/server/tests/test_query_partitioned_api.py
+++ b/server/tests/test_query_partitioned_api.py
@@ -102,7 +102,8 @@ def test_partition_config_error_cells_no_bucket_or_path(
 ) -> None:
     """When execution_mode=parquet_partitioned but no bucket/path is set,
     /query/cells returns 500 PARTITION_CONFIG_ERROR."""
-    r = client.post("/query/cells", json=_cells_body())
+    body = _cells_body()
+    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
     assert r.status_code == 500
     data = r.json()
     assert data["code"] == "PARTITION_CONFIG_ERROR"
@@ -112,7 +113,8 @@ def test_partition_config_error_tuples_no_bucket_or_path(
     partitioned_no_storage, client: TestClient
 ) -> None:
     """Same PARTITION_CONFIG_ERROR check for /query/tuples."""
-    r = client.post("/query/tuples", json=_tuples_body())
+    body = _tuples_body()
+    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
     assert r.status_code == 500
     data = r.json()
     assert data["code"] == "PARTITION_CONFIG_ERROR"
@@ -122,7 +124,8 @@ def test_partition_config_error_picklist_no_bucket_or_path(
     partitioned_no_storage, client: TestClient
 ) -> None:
     """Same PARTITION_CONFIG_ERROR check for /query/picklist."""
-    r = client.post("/query/picklist", json=_picklist_body())
+    body = _picklist_body()
+    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
     assert r.status_code == 500
     data = r.json()
     assert data["code"] == "PARTITION_CONFIG_ERROR"
@@ -134,7 +137,8 @@ def test_partition_not_found_cells_missing_date(
     """When execution_mode=parquet_partitioned with a base path but the
     requested date partition directory does not exist, /query/cells returns
     404 PARTITION_NOT_FOUND."""
-    r = client.post("/query/cells", json=_cells_body())
+    body = _cells_body()
+    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
     assert r.status_code == 404
     data = r.json()
     assert data["code"] == "PARTITION_NOT_FOUND"
@@ -146,7 +150,8 @@ def test_partition_not_found_tuples_missing_date(
     partitioned_empty_base_path, client: TestClient
 ) -> None:
     """Same PARTITION_NOT_FOUND check for /query/tuples."""
-    r = client.post("/query/tuples", json=_tuples_body())
+    body = _tuples_body()
+    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
     assert r.status_code == 404
     data = r.json()
     assert data["code"] == "PARTITION_NOT_FOUND"
@@ -156,7 +161,8 @@ def test_partition_not_found_picklist_missing_date(
     partitioned_empty_base_path, client: TestClient
 ) -> None:
     """Same PARTITION_NOT_FOUND check for /query/picklist."""
-    r = client.post("/query/picklist", json=_picklist_body())
+    body = _picklist_body()
+    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
     assert r.status_code == 404
     data = r.json()
     assert data["code"] == "PARTITION_NOT_FOUND"

--- a/server/tests/test_query_picklist_api.py
+++ b/server/tests/test_query_picklist_api.py
@@ -1,4 +1,4 @@
-"""Tests for POST /query/picklist API — functional / happy-path tests."""
+"""Tests for POST /api/v1/datasets/{dataset_id}/query/picklist."""
 
 from fastapi.testclient import TestClient
 
@@ -121,7 +121,7 @@ def test_query_picklist_dataset_not_found(client: TestClient) -> None:
 
 
 def test_picklist_executes_sql_exactly_once(monkeypatch, client: TestClient) -> None:
-    """Regression guard: /query/picklist must call execute_sql_async exactly once per request."""
+    """Regression guard: the v1 picklist endpoint must call execute_sql_async exactly once per request."""
     call_count = {"n": 0}
     original = db_manager.execute_sql_async
 
@@ -137,4 +137,7 @@ def test_picklist_executes_sql_exactly_once(monkeypatch, client: TestClient) -> 
     }
     r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
     assert r.status_code == 200
-    assert call_count["n"] == 1, f"Expected exactly 1 SQL execution for /query/picklist, got {call_count['n']}"
+    assert call_count["n"] == 1, (
+        "Expected exactly 1 SQL execution for /api/v1/datasets/{dataset_id}/query/picklist, "
+        f"got {call_count['n']}"
+    )

--- a/server/tests/test_query_picklist_api.py
+++ b/server/tests/test_query_picklist_api.py
@@ -11,7 +11,7 @@ def test_query_picklist_returns_values(client: TestClient) -> None:
         "date_range": {"type": "single", "date": "2026-03-01"},
         "query": {"field": "symbol", "paging": {"limit": 100, "offset": 0}},
     }
-    r = client.post("/query/picklist", json=body)
+    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
     assert r.status_code == 200
     data = r.json()
     assert data["total_count"] > 0
@@ -29,7 +29,7 @@ def test_query_picklist_search_wildcard(client: TestClient) -> None:
         "date_range": {"type": "single", "date": "2026-03-01"},
         "query": {"field": "symbol", "search": "A*", "paging": {"limit": 100, "offset": 0}},
     }
-    r = client.post("/query/picklist", json=body)
+    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
     assert r.status_code == 200
     data = r.json()
     values = [v["value"] for v in data["values"]]
@@ -48,7 +48,7 @@ def test_query_picklist_with_filter(client: TestClient) -> None:
             "paging": {"limit": 100, "offset": 0},
         },
     }
-    r = client.post("/query/picklist", json=body)
+    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
     assert r.status_code == 200
     values = [v["value"] for v in r.json()["values"]]
     assert "AAPL" not in values
@@ -65,7 +65,7 @@ def test_query_picklist_with_search_and_between_filter(client: TestClient) -> No
             "paging": {"limit": 10, "offset": 0},
         },
     }
-    r = client.post("/query/picklist", json=body)
+    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
     assert r.status_code == 200
     data = r.json()
     assert data["total_count"] == 1
@@ -79,7 +79,7 @@ def test_query_picklist_paging(client: TestClient) -> None:
         "date_range": {"type": "single", "date": "2026-03-01"},
         "query": {"field": "symbol", "paging": {"limit": 2, "offset": 0}},
     }
-    r = client.post("/query/picklist", json=body)
+    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
     assert r.status_code == 200
     data = r.json()
     assert data["paging"]["returned"] == 2
@@ -92,7 +92,7 @@ def test_query_picklist_paging_limit_one(client: TestClient) -> None:
         "date_range": {"type": "single", "date": "2026-03-01"},
         "query": {"field": "symbol", "paging": {"limit": 1, "offset": 0}},
     }
-    r = client.post("/query/picklist", json=body)
+    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
     assert r.status_code == 200
     data = r.json()
     assert data["paging"]["limit"] == 1
@@ -106,7 +106,7 @@ def test_query_picklist_empty_page_reports_total(client: TestClient) -> None:
         "date_range": {"type": "single", "date": "2026-03-01"},
         "query": {"field": "symbol", "paging": {"limit": 5, "offset": 10}},
     }
-    r = client.post("/query/picklist", json=body)
+    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
     assert r.status_code == 200
     data = r.json()
     assert data["values"] == []
@@ -116,7 +116,7 @@ def test_query_picklist_empty_page_reports_total(client: TestClient) -> None:
 
 def test_query_picklist_dataset_not_found(client: TestClient) -> None:
     body = {"dataset_id": "nonexistent", "date_range": {"type": "single", "date": "2026-03-01"}, "query": {}}
-    r = client.post("/query/picklist", json=body)
+    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
     assert r.status_code == 404
 
 
@@ -135,6 +135,6 @@ def test_picklist_executes_sql_exactly_once(monkeypatch, client: TestClient) -> 
         "date_range": {"type": "single", "date": "2026-03-01"},
         "query": {"field": "symbol", "paging": {"limit": 10, "offset": 0}},
     }
-    r = client.post("/query/picklist", json=body)
+    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
     assert r.status_code == 200
     assert call_count["n"] == 1, f"Expected exactly 1 SQL execution for /query/picklist, got {call_count['n']}"

--- a/server/tests/test_query_tuples_api.py
+++ b/server/tests/test_query_tuples_api.py
@@ -1,4 +1,4 @@
-"""Tests for POST /query/tuples API — functional / happy-path tests."""
+"""Tests for POST /api/v1/datasets/{dataset_id}/query/tuples."""
 
 from fastapi.testclient import TestClient
 
@@ -168,7 +168,7 @@ def test_query_tuples_dataset_not_found(client: TestClient) -> None:
 
 
 def test_tuples_executes_sql_exactly_once(monkeypatch, client: TestClient) -> None:
-    """Regression guard: /query/tuples must call execute_sql_async exactly once per request."""
+    """Regression guard: the v1 tuples endpoint must call execute_sql_async exactly once per request."""
     call_count = {"n": 0}
     original = db_manager.execute_sql_async
 
@@ -184,4 +184,7 @@ def test_tuples_executes_sql_exactly_once(monkeypatch, client: TestClient) -> No
     }
     r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
     assert r.status_code == 200
-    assert call_count["n"] == 1, f"Expected exactly 1 SQL execution for /query/tuples, got {call_count['n']}"
+    assert call_count["n"] == 1, (
+        "Expected exactly 1 SQL execution for /api/v1/datasets/{dataset_id}/query/tuples, "
+        f"got {call_count['n']}"
+    )

--- a/server/tests/test_query_tuples_api.py
+++ b/server/tests/test_query_tuples_api.py
@@ -11,7 +11,7 @@ def test_query_tuples_returns_results(client: TestClient) -> None:
         "date_range": {"type": "single", "date": "2026-03-01"},
         "query": {"fields": [{"field": "symbol"}], "paging": {"limit": 10, "offset": 0}},
     }
-    r = client.post("/query/tuples", json=body)
+    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
     assert r.status_code == 200
     data = r.json()
     assert data["total_count"] > 0
@@ -31,7 +31,7 @@ def test_query_tuples_with_include_filter(client: TestClient) -> None:
             "paging": {"limit": 10, "offset": 0},
         },
     }
-    r = client.post("/query/tuples", json=body)
+    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
     assert r.status_code == 200
     data = r.json()
     assert data["total_count"] == 2
@@ -49,7 +49,7 @@ def test_query_tuples_with_exclude_filter(client: TestClient) -> None:
             "paging": {"limit": 10, "offset": 0},
         },
     }
-    r = client.post("/query/tuples", json=body)
+    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
     assert r.status_code == 200
     data = r.json()
     symbols = {item["values"][0] for item in data["items"]}
@@ -63,7 +63,7 @@ def test_query_tuples_date_range(client: TestClient) -> None:
         "date_range": {"type": "range", "start": "2026-03-01", "end": "2026-03-02"},
         "query": {"fields": [{"field": "symbol"}], "paging": {"limit": 10, "offset": 0}},
     }
-    r = client.post("/query/tuples", json=body)
+    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
     assert r.status_code == 200
     data = r.json()
     assert data["total_count"] == 5
@@ -75,7 +75,7 @@ def test_query_tuples_paging(client: TestClient) -> None:
         "date_range": {"type": "single", "date": "2026-03-01"},
         "query": {"fields": [{"field": "symbol"}], "paging": {"limit": 2, "offset": 0}},
     }
-    r = client.post("/query/tuples", json=body)
+    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
     assert r.status_code == 200
     data = r.json()
     assert data["paging"]["returned"] == 2
@@ -88,7 +88,7 @@ def test_query_tuples_paging_limit_one(client: TestClient) -> None:
         "date_range": {"type": "single", "date": "2026-03-01"},
         "query": {"fields": [{"field": "symbol", "sort": "ASC"}], "paging": {"limit": 1, "offset": 0}},
     }
-    r = client.post("/query/tuples", json=body)
+    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
     assert r.status_code == 200
     data = r.json()
     assert data["paging"]["limit"] == 1
@@ -103,8 +103,8 @@ def test_query_tuples_paging_offset(client: TestClient) -> None:
         "query": {"fields": [{"field": "symbol", "sort": "ASC"}], "paging": {"limit": 2, "offset": 0}},
     }
     body_page2 = {**body_page1, "query": {**body_page1["query"], "paging": {"limit": 2, "offset": 2}}}
-    r1 = client.post("/query/tuples", json=body_page1)
-    r2 = client.post("/query/tuples", json=body_page2)
+    r1 = client.post(f"/api/v1/datasets/{body_page1['dataset_id']}/query/tuples", json=body_page1)
+    r2 = client.post(f"/api/v1/datasets/{body_page2['dataset_id']}/query/tuples", json=body_page2)
     page1_symbols = {item["values"][0] for item in r1.json()["items"]}
     page2_symbols = {item["values"][0] for item in r2.json()["items"]}
     assert page1_symbols.isdisjoint(page2_symbols)
@@ -118,8 +118,8 @@ def test_query_tuples_paging_offset_limit_one(client: TestClient) -> None:
     }
     body_page1 = {**base_query, "query": {**base_query["query"], "paging": {"limit": 1, "offset": 0}}}
     body_page2 = {**base_query, "query": {**base_query["query"], "paging": {"limit": 1, "offset": 1}}}
-    r1 = client.post("/query/tuples", json=body_page1)
-    r2 = client.post("/query/tuples", json=body_page2)
+    r1 = client.post(f"/api/v1/datasets/{body_page1['dataset_id']}/query/tuples", json=body_page1)
+    r2 = client.post(f"/api/v1/datasets/{body_page2['dataset_id']}/query/tuples", json=body_page2)
     assert r1.status_code == 200
     assert r2.status_code == 200
     data1 = r1.json()
@@ -136,7 +136,7 @@ def test_query_tuples_empty_page_reports_total(client: TestClient) -> None:
         "date_range": {"type": "single", "date": "2026-03-01"},
         "query": {"fields": [{"field": "symbol"}], "paging": {"limit": 10, "offset": 10}},
     }
-    r = client.post("/query/tuples", json=body)
+    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
     assert r.status_code == 200
     data = r.json()
     assert data["items"] == []
@@ -150,7 +150,7 @@ def test_query_tuples_sort_desc(client: TestClient) -> None:
         "date_range": {"type": "single", "date": "2026-03-01"},
         "query": {"fields": [{"field": "symbol", "sort": "DESC"}], "paging": {"limit": 10, "offset": 0}},
     }
-    r = client.post("/query/tuples", json=body)
+    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
     assert r.status_code == 200
     symbols = [item["values"][0] for item in r.json()["items"]]
     assert symbols == sorted(symbols, reverse=True)
@@ -162,7 +162,7 @@ def test_query_tuples_dataset_not_found(client: TestClient) -> None:
         "date_range": {"type": "single", "date": "2026-03-01"},
         "query": {},
     }
-    r = client.post("/query/tuples", json=body)
+    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
     assert r.status_code == 404
 
 
@@ -182,6 +182,6 @@ def test_tuples_executes_sql_exactly_once(monkeypatch, client: TestClient) -> No
         "date_range": {"type": "single", "date": "2026-03-01"},
         "query": {"fields": [{"field": "symbol"}], "paging": {"limit": 10, "offset": 0}},
     }
-    r = client.post("/query/tuples", json=body)
+    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
     assert r.status_code == 200
     assert call_count["n"] == 1, f"Expected exactly 1 SQL execution for /query/tuples, got {call_count['n']}"

--- a/server/tests/test_rate_limiting.py
+++ b/server/tests/test_rate_limiting.py
@@ -52,18 +52,18 @@ def _export_body() -> dict:
 def test_rate_limit_exceeded(rate_limited_client: TestClient) -> None:
     body = _query_body()
     for _ in range(2):
-        rate_limited_client.post("/query/tuples", json=body)
+        rate_limited_client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
 
-    response = rate_limited_client.post("/query/tuples", json=body)
+    response = rate_limited_client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
     assert response.status_code == 429
 
 
 def test_rate_limit_returns_retry_after(rate_limited_client: TestClient) -> None:
     body = _query_body()
-    rate_limited_client.post("/query/tuples", json=body)
-    rate_limited_client.post("/query/tuples", json=body)
+    rate_limited_client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
+    rate_limited_client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
 
-    response = rate_limited_client.post("/query/tuples", json=body)
+    response = rate_limited_client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
     assert response.status_code == 429
     retry_after = response.headers.get("Retry-After")
     assert retry_after is not None
@@ -71,18 +71,18 @@ def test_rate_limit_returns_retry_after(rate_limited_client: TestClient) -> None
 
 
 def test_export_rate_limit_exceeded(rate_limited_client: TestClient) -> None:
-    """POST /export is rate-limited; exceeding the limit returns 429."""
+    """POST /exports is rate-limited; exceeding the limit returns 429."""
     # RATE_LIMIT_EXPORT = "1/minute", so two requests should exceed it
-    rate_limited_client.post("/export", json=_export_body())
+    rate_limited_client.post("/api/v1/exports", json=_export_body())
 
-    response = rate_limited_client.post("/export", json=_export_body())
+    response = rate_limited_client.post("/api/v1/exports", json=_export_body())
     assert response.status_code == 429
 
 
 def test_export_rate_limit_returns_retry_after(rate_limited_client: TestClient) -> None:
     """Exceeded export rate limit includes a Retry-After header."""
-    rate_limited_client.post("/export", json=_export_body())
-    response = rate_limited_client.post("/export", json=_export_body())
+    rate_limited_client.post("/api/v1/exports", json=_export_body())
+    response = rate_limited_client.post("/api/v1/exports", json=_export_body())
     assert response.status_code == 429
     retry_after = response.headers.get("Retry-After")
     assert retry_after is not None
@@ -100,11 +100,12 @@ def test_rate_limiting_disabled(monkeypatch) -> None:
         client = TestClient(app)
         # Query: two calls exceed the "1/minute" limit but limiting is off
         for _ in range(2):
-            r = client.post("/query/tuples", json=_query_body())
+            body = _query_body()
+            r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
             assert r.status_code == 200
         # Export: two calls exceed the "1/minute" limit but limiting is off
         for _ in range(2):
-            r = client.post("/export", json=_export_body())
+            r = client.post("/api/v1/exports", json=_export_body())
             assert r.status_code == 200
     finally:
         get_settings.cache_clear()

--- a/server/tests/test_schema_api.py
+++ b/server/tests/test_schema_api.py
@@ -1,10 +1,10 @@
-"""Tests for GET /schema API."""
+"""Tests for GET /api/v1/datasets/{dataset_id}/schema."""
 
 from fastapi.testclient import TestClient
 
 
 def test_schema_found(client: TestClient) -> None:
-    """GET /schema?dataset_id=trades_v1 returns 200 and schema (from default config)."""
+    """GET /api/v1/datasets/trades_v1/schema returns 200 and schema."""
     r = client.get("/api/v1/datasets/trades_v1/schema")
     assert r.status_code == 200
     data = r.json()
@@ -14,6 +14,6 @@ def test_schema_found(client: TestClient) -> None:
 
 
 def test_schema_not_found(client: TestClient) -> None:
-    """GET /schema?dataset_id=nonexistent returns 404."""
+    """GET /api/v1/datasets/nonexistent/schema returns 404."""
     r = client.get("/api/v1/datasets/nonexistent/schema")
     assert r.status_code == 404

--- a/server/tests/test_schema_api.py
+++ b/server/tests/test_schema_api.py
@@ -5,7 +5,7 @@ from fastapi.testclient import TestClient
 
 def test_schema_found(client: TestClient) -> None:
     """GET /schema?dataset_id=trades_v1 returns 200 and schema (from default config)."""
-    r = client.get("/schema", params={"dataset_id": "trades_v1"})
+    r = client.get("/api/v1/datasets/trades_v1/schema")
     assert r.status_code == 200
     data = r.json()
     assert data["dataset_id"] == "trades_v1"
@@ -15,5 +15,5 @@ def test_schema_found(client: TestClient) -> None:
 
 def test_schema_not_found(client: TestClient) -> None:
     """GET /schema?dataset_id=nonexistent returns 404."""
-    r = client.get("/schema", params={"dataset_id": "nonexistent"})
+    r = client.get("/api/v1/datasets/nonexistent/schema")
     assert r.status_code == 404

--- a/server/tests/test_validation_errors.py
+++ b/server/tests/test_validation_errors.py
@@ -10,8 +10,9 @@ from fastapi.testclient import TestClient
 
 from server.config import get_settings
 
-QUERY_ENDPOINTS = ["/query/tuples", "/query/cells", "/query/picklist"]
-ALL_POST_ENDPOINTS = [*QUERY_ENDPOINTS, "/export"]
+QUERY_ENDPOINTS = ["tuples", "cells", "picklist"]
+ALL_POST_ENDPOINTS = [*QUERY_ENDPOINTS, "export"]
+EXPORTS_ROOT = "/api/v1/exports"
 
 _BASE_BODY = {
     "dataset_id": "trades_v1",
@@ -27,9 +28,9 @@ def _body(**query_overrides):
 
 
 def _valid_body_for(endpoint: str) -> dict:
-    if endpoint == "/query/tuples":
+    if endpoint == "tuples":
         return _body(fields=[{"field": "symbol"}], paging={"limit": 10, "offset": 0})
-    if endpoint == "/query/cells":
+    if endpoint == "cells":
         return _body(
             axes={
                 "rows": [{"field": "symbol"}],
@@ -37,7 +38,7 @@ def _valid_body_for(endpoint: str) -> dict:
                 "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}],
             }
         )
-    if endpoint == "/query/picklist":
+    if endpoint == "picklist":
         return _body(field="symbol", paging={"limit": 10, "offset": 0})
     return {
         "dataset_id": "trades_v1",
@@ -46,99 +47,120 @@ def _valid_body_for(endpoint: str) -> dict:
     }
 
 
+def _post_path(endpoint: str, body: dict) -> str:
+    dataset_id = body.get("dataset_id", "trades_v1")
+    if endpoint == "tuples":
+        return f"/api/v1/datasets/{dataset_id}/query/tuples"
+    if endpoint == "cells":
+        return f"/api/v1/datasets/{dataset_id}/query/cells"
+    if endpoint == "picklist":
+        return f"/api/v1/datasets/{dataset_id}/query/picklist"
+    return EXPORTS_ROOT
+
+
 @pytest.mark.parametrize("endpoint", ALL_POST_ENDPOINTS)
 class TestCommonValidation:
     """Validation scenarios shared across all POST endpoints."""
 
     def test_empty_body(self, client: TestClient, endpoint: str) -> None:
-        r = client.post(endpoint, json={})
+        r = client.post(_post_path(endpoint, {}), json={})
         assert r.status_code == 422
 
     def test_missing_dataset_id(self, client: TestClient, endpoint: str) -> None:
-        r = client.post(endpoint, json={
+        r = client.post(_post_path(endpoint, {}), json={
             "date_range": {"type": "single", "date": "2026-01-01"},
             "query": {},
         })
         assert r.status_code == 422
 
     def test_dataset_id_wrong_type(self, client: TestClient, endpoint: str) -> None:
-        r = client.post(endpoint, json={
+        body = {
             "dataset_id": 123,
             "date_range": {"type": "single", "date": "2026-01-01"},
             "query": {},
-        })
+        }
+        r = client.post(_post_path(endpoint, body), json=body)
         assert r.status_code == 422
 
     def test_date_range_null(self, client: TestClient, endpoint: str) -> None:
-        r = client.post(endpoint, json={
+        body = {
             "dataset_id": "trades_v1",
             "date_range": None,
             "query": {},
-        })
+        }
+        r = client.post(_post_path(endpoint, body), json=body)
         assert r.status_code == 422
 
     def test_date_range_empty_object(self, client: TestClient, endpoint: str) -> None:
-        r = client.post(endpoint, json={
+        body = {
             "dataset_id": "trades_v1",
             "date_range": {},
             "query": {},
-        })
+        }
+        r = client.post(_post_path(endpoint, body), json=body)
         assert r.status_code == 422
 
     def test_date_range_unknown_type(self, client: TestClient, endpoint: str) -> None:
-        r = client.post(endpoint, json={
+        body = {
             "dataset_id": "trades_v1",
             "date_range": {"type": "weekly", "date": "2026-01-01"},
             "query": {},
-        })
+        }
+        r = client.post(_post_path(endpoint, body), json=body)
         assert r.status_code == 422
 
     def test_date_bad_format(self, client: TestClient, endpoint: str) -> None:
-        r = client.post(endpoint, json={
+        body = {
             "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "not-a-date"},
             "query": {},
-        })
+        }
+        r = client.post(_post_path(endpoint, body), json=body)
         assert r.status_code == 422
 
     def test_date_invalid_calendar_value(self, client: TestClient, endpoint: str) -> None:
-        r = client.post(endpoint, json={
+        body = {
             "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2026-02-30"},
             "query": {},
-        })
+        }
+        r = client.post(_post_path(endpoint, body), json=body)
         assert r.status_code == 422
 
     def test_date_range_inverted(self, client: TestClient, endpoint: str) -> None:
-        r = client.post(endpoint, json={
+        body = {
             "dataset_id": "trades_v1",
             "date_range": {"type": "range", "start": "2026-12-01", "end": "2026-01-01"},
             "query": {},
-        })
+        }
+        r = client.post(_post_path(endpoint, body), json=body)
         assert r.status_code == 422
 
     def test_date_range_missing_end(self, client: TestClient, endpoint: str) -> None:
-        r = client.post(endpoint, json={
+        body = {
             "dataset_id": "trades_v1",
             "date_range": {"type": "range", "start": "2026-01-01"},
             "query": {},
-        })
+        }
+        r = client.post(_post_path(endpoint, body), json=body)
         assert r.status_code == 422
 
     def test_date_range_missing_date_field(self, client: TestClient, endpoint: str) -> None:
-        r = client.post(endpoint, json={
+        body = {
             "dataset_id": "trades_v1",
             "date_range": {"type": "single"},
             "query": {},
-        })
+        }
+        r = client.post(_post_path(endpoint, body), json=body)
         assert r.status_code == 422
 
     def test_date_range_invalid_calendar_value(self, client: TestClient, endpoint: str) -> None:
-        r = client.post(endpoint, json={
+        body = {
             "dataset_id": "trades_v1",
             "date_range": {"type": "range", "start": "2026-01-01", "end": "2026-13-01"},
             "query": {},
-        })
+        }
+        r = client.post(_post_path(endpoint, body), json=body)
         assert r.status_code == 422
 
     def test_date_range_at_span_limit(self, monkeypatch, client: TestClient, endpoint: str) -> None:
@@ -147,7 +169,7 @@ class TestCommonValidation:
         try:
             body = _valid_body_for(endpoint)
             body["date_range"] = {"type": "range", "start": "2026-03-01", "end": "2026-03-02"}
-            r = client.post(endpoint, json=body)
+            r = client.post(_post_path(endpoint, body), json=body)
         finally:
             get_settings.cache_clear()
         assert r.status_code < 400
@@ -160,7 +182,7 @@ class TestCommonValidation:
         try:
             request_body = _valid_body_for(endpoint)
             request_body["date_range"] = {"type": "range", "start": "2026-03-01", "end": "2026-03-03"}
-            r = client.post(endpoint, json=request_body)
+            r = client.post(_post_path(endpoint, request_body), json=request_body)
         finally:
             get_settings.cache_clear()
         assert r.status_code == 422
@@ -170,7 +192,7 @@ class TestCommonValidation:
         assert "exceeds configured max of 2" in resp_body["details"]["errors"][0]["msg"]
 
     def test_not_json(self, client: TestClient, endpoint: str) -> None:
-        r = client.post(endpoint, content="not json", headers={"Content-Type": "application/json"})
+        r = client.post(_post_path(endpoint, {}), content="not json", headers={"Content-Type": "application/json"})
         assert r.status_code == 422
 
 
@@ -178,47 +200,51 @@ class TestFilterValidation:
     """Filter operator and value validation."""
 
     def test_filter_missing_operator(self, client: TestClient) -> None:
-        r = client.post("/query/tuples", json={
+        body = {
             "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2026-03-01"},
             "query": {
                 "fields": [{"field": "symbol"}],
                 "filters": [{"field": "symbol", "values": ["AAPL"]}],
             },
-        })
+        }
+        r = client.post(_post_path("tuples", body), json=body)
         assert r.status_code == 422
 
     def test_filter_missing_values(self, client: TestClient) -> None:
-        r = client.post("/query/tuples", json={
+        body = {
             "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2026-03-01"},
             "query": {
                 "fields": [{"field": "symbol"}],
                 "filters": [{"field": "symbol", "operator": "INCLUDE"}],
             },
-        })
+        }
+        r = client.post(_post_path("tuples", body), json=body)
         assert r.status_code == 422
 
     def test_invalid_operator_rejected(self, client: TestClient) -> None:
-        r = client.post("/query/tuples", json={
+        body = {
             "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2026-03-01"},
             "query": {
                 "fields": [{"field": "symbol"}],
                 "filters": [{"field": "symbol", "operator": "INVALID", "values": ["x"]}],
             },
-        })
+        }
+        r = client.post(_post_path("tuples", body), json=body)
         assert r.status_code == 422
 
     def test_lowercase_operator_rejected(self, client: TestClient) -> None:
-        r = client.post("/query/tuples", json={
+        body = {
             "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2026-03-01"},
             "query": {
                 "fields": [{"field": "symbol"}],
                 "filters": [{"field": "symbol", "operator": "include", "values": ["x"]}],
             },
-        })
+        }
+        r = client.post(_post_path("tuples", body), json=body)
         assert r.status_code == 422
 
 
@@ -226,63 +252,69 @@ class TestSortValidation:
     """Sort direction validation."""
 
     def test_invalid_sort_rejected(self, client: TestClient) -> None:
-        r = client.post("/query/tuples", json={
+        body = {
             "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2026-03-01"},
             "query": {
                 "fields": [{"field": "symbol", "sort": "RANDOM"}],
             },
-        })
+        }
+        r = client.post(_post_path("tuples", body), json=body)
         assert r.status_code == 422
 
     def test_lowercase_sort_rejected(self, client: TestClient) -> None:
-        r = client.post("/query/tuples", json={
+        body = {
             "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2026-03-01"},
             "query": {
                 "fields": [{"field": "symbol", "sort": "asc"}],
             },
-        })
+        }
+        r = client.post(_post_path("tuples", body), json=body)
         assert r.status_code == 422
 
 
 class TestPagingValidation:
     """Paging bounds validation across tuples and picklist endpoints."""
 
-    @pytest.mark.parametrize("endpoint", ["/query/tuples", "/query/picklist"])
+    @pytest.mark.parametrize("endpoint", ["tuples", "picklist"])
     def test_limit_zero_rejected(self, client: TestClient, endpoint: str) -> None:
-        r = client.post(endpoint, json={
+        body = {
             "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2026-03-01"},
             "query": {"fields": [{"field": "symbol"}], "field": "symbol", "paging": {"limit": 0}},
-        })
+        }
+        r = client.post(_post_path(endpoint, body), json=body)
         assert r.status_code == 422
 
-    @pytest.mark.parametrize("endpoint", ["/query/tuples", "/query/picklist"])
+    @pytest.mark.parametrize("endpoint", ["tuples", "picklist"])
     def test_limit_negative_rejected(self, client: TestClient, endpoint: str) -> None:
-        r = client.post(endpoint, json={
+        body = {
             "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2026-03-01"},
             "query": {"fields": [{"field": "symbol"}], "field": "symbol", "paging": {"limit": -5}},
-        })
+        }
+        r = client.post(_post_path(endpoint, body), json=body)
         assert r.status_code == 422
 
-    @pytest.mark.parametrize("endpoint", ["/query/tuples", "/query/picklist"])
+    @pytest.mark.parametrize("endpoint", ["tuples", "picklist"])
     def test_limit_exceeds_max_rejected(self, client: TestClient, endpoint: str) -> None:
-        r = client.post(endpoint, json={
+        body = {
             "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2026-03-01"},
             "query": {"fields": [{"field": "symbol"}], "field": "symbol", "paging": {"limit": 10001}},
-        })
+        }
+        r = client.post(_post_path(endpoint, body), json=body)
         assert r.status_code == 422
 
-    @pytest.mark.parametrize("endpoint", ["/query/tuples", "/query/picklist"])
+    @pytest.mark.parametrize("endpoint", ["tuples", "picklist"])
     def test_offset_negative_rejected(self, client: TestClient, endpoint: str) -> None:
-        r = client.post(endpoint, json={
+        body = {
             "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2026-03-01"},
             "query": {"fields": [{"field": "symbol"}], "field": "symbol", "paging": {"offset": -1}},
-        })
+        }
+        r = client.post(_post_path(endpoint, body), json=body)
         assert r.status_code == 422
 
 
@@ -290,7 +322,7 @@ class TestAxesValidation:
     """Typed axes model validation — invalid aggregation rejected at parse time."""
 
     def test_invalid_aggregation_in_cells_rejected(self, client: TestClient) -> None:
-        r = client.post("/query/cells", json={
+        body = {
             "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2026-03-01"},
             "query": {
@@ -299,13 +331,14 @@ class TestAxesValidation:
                     "measures": [{"field": "volume", "aggregation": "INVALID"}],
                 },
             },
-        })
+        }
+        r = client.post(_post_path("cells", body), json=body)
         assert r.status_code == 422
         body = r.json()
         assert body["code"] == "VALIDATION_ERROR"
 
     def test_invalid_aggregation_in_export_rejected(self, client: TestClient) -> None:
-        r = client.post("/export", json={
+        r = client.post("/api/v1/exports", json={
             "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2026-03-01"},
             "query": {
@@ -324,7 +357,7 @@ class TestExportValidation:
     """Export-specific field validation."""
 
     def test_invalid_format_rejected(self, client: TestClient) -> None:
-        r = client.post("/export", json={
+        r = client.post("/api/v1/exports", json={
             "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2026-03-01"},
             "query": {"format": "xlsx"},
@@ -332,7 +365,7 @@ class TestExportValidation:
         assert r.status_code == 422
 
     def test_max_rows_zero_rejected(self, client: TestClient) -> None:
-        r = client.post("/export", json={
+        r = client.post("/api/v1/exports", json={
             "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2026-03-01"},
             "query": {"max_rows": 0},
@@ -340,7 +373,7 @@ class TestExportValidation:
         assert r.status_code == 422
 
     def test_max_rows_negative_rejected(self, client: TestClient) -> None:
-        r = client.post("/export", json={
+        r = client.post("/api/v1/exports", json={
             "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2026-03-01"},
             "query": {"max_rows": -10},
@@ -348,7 +381,7 @@ class TestExportValidation:
         assert r.status_code == 422
 
     def test_max_rows_exceeds_limit_rejected(self, client: TestClient) -> None:
-        r = client.post("/export", json={
+        r = client.post("/api/v1/exports", json={
             "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2026-03-01"},
             "query": {"max_rows": 100001},
@@ -358,38 +391,40 @@ class TestExportValidation:
 
 class TestSchemaValidation:
     def test_missing_dataset_id_param(self, client: TestClient) -> None:
-        r = client.get("/schema")
-        assert r.status_code == 422
+        r = client.get("/api/v1/datasets//schema")
+        assert r.status_code == 404
 
 
 class TestUnknownSchemaFields:
     def test_unknown_tuples_field_rejected(self, client: TestClient) -> None:
-        r = client.post("/query/tuples", json={
+        body = {
             "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2026-03-01"},
             "query": {"fields": [{"field": "not_a_field"}]},
-        })
+        }
+        r = client.post(_post_path("tuples", body), json=body)
         assert r.status_code == 422
         body = r.json()
         assert body["code"] == "VALIDATION_ERROR"
         assert body["details"]["errors"][0]["loc"] == ["body", "query", "fields", 0, "field"]
 
     def test_unknown_filter_field_rejected(self, client: TestClient) -> None:
-        r = client.post("/query/tuples", json={
+        body = {
             "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2026-03-01"},
             "query": {
                 "fields": [{"field": "symbol"}],
                 "filters": [{"field": "not_a_field", "operator": "INCLUDE", "values": ["AAPL"]}],
             },
-        })
+        }
+        r = client.post(_post_path("tuples", body), json=body)
         assert r.status_code == 422
         body = r.json()
         assert body["code"] == "VALIDATION_ERROR"
         assert body["details"]["errors"][0]["loc"] == ["body", "query", "filters", 0, "field"]
 
     def test_unknown_cells_axis_or_measure_rejected(self, client: TestClient) -> None:
-        r = client.post("/query/cells", json={
+        body = {
             "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2026-03-01"},
             "query": {
@@ -399,25 +434,27 @@ class TestUnknownSchemaFields:
                     "measures": [{"field": "also_not_a_field", "aggregation": "SUM", "alias": "bad"}],
                 },
             },
-        })
+        }
+        r = client.post(_post_path("cells", body), json=body)
         assert r.status_code == 422
         body = r.json()
         assert body["code"] == "VALIDATION_ERROR"
         assert len(body["details"]["errors"]) == 2
 
     def test_unknown_picklist_field_rejected(self, client: TestClient) -> None:
-        r = client.post("/query/picklist", json={
+        body = {
             "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2026-03-01"},
             "query": {"field": "not_a_field"},
-        })
+        }
+        r = client.post(_post_path("picklist", body), json=body)
         assert r.status_code == 422
         body = r.json()
         assert body["code"] == "VALIDATION_ERROR"
         assert body["details"]["errors"][0]["loc"] == ["body", "query", "field"]
 
     def test_unknown_export_field_rejected(self, client: TestClient) -> None:
-        r = client.post("/export", json={
+        r = client.post("/api/v1/exports", json={
             "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2026-03-01"},
             "query": {

--- a/server/tests/test_validation_errors.py
+++ b/server/tests/test_validation_errors.py
@@ -211,6 +211,24 @@ class TestFilterValidation:
         r = client.post(_post_path("tuples", body), json=body)
         assert r.status_code == 422
 
+
+class TestVersionedDatasetIdValidation:
+    @pytest.mark.parametrize("endpoint", QUERY_ENDPOINTS)
+    def test_dataset_id_must_match_path(self, client: TestClient, endpoint: str) -> None:
+        body = _valid_body_for(endpoint)
+        body["dataset_id"] = "trades_v1"
+        r = client.post(f"/api/v1/datasets/other_ds/query/{endpoint}", json=body)
+        assert r.status_code == 422
+        payload = r.json()
+        assert payload["code"] == "VALIDATION_ERROR"
+        error = payload["details"]["errors"][0]
+        assert error["loc"] == ["body", "dataset_id"]
+        assert error["type"] == "value_error.dataset_id_mismatch"
+        assert error["ctx"] == {
+            "path_dataset_id": "other_ds",
+            "body_dataset_id": "trades_v1",
+        }
+
     def test_filter_missing_values(self, client: TestClient) -> None:
         body = {
             "dataset_id": "trades_v1",

--- a/src/DataSource/remote/RemoteDatasource.js
+++ b/src/DataSource/remote/RemoteDatasource.js
@@ -43,6 +43,12 @@ function buildEnvelope(datasetId, dateRange, query, clientContext) {
   return envelope;
 }
 
+function buildDatasetPath(datasource, suffix) {
+  const baseUrl = datasource.getBaseUrl();
+  const datasetId = datasource.getDatasetId();
+  return `${baseUrl}/api/v1/datasets/${encodeURIComponent(datasetId)}${suffix}`;
+}
+
 function buildHeaders(datasource, includeJson) {
   const headers = {};
   if (includeJson) {
@@ -73,9 +79,7 @@ class RemoteConnection {
   }
 
   getSchema() {
-    const baseUrl = this.#datasource.getBaseUrl();
-    const datasetId = this.#datasource.getDatasetId();
-    const url = `${baseUrl}/schema?dataset_id=${encodeURIComponent(datasetId)}`;
+    const url = buildDatasetPath(this.#datasource, '/schema');
     this.#abortController = new AbortController();
     return fetch(url, {
       signal: this.#abortController.signal,
@@ -98,11 +102,10 @@ class RemoteConnection {
   }
 
   fetchTuples(dateRange, query, clientContext) {
-    const baseUrl = this.#datasource.getBaseUrl();
     const datasetId = this.#datasource.getDatasetId();
     const envelope = buildEnvelope(datasetId, dateRange, query, clientContext);
     this.#abortController = new AbortController();
-    return fetch(`${baseUrl}/query/tuples`, {
+    return fetch(buildDatasetPath(this.#datasource, '/query/tuples'), {
       method: 'POST',
       headers: buildHeaders(this.#datasource, true),
       body: JSON.stringify(envelope),
@@ -125,11 +128,10 @@ class RemoteConnection {
   }
 
   fetchCells(dateRange, query, clientContext) {
-    const baseUrl = this.#datasource.getBaseUrl();
     const datasetId = this.#datasource.getDatasetId();
     const envelope = buildEnvelope(datasetId, dateRange, query, clientContext);
     this.#abortController = new AbortController();
-    return fetch(`${baseUrl}/query/cells`, {
+    return fetch(buildDatasetPath(this.#datasource, '/query/cells'), {
       method: 'POST',
       headers: buildHeaders(this.#datasource, true),
       body: JSON.stringify(envelope),
@@ -152,11 +154,10 @@ class RemoteConnection {
   }
 
   fetchPicklist(dateRange, query, clientContext) {
-    const baseUrl = this.#datasource.getBaseUrl();
     const datasetId = this.#datasource.getDatasetId();
     const envelope = buildEnvelope(datasetId, dateRange, query, clientContext);
     this.#abortController = new AbortController();
-    return fetch(`${baseUrl}/query/picklist`, {
+    return fetch(buildDatasetPath(this.#datasource, '/query/picklist'), {
       method: 'POST',
       headers: buildHeaders(this.#datasource, true),
       body: JSON.stringify(envelope),

--- a/src/DataSource/remote/RemoteDatasourceConfig.js
+++ b/src/DataSource/remote/RemoteDatasourceConfig.js
@@ -4,7 +4,7 @@
  *
  * Config shape:
  * - type: 'remote'
- * - baseUrl: string (QueryService base URL, e.g. 'https://api.example.com')
+ * - baseUrl: string (QueryService base URL, e.g. 'https://api.example.com'; v1 paths are appended automatically)
  * - datasetId: string (logical dataset id, e.g. 'trades_v1')
  * - id: string (optional; stable id for this datasource instance in the UI)
  */

--- a/tests/test_backend_benchmark_runner.py
+++ b/tests/test_backend_benchmark_runner.py
@@ -14,7 +14,12 @@ from threading import Thread
 class _BenchmarkHandler(BaseHTTPRequestHandler):
     def do_POST(self) -> None:  # noqa: N802
         self.rfile.read(int(self.headers.get("content-length", "0")))
-        if self.path in {"/query/tuples", "/query/cells", "/query/picklist", "/export"}:
+        if self.path in {
+            "/api/v1/datasets/trades_v1/query/tuples",
+            "/api/v1/datasets/trades_v1/query/cells",
+            "/api/v1/datasets/trades_v1/query/picklist",
+            "/api/v1/exports",
+        }:
             payload = b'{"ok":true}'
             self.send_response(200)
             self.send_header("Content-Type", "application/json")

--- a/tests/ui/remote-mode.spec.js
+++ b/tests/ui/remote-mode.spec.js
@@ -51,10 +51,10 @@ test.describe('Remote mode UI', () => {
       ],
     };
 
-    await page.route('**/schema?dataset_id=*', (route) => route.fulfill({ status: 200, body: JSON.stringify(schemaResponse) }));
-    await page.route('**/query/tuples', (route) => route.fulfill({ status: 200, body: JSON.stringify(tuplesResponse) }));
-    await page.route('**/query/cells', (route) => route.fulfill({ status: 200, body: JSON.stringify(cellsResponse) }));
-    await page.route('**/query/picklist', (route) => route.fulfill({ status: 200, body: JSON.stringify({ total_count: 3, values: [{ value: 'AAPL', label: 'AAPL' }], paging: { limit: 100, offset: 0, returned: 1 } }) }));
+    await page.route('**/api/v1/datasets/*/schema', (route) => route.fulfill({ status: 200, body: JSON.stringify(schemaResponse) }));
+    await page.route('**/api/v1/datasets/*/query/tuples', (route) => route.fulfill({ status: 200, body: JSON.stringify(tuplesResponse) }));
+    await page.route('**/api/v1/datasets/*/query/cells', (route) => route.fulfill({ status: 200, body: JSON.stringify(cellsResponse) }));
+    await page.route('**/api/v1/datasets/*/query/picklist', (route) => route.fulfill({ status: 200, body: JSON.stringify({ total_count: 3, values: [{ value: 'AAPL', label: 'AAPL' }], paging: { limit: 100, offset: 0, returned: 1 } }) }));
 
     await waitForAppReady(page);
     await expect(page.locator('#addRemoteDatasource')).toBeVisible({ timeout: 10000 });


### PR DESCRIPTION
## Summary
- add the v1 backend routing infrastructure under `/api/v1`
- add the service root and startup probe
- mount versioned query/schema/export aliases while keeping old routes available but out of schema
- move OpenAPI/docs/redoc to versioned URLs and allow DELETE in CORS

Implements #404

## Validation
- ./.venv-server/bin/pytest server/tests/test_health.py server/tests/test_schema_api.py server/tests/test_query_tuples_api.py server/tests/test_query_cells_api.py server/tests/test_query_picklist_api.py server/tests/test_export_api.py server/tests/test_api_v1_routing.py -q
