### PR TITLE
Add v1 response headers and header-based client metadata

### DIFF
--- a/docs/server/README.md
+++ b/docs/server/README.md
@@ -120,6 +120,13 @@ PYTHONPATH=. ./.venv-server/bin/uvicorn server.main:app --host 0.0.0.0 --port 80
 - When enabled, clients must send `X-API-Key`
 - Health endpoints remain accessible without API key
 
+### Request and response metadata
+
+- `X-Request-ID` can be supplied by clients and is echoed back in responses.
+- `X-Client-Version` can be supplied by clients and is included in server logs.
+- API responses include `X-API-Version: 1`.
+- When rate limiting is enabled, API responses include `X-RateLimit-*` headers, and `429` responses include `Retry-After`.
+
 ### Request conventions
 
 - Query/export requests use an envelope with `dataset_id`, `date_range`, and `query`

--- a/docs/server/api-reference.md
+++ b/docs/server/api-reference.md
@@ -18,10 +18,17 @@ Interactive OpenAPI:
 - Protected endpoints require `X-API-Key` only when `QUERYSERVICE_AUTH_ENABLED=true`.
 - Health endpoints do not require API key.
 
-### Correlation IDs
+### Request metadata headers
 
 - `X-Request-ID` is accepted and echoed in response headers.
+- `X-Client-Version` is accepted on query/export requests and recorded in server logs.
 - Error envelopes usually include `request_id` when available.
+
+### Standard response headers
+
+- `X-API-Version: 1` is returned on API responses.
+- `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` are returned when rate limiting is enabled for the endpoint.
+- `Retry-After` is returned on `429` responses.
 
 ### Shared request envelope (query/export)
 

--- a/docs/server/api-reference.md
+++ b/docs/server/api-reference.md
@@ -21,7 +21,7 @@ Interactive OpenAPI:
 ### Request metadata headers
 
 - `X-Request-ID` is accepted and echoed in response headers.
-- `X-Client-Version` is accepted on query/export requests and recorded in server logs.
+- `X-Client-Version` is accepted on requests and recorded in server logs.
 - Error envelopes usually include `request_id` when available.
 
 ### Standard response headers

--- a/server/logging_config.py
+++ b/server/logging_config.py
@@ -17,10 +17,10 @@ from server.request_context import get_client_version, get_request_id
 
 
 class RequestIdFilter(logging.Filter):
-    """Inject the current correlation ID into every log record."""
+    """Inject request-scoped metadata into every log record."""
 
     def filter(self, record: logging.LogRecord) -> bool:
-        """Attach request_id (if any) so formatters can include it."""
+        """Attach request_id and client_version so formatters can include them."""
         record.request_id = get_request_id()  # type: ignore[attr-defined]
         record.client_version = get_client_version()  # type: ignore[attr-defined]
         return True

--- a/server/logging_config.py
+++ b/server/logging_config.py
@@ -13,7 +13,7 @@ import sys
 
 from pythonjsonlogger.json import JsonFormatter
 
-from server.request_context import get_request_id
+from server.request_context import get_client_version, get_request_id
 
 
 class RequestIdFilter(logging.Filter):
@@ -22,6 +22,7 @@ class RequestIdFilter(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:
         """Attach request_id (if any) so formatters can include it."""
         record.request_id = get_request_id()  # type: ignore[attr-defined]
+        record.client_version = get_client_version()  # type: ignore[attr-defined]
         return True
 
 

--- a/server/main.py
+++ b/server/main.py
@@ -130,7 +130,8 @@ app.include_router(v1_router)
 
 
 @app.get("/api/v1", include_in_schema=False)
-async def api_root() -> dict[str, object]:
+@limiter.limit(lambda: get_settings().rate_limit_query)
+async def api_root(request: Request) -> dict[str, object]:
     """Service root for the versioned v1 API."""
     build = os.getenv("QUERYSERVICE_BUILD", "dev")
     return {

--- a/server/middleware.py
+++ b/server/middleware.py
@@ -7,7 +7,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
 
-from server.request_context import generate_request_id, set_request_id
+from server.request_context import generate_request_id, set_client_version, set_request_id
 
 logger = logging.getLogger("query_service.access")
 
@@ -15,21 +15,24 @@ logger = logging.getLogger("query_service.access")
 class CorrelationIdMiddleware(BaseHTTPMiddleware):
     """Extract or generate a correlation ID and attach it to the response.
 
-    The ID is stored on request.state so route handlers can override it
-    (e.g. from client_context.request_id) and the override propagates
-    back to the response header.
+    The ID and optional client version are stored on request.state and
+    reflected back through response/logging metadata.
     """
 
     async def dispatch(self, request: Request, call_next) -> Response:
         """Assign a correlation ID for the request and propagate it to the response."""
         request_id = request.headers.get("X-Request-ID") or generate_request_id()
+        client_version = request.headers.get("X-Client-Version", "")
         request.state.request_id = request_id
+        request.state.client_version = client_version
         set_request_id(request_id)
+        set_client_version(client_version)
 
         response = await call_next(request)
         response.headers["X-Request-ID"] = getattr(
             request.state, "request_id", request_id
         )
+        response.headers["X-API-Version"] = "1"
         return response
 
 
@@ -54,6 +57,7 @@ class AccessLogMiddleware(BaseHTTPMiddleware):
                 "status_code": response.status_code,
                 "duration_ms": round(duration_ms, 2),
                 "client_ip": request.client.host if request.client else None,
+                "client_version": getattr(request.state, "client_version", ""),
             },
         )
         return response

--- a/server/models.py
+++ b/server/models.py
@@ -141,15 +141,6 @@ DateRange = Annotated[
 ]
 
 
-# --- Common envelope ---
-class ClientContext(BaseModel):
-    """Optional client metadata propagated through logs and responses."""
-
-    user_id: str | None = None
-    request_id: str | None = None
-    huey_version: str | None = None
-
-
 # --- Shared query components ---
 class TupleFieldSpec(BaseModel):
     """Dimension or measure requested in tuple queries, with sort/totals flags."""
@@ -258,7 +249,6 @@ class QueryTuplesRequest(BaseModel):
     dataset_id: str
     date_range: DateRange
     query: TuplesQueryBody = TuplesQueryBody()
-    client_context: ClientContext | None = None
 
 
 class QueryCellsRequest(BaseModel):
@@ -267,7 +257,6 @@ class QueryCellsRequest(BaseModel):
     dataset_id: str
     date_range: DateRange
     query: CellsQueryBody = CellsQueryBody()
-    client_context: ClientContext | None = None
 
 
 class QueryPicklistRequest(BaseModel):
@@ -276,7 +265,6 @@ class QueryPicklistRequest(BaseModel):
     dataset_id: str
     date_range: DateRange
     query: PicklistQueryBody = PicklistQueryBody()
-    client_context: ClientContext | None = None
 
 
 class ExportRequest(BaseModel):
@@ -285,7 +273,6 @@ class ExportRequest(BaseModel):
     dataset_id: str
     date_range: DateRange
     query: ExportQueryBody = ExportQueryBody()
-    client_context: ClientContext | None = None
 
 
 # --- Response models ---

--- a/server/request_context.py
+++ b/server/request_context.py
@@ -1,8 +1,9 @@
 """
-Contextvars-based request context for correlation ID propagation.
+Contextvars-based request metadata propagation.
 
-The request ID is set by CorrelationIdMiddleware and flows through
-the entire request lifecycle for logging and tracing.
+Request-scoped metadata such as the correlation ID and client version
+is set by middleware and flows through the request lifecycle for
+logging and tracing.
 """
 
 import contextvars

--- a/server/request_context.py
+++ b/server/request_context.py
@@ -11,6 +11,9 @@ import uuid
 request_id_var: contextvars.ContextVar[str] = contextvars.ContextVar(
     "request_id", default=""
 )
+client_version_var: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "client_version", default=""
+)
 
 
 def get_request_id() -> str:
@@ -21,6 +24,16 @@ def get_request_id() -> str:
 def set_request_id(request_id: str) -> contextvars.Token:
     """Set the correlation ID for the current request context."""
     return request_id_var.set(request_id)
+
+
+def get_client_version() -> str:
+    """Return the current request's client version header value, if any."""
+    return client_version_var.get()
+
+
+def set_client_version(client_version: str) -> contextvars.Token:
+    """Set the client version for the current request context."""
+    return client_version_var.set(client_version)
 
 
 def generate_request_id() -> str:

--- a/server/routers/export.py
+++ b/server/routers/export.py
@@ -20,7 +20,6 @@ from server.export_service import get_export_service
 from server.models import ExportRequest, ExportResponse, ExportStatusResponse
 from server.query_builder import validate_export_query_fields
 from server.rate_limit import limiter
-from server.request_context import set_request_id
 
 logger = logging.getLogger("query_service.export")
 
@@ -37,10 +36,6 @@ async def post_export(
     _api_key: str = Depends(require_api_key),
 ) -> ExportResponse:
     """POST /api/v1/exports."""
-    if body.client_context and body.client_context.request_id:
-        rid = body.client_context.request_id
-        set_request_id(rid)
-        request.state.request_id = rid
     if datasets.get_schema(body.dataset_id) is None:
         raise DatasetNotFoundError(body.dataset_id)
     settings = get_settings()
@@ -55,7 +50,8 @@ async def post_export(
 
 
 @router.get("/{export_id}", response_model=ExportStatusResponse)
-async def get_export_status(export_id: str, _api_key: str = Depends(require_api_key)) -> ExportStatusResponse:
+@limiter.limit(lambda: get_settings().rate_limit_export)
+async def get_export_status(request: Request, export_id: str, _api_key: str = Depends(require_api_key)) -> ExportStatusResponse:
     """GET /api/v1/exports/{export_id}."""
     service = get_export_service()
     job = service.get_status(export_id)
@@ -68,7 +64,8 @@ async def get_export_status(export_id: str, _api_key: str = Depends(require_api_
 
 
 @router.get("/{export_id}/download")
-async def download_export(export_id: str, _api_key: str = Depends(require_api_key)) -> FileResponse:
+@limiter.limit(lambda: get_settings().rate_limit_export)
+async def download_export(request: Request, export_id: str, _api_key: str = Depends(require_api_key)) -> FileResponse:
     """GET /api/v1/exports/{export_id}/download."""
     service = get_export_service()
     file_path = service.get_download_path(export_id)

--- a/server/routers/query.py
+++ b/server/routers/query.py
@@ -33,7 +33,6 @@ from server.query_builder import (
     build_tuples_sql,
 )
 from server.rate_limit import limiter
-from server.request_context import set_request_id
 
 logger = logging.getLogger("query_service.query")
 router = APIRouter(prefix="/query", tags=["query"])
@@ -67,14 +66,6 @@ def _canonical_dataset_id(request: Request, body_dataset_id: str) -> str:
     return path_dataset_id
 
 
-def _apply_client_request_id(body, request: Request) -> None:
-    """Override correlation ID with client_context.request_id when provided."""
-    if body.client_context and body.client_context.request_id:
-        rid = body.client_context.request_id
-        set_request_id(rid)
-        request.state.request_id = rid
-
-
 def _time_filter_metadata(dataset_id: str) -> tuple[bool, str | None]:
     """Describe whether date_range is actively applied for dataset execution."""
     settings = get_settings()
@@ -105,7 +96,6 @@ async def post_query_tuples(
     _api_key: str = Depends(require_api_key),
 ) -> TuplesResponse:
     """POST /api/v1/datasets/{dataset_id}/query/tuples."""
-    _apply_client_request_id(body, request)
     dataset_id = _canonical_dataset_id(request, body.dataset_id)
     body.dataset_id = dataset_id
     settings = get_settings()
@@ -222,7 +212,6 @@ async def post_query_cells(
     _api_key: str = Depends(require_api_key),
 ) -> CellsResponse:
     """POST /api/v1/datasets/{dataset_id}/query/cells."""
-    _apply_client_request_id(body, request)
     dataset_id = _canonical_dataset_id(request, body.dataset_id)
     body.dataset_id = dataset_id
     settings = get_settings()
@@ -369,7 +358,6 @@ async def post_query_picklist(
     _api_key: str = Depends(require_api_key),
 ) -> PicklistResponse:
     """POST /api/v1/datasets/{dataset_id}/query/picklist."""
-    _apply_client_request_id(body, request)
     dataset_id = _canonical_dataset_id(request, body.dataset_id)
     body.dataset_id = dataset_id
     settings = get_settings()

--- a/server/routers/schema.py
+++ b/server/routers/schema.py
@@ -2,17 +2,20 @@
 Schema endpoint under /api/v1/datasets/{dataset_id}/schema.
 """
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 
 from server import datasets
 from server.auth import require_api_key
+from server.config import get_settings
 from server.errors import DatasetNotFoundError
+from server.rate_limit import limiter
 
 router = APIRouter(tags=["schema"])
 
 
 @router.get("/schema")
-async def get_schema(dataset_id: str, _api_key: str = Depends(require_api_key)) -> dict:
+@limiter.limit(lambda: get_settings().rate_limit_query)
+async def get_schema(request: Request, dataset_id: str, _api_key: str = Depends(require_api_key)) -> dict:
     """
     Fetch schema metadata for a dataset.
     GET /api/v1/datasets/{dataset_id}/schema

--- a/server/tests/test_api_v1_routing.py
+++ b/server/tests/test_api_v1_routing.py
@@ -8,6 +8,7 @@ from server.routers import health
 def test_api_v1_root(client: TestClient) -> None:
     r = client.get("/api/v1")
     assert r.status_code == 200
+    assert r.headers["X-API-Version"] == "1"
     data = r.json()
     assert data["service"] == "huey-queryservice"
     assert data["api_version"] == "1"
@@ -44,6 +45,7 @@ def test_health_startup_probe(client: TestClient) -> None:
 def test_versioned_schema_route(client: TestClient) -> None:
     r = client.get("/api/v1/datasets/trades_v1/schema")
     assert r.status_code == 200
+    assert r.headers["X-API-Version"] == "1"
     data = r.json()
     assert data["dataset_id"] == "trades_v1"
 

--- a/server/tests/test_correlation.py
+++ b/server/tests/test_correlation.py
@@ -39,6 +39,7 @@ class TestCorrelationIdMiddleware:
     def test_response_includes_request_id(self, client: TestClient) -> None:
         r = client.get("/health/liveness")
         assert "X-Request-ID" in r.headers
+        assert r.headers["X-API-Version"] == "1"
         assert len(r.headers["X-Request-ID"]) > 0
 
     def test_custom_request_id_echoed(self, client: TestClient) -> None:
@@ -65,13 +66,17 @@ class TestCorrelationIdMiddleware:
         assert len(r.headers["X-Request-ID"]) > 0
 
 
-class TestClientContextOverride:
-    def test_client_context_request_id_overrides(self, client: TestClient) -> None:
-        body = _query_body(client_context={"request_id": "frontend-456"})
-        r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
+class TestRequestMetadataHeaders:
+    def test_request_id_header_propagates_to_tuples(self, client: TestClient) -> None:
+        body = _query_body()
+        r = client.post(
+            f"/api/v1/datasets/{body['dataset_id']}/query/tuples",
+            json=body,
+            headers={"X-Request-ID": "frontend-456"},
+        )
         assert r.headers["X-Request-ID"] == "frontend-456"
 
-    def test_client_context_on_cells(self, client: TestClient) -> None:
+    def test_request_id_header_propagates_to_cells(self, client: TestClient) -> None:
         body = {
             "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2026-03-01"},
@@ -81,39 +86,60 @@ class TestClientContextOverride:
                     "measures": [{"field": "volume", "aggregation": "SUM", "alias": "vol"}],
                 },
             },
-            "client_context": {"request_id": "cells-trace-789"},
         }
-        r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
+        r = client.post(
+            f"/api/v1/datasets/{body['dataset_id']}/query/cells",
+            json=body,
+            headers={"X-Request-ID": "cells-trace-789"},
+        )
         assert r.headers["X-Request-ID"] == "cells-trace-789"
 
-    def test_client_context_on_picklist(self, client: TestClient) -> None:
+    def test_request_id_header_propagates_to_picklist(self, client: TestClient) -> None:
         body = {
             "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2026-03-01"},
             "query": {"field": "symbol"},
-            "client_context": {"request_id": "picklist-trace-abc"},
         }
-        r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
+        r = client.post(
+            f"/api/v1/datasets/{body['dataset_id']}/query/picklist",
+            json=body,
+            headers={"X-Request-ID": "picklist-trace-abc"},
+        )
         assert r.headers["X-Request-ID"] == "picklist-trace-abc"
 
-    def test_client_context_on_export(self, client: TestClient) -> None:
+    def test_request_id_header_propagates_to_export(self, client: TestClient) -> None:
         body = {
             "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2026-03-01"},
             "query": {"axes": {}, "format": "csv"},
-            "client_context": {"request_id": "export-trace-def"},
         }
-        r = client.post("/api/v1/exports", json=body)
+        r = client.post(
+            "/api/v1/exports",
+            json=body,
+            headers={"X-Request-ID": "export-trace-def"},
+        )
         assert r.headers["X-Request-ID"] == "export-trace-def"
 
-    def test_no_client_context_uses_header(self, client: TestClient) -> None:
+    def test_client_version_header_is_logged(self, client: TestClient, caplog: "pytest.LogCaptureFixture") -> None:
+        body = _query_body()
+        with caplog.at_level(logging.INFO, logger="query_service.access"):
+            client.post(
+                f"/api/v1/datasets/{body['dataset_id']}/query/tuples",
+                json=body,
+                headers={"X-Client-Version": "huey-web/1.2.3"},
+            )
+        assert any(
+            getattr(record, "client_version", "") == "huey-web/1.2.3"
+            for record in caplog.records
+        )
+
+    def test_no_request_id_header_generates_one(self, client: TestClient) -> None:
         body = _query_body()
         r = client.post(
             f"/api/v1/datasets/{body['dataset_id']}/query/tuples",
             json=body,
-            headers={"X-Request-ID": "header-id-999"},
         )
-        assert r.headers["X-Request-ID"] == "header-id-999"
+        assert len(r.headers["X-Request-ID"]) > 0
 
 
 class TestLoggingIncludesRequestId:
@@ -123,7 +149,8 @@ class TestLoggingIncludesRequestId:
         with caplog.at_level(logging.INFO, logger="query_service"):
             client.post(
                 "/api/v1/datasets/trades_v1/query/tuples",
-                json=_query_body(client_context={"request_id": "log-check-42"}),
+                json=_query_body(),
+                headers={"X-Request-ID": "log-check-42"},
             )
         matching = [r for r in caplog.records if hasattr(r, "request_id")]
         assert len(matching) > 0

--- a/server/tests/test_rate_limiting.py
+++ b/server/tests/test_rate_limiting.py
@@ -51,8 +51,13 @@ def _export_body() -> dict:
 
 def test_rate_limit_exceeded(rate_limited_client: TestClient) -> None:
     body = _query_body()
-    for _ in range(2):
-        rate_limited_client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
+    first = rate_limited_client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
+    assert first.headers["X-API-Version"] == "1"
+    assert "X-RateLimit-Limit" in first.headers
+    assert "X-RateLimit-Remaining" in first.headers
+    assert "X-RateLimit-Reset" in first.headers
+    second = rate_limited_client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
+    assert "X-RateLimit-Limit" in second.headers
 
     response = rate_limited_client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
     assert response.status_code == 429
@@ -65,6 +70,7 @@ def test_rate_limit_returns_retry_after(rate_limited_client: TestClient) -> None
 
     response = rate_limited_client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
     assert response.status_code == 429
+    assert response.headers["X-API-Version"] == "1"
     retry_after = response.headers.get("Retry-After")
     assert retry_after is not None
     assert retry_after.isdigit()
@@ -73,7 +79,9 @@ def test_rate_limit_returns_retry_after(rate_limited_client: TestClient) -> None
 def test_export_rate_limit_exceeded(rate_limited_client: TestClient) -> None:
     """POST /exports is rate-limited; exceeding the limit returns 429."""
     # RATE_LIMIT_EXPORT = "1/minute", so two requests should exceed it
-    rate_limited_client.post("/api/v1/exports", json=_export_body())
+    first = rate_limited_client.post("/api/v1/exports", json=_export_body())
+    assert first.headers["X-API-Version"] == "1"
+    assert "X-RateLimit-Limit" in first.headers
 
     response = rate_limited_client.post("/api/v1/exports", json=_export_body())
     assert response.status_code == 429
@@ -84,6 +92,7 @@ def test_export_rate_limit_returns_retry_after(rate_limited_client: TestClient) 
     rate_limited_client.post("/api/v1/exports", json=_export_body())
     response = rate_limited_client.post("/api/v1/exports", json=_export_body())
     assert response.status_code == 429
+    assert response.headers["X-API-Version"] == "1"
     retry_after = response.headers.get("Retry-After")
     assert retry_after is not None
     assert retry_after.isdigit()

--- a/src/DataSource/remote/RemoteDatasource.js
+++ b/src/DataSource/remote/RemoteDatasource.js
@@ -31,16 +31,12 @@ function normalizeDateRange(dateRange) {
   return { type: 'single', date };
 }
 
-function buildEnvelope(datasetId, dateRange, query, clientContext) {
-  const envelope = {
+function buildEnvelope(datasetId, dateRange, query) {
+  return {
     dataset_id: datasetId,
     date_range: normalizeDateRange(dateRange),
     query: query || {}
   };
-  if (clientContext) {
-    envelope.client_context = clientContext;
-  }
-  return envelope;
 }
 
 function buildDatasetPath(datasource, suffix) {
@@ -49,7 +45,7 @@ function buildDatasetPath(datasource, suffix) {
   return `${baseUrl}/api/v1/datasets/${encodeURIComponent(datasetId)}${suffix}`;
 }
 
-function buildHeaders(datasource, includeJson) {
+function buildHeaders(datasource, includeJson, clientContext) {
   const headers = {};
   if (includeJson) {
     headers['Content-Type'] = 'application/json';
@@ -57,6 +53,12 @@ function buildHeaders(datasource, includeJson) {
   const apiKey = datasource.getApiKey && datasource.getApiKey();
   if (apiKey) {
     headers['X-API-Key'] = apiKey;
+  }
+  if (clientContext && typeof clientContext.request_id === 'string' && clientContext.request_id) {
+    headers['X-Request-ID'] = clientContext.request_id;
+  }
+  if (clientContext && typeof clientContext.huey_version === 'string' && clientContext.huey_version) {
+    headers['X-Client-Version'] = clientContext.huey_version;
   }
   return headers;
 }
@@ -103,11 +105,11 @@ class RemoteConnection {
 
   fetchTuples(dateRange, query, clientContext) {
     const datasetId = this.#datasource.getDatasetId();
-    const envelope = buildEnvelope(datasetId, dateRange, query, clientContext);
+    const envelope = buildEnvelope(datasetId, dateRange, query);
     this.#abortController = new AbortController();
     return fetch(buildDatasetPath(this.#datasource, '/query/tuples'), {
       method: 'POST',
-      headers: buildHeaders(this.#datasource, true),
+      headers: buildHeaders(this.#datasource, true, clientContext),
       body: JSON.stringify(envelope),
       signal: this.#abortController.signal
     }).then((res) => {
@@ -129,11 +131,11 @@ class RemoteConnection {
 
   fetchCells(dateRange, query, clientContext) {
     const datasetId = this.#datasource.getDatasetId();
-    const envelope = buildEnvelope(datasetId, dateRange, query, clientContext);
+    const envelope = buildEnvelope(datasetId, dateRange, query);
     this.#abortController = new AbortController();
     return fetch(buildDatasetPath(this.#datasource, '/query/cells'), {
       method: 'POST',
-      headers: buildHeaders(this.#datasource, true),
+      headers: buildHeaders(this.#datasource, true, clientContext),
       body: JSON.stringify(envelope),
       signal: this.#abortController.signal
     }).then((res) => {
@@ -155,11 +157,11 @@ class RemoteConnection {
 
   fetchPicklist(dateRange, query, clientContext) {
     const datasetId = this.#datasource.getDatasetId();
-    const envelope = buildEnvelope(datasetId, dateRange, query, clientContext);
+    const envelope = buildEnvelope(datasetId, dateRange, query);
     this.#abortController = new AbortController();
     return fetch(buildDatasetPath(this.#datasource, '/query/picklist'), {
       method: 'POST',
-      headers: buildHeaders(this.#datasource, true),
+      headers: buildHeaders(this.#datasource, true, clientContext),
       body: JSON.stringify(envelope),
       signal: this.#abortController.signal
     }).then((res) => {

--- a/src/DataSource/remote/RemoteDatasource.js
+++ b/src/DataSource/remote/RemoteDatasource.js
@@ -45,6 +45,10 @@ function buildDatasetPath(datasource, suffix) {
   return `${baseUrl}/api/v1/datasets/${encodeURIComponent(datasetId)}${suffix}`;
 }
 
+function sanitizeHeaderValue(value) {
+  return value.replace(/[\r\n]+/g, '');
+}
+
 function buildHeaders(datasource, includeJson, clientContext) {
   const headers = {};
   if (includeJson) {
@@ -55,10 +59,10 @@ function buildHeaders(datasource, includeJson, clientContext) {
     headers['X-API-Key'] = apiKey;
   }
   if (clientContext && typeof clientContext.request_id === 'string' && clientContext.request_id) {
-    headers['X-Request-ID'] = clientContext.request_id;
+    headers['X-Request-ID'] = sanitizeHeaderValue(clientContext.request_id);
   }
   if (clientContext && typeof clientContext.huey_version === 'string' && clientContext.huey_version) {
-    headers['X-Client-Version'] = clientContext.huey_version;
+    headers['X-Client-Version'] = sanitizeHeaderValue(clientContext.huey_version);
   }
   return headers;
 }


### PR DESCRIPTION
Implements #405 as part of #403.

Summary:
- add `X-API-Version: 1` on API responses
- log `X-Client-Version` via request context
- remove `client_context` from backend request models and routers
- move remote datasource request metadata to headers
- broaden rate-limit header coverage across current v1 GET routes

Validation:
- `./.venv-server/bin/ruff check server/`
- `./.venv-server/bin/pytest server/tests -q`
- `npm run lint:js`