### PR TITLE
Update query endpoints to v1 request shapes

### DIFF
--- a/docs/server/README.md
+++ b/docs/server/README.md
@@ -40,7 +40,7 @@ Typical workflows:
 
 1. Discover datasets with `GET /api/v1/datasets` and inspect metadata with `GET /api/v1/datasets/{dataset_id}`.
 2. Fetch the lightweight field list with `GET /api/v1/datasets/{dataset_id}/schema`.
-3. Build interactive queries with `POST /api/v1/datasets/{dataset_id}/query/tuples`, `POST /api/v1/datasets/{dataset_id}/query/cells`, `POST /api/v1/datasets/{dataset_id}/query/picklist`.
+3. Build interactive queries with `POST /api/v1/datasets/{dataset_id}/query/tuples`, `POST /api/v1/datasets/{dataset_id}/query/cells`, `POST /api/v1/datasets/{dataset_id}/query/members`.
 4. Trigger async export with `POST /api/v1/exports`, poll with `GET /api/v1/exports/{export_id}`, then download.
 
 ## 3. Installation and Setup
@@ -200,9 +200,9 @@ Run tuples query:
 curl -X POST 'http://localhost:8000/api/v1/datasets/trades_v1/query/tuples' \
   -H 'Content-Type: application/json' \
   -d '{
-    "dataset_id": "trades_v1",
     "date_range": {"type": "single", "date": "2026-03-01"},
-    "query": {"fields": [{"field": "symbol", "sort": "ASC"}], "paging": {"limit": 10, "offset": 0}}
+    "fields": [{"field": "symbol", "sort": "ASC"}],
+    "paging": {"limit": 10, "offset": 0}
   }'
 ```
 

--- a/docs/server/api-reference.md
+++ b/docs/server/api-reference.md
@@ -30,13 +30,12 @@ Interactive OpenAPI:
 - `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` are returned when rate limiting is enabled for the endpoint.
 - `Retry-After` is returned on `429` responses.
 
-### Shared request envelope (query/export)
+### Shared request shapes
 
 ```json
 {
-  "dataset_id": "trades_v1",
   "date_range": {"type": "single", "date": "2026-03-01"},
-  "query": {}
+  "... endpoint-specific fields ..."
 }
 ```
 
@@ -128,7 +127,7 @@ Success `200` example:
         "schema": "/api/v1/datasets/trades_v1/schema",
         "tuples": "/api/v1/datasets/trades_v1/query/tuples",
         "cells": "/api/v1/datasets/trades_v1/query/cells",
-        "picklist": "/api/v1/datasets/trades_v1/query/picklist"
+        "picklist": "/api/v1/datasets/trades_v1/query/members"
       }
     }
   ],
@@ -178,7 +177,7 @@ Success `200` example:
     "schema": "/api/v1/datasets/trades_v1/schema",
     "tuples": "/api/v1/datasets/trades_v1/query/tuples",
     "cells": "/api/v1/datasets/trades_v1/query/cells",
-    "picklist": "/api/v1/datasets/trades_v1/query/picklist"
+    "picklist": "/api/v1/datasets/trades_v1/query/members"
   }
 }
 ```
@@ -231,18 +230,17 @@ Authentication: conditional API key.
 
 Request body fields:
 
-- `dataset_id` (string, required)
-- `date_range` (required)
-- `query.fields` (array of objects):
+- `date_range` (optional)
+- `fields` (array of objects):
   - `field` (string, required)
   - `sort` (`ASC` or `DESC`, optional)
   - `derivation` (optional)
   - `include_totals` (optional)
-- `query.filters` (optional):
+- `filters` (optional):
   - `field` (string)
   - `operator` (`INCLUDE`, `EXCLUDE`, `LIKE`, `BETWEEN`)
   - `values` (array)
-- `query.paging` (optional):
+- `paging` (optional):
   - `limit` (`1..10000`, default from config)
   - `offset` (`>=0`)
 
@@ -250,13 +248,10 @@ Request example:
 
 ```json
 {
-  "dataset_id": "trades_v1",
   "date_range": {"type": "single", "date": "2026-03-01"},
-  "query": {
-    "fields": [{"field": "symbol", "sort": "ASC"}],
-    "filters": [{"field": "symbol", "operator": "INCLUDE", "values": ["AAPL", "GOOG"]}],
-    "paging": {"limit": 10, "offset": 0}
-  }
+  "fields": [{"field": "symbol", "sort": "ASC"}],
+  "filters": [{"field": "symbol", "operator": "INCLUDE", "values": ["AAPL", "GOOG"]}],
+  "paging": {"limit": 10, "offset": 0}
 }
 ```
 
@@ -286,32 +281,30 @@ Authentication: conditional API key.
 
 Request body fields:
 
-- `dataset_id` (string, required)
-- `date_range` (required)
-- `query.axes.rows` (array of `{ "field": string }`)
-- `query.axes.columns` (array of `{ "field": string }`)
-- `query.axes.measures` (array):
+- `date_range` (optional)
+- `axes.rows` (array of `{ "field": string }`)
+- `axes.columns` (array of `{ "field": string }`)
+- `axes.measures` (array):
   - `field` (string)
   - `aggregation` (`SUM`, `COUNT`, `AVG`, `MIN`, `MAX`)
   - `alias` (string, optional)
-- `query.rows` and `query.columns` windows (optional):
-  - `start_index` (`>=0`)
-  - `count` (`>=1`)
-- `query.filters` (optional)
+- `window.rows` and `window.columns` (optional):
+  - `offset` (`>=0`)
+  - `limit` (`>=1`)
+- `filters` (optional)
 
 Request example:
 
 ```json
 {
-  "dataset_id": "trades_v1",
   "date_range": {"type": "single", "date": "2026-03-01"},
-  "query": {
-    "rows": {"start_index": 0, "count": 10},
-    "axes": {
-      "rows": [{"field": "symbol"}],
-      "columns": [],
-      "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}]
-    }
+  "window": {
+    "rows": {"offset": 0, "limit": 10}
+  },
+  "axes": {
+    "rows": [{"field": "symbol"}],
+    "columns": [],
+    "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}]
   }
 }
 ```
@@ -336,7 +329,7 @@ Error statuses:
 - `401` auth failure when auth enabled
 - `429` if rate limiting enabled and exceeded
 
-## `POST /api/v1/datasets/{dataset_id}/query/picklist`
+## `POST /api/v1/datasets/{dataset_id}/query/members`
 
 Returns distinct values for one field, typically used for filter UIs.
 
@@ -344,24 +337,20 @@ Authentication: conditional API key.
 
 Request body fields:
 
-- `dataset_id` (string, required)
-- `date_range` (required)
-- `query.field` (string)
-- `query.search` (string, optional; `*` is translated to SQL `%` wildcard)
-- `query.filters` (optional)
-- `query.paging` (optional)
+- `date_range` (optional)
+- `field` (string)
+- `search` (string, optional; `*` is translated to SQL `%` wildcard)
+- `filters` (optional)
+- `paging` (optional)
 
 Request example:
 
 ```json
 {
-  "dataset_id": "trades_v1",
   "date_range": {"type": "range", "start": "2026-03-01", "end": "2026-03-02"},
-  "query": {
-    "field": "symbol",
-    "search": "A*",
-    "paging": {"limit": 10, "offset": 0}
-  }
+  "field": "symbol",
+  "search": "A*",
+  "paging": {"limit": 10, "offset": 0}
 }
 ```
 

--- a/docs/server/api-reference.md
+++ b/docs/server/api-reference.md
@@ -127,7 +127,7 @@ Success `200` example:
         "schema": "/api/v1/datasets/trades_v1/schema",
         "tuples": "/api/v1/datasets/trades_v1/query/tuples",
         "cells": "/api/v1/datasets/trades_v1/query/cells",
-        "picklist": "/api/v1/datasets/trades_v1/query/members"
+        "members": "/api/v1/datasets/trades_v1/query/members"
       }
     }
   ],
@@ -177,7 +177,7 @@ Success `200` example:
     "schema": "/api/v1/datasets/trades_v1/schema",
     "tuples": "/api/v1/datasets/trades_v1/query/tuples",
     "cells": "/api/v1/datasets/trades_v1/query/cells",
-    "picklist": "/api/v1/datasets/trades_v1/query/members"
+    "members": "/api/v1/datasets/trades_v1/query/members"
   }
 }
 ```

--- a/docs/server/configuration-reference.md
+++ b/docs/server/configuration-reference.md
@@ -107,12 +107,12 @@ Query cache keys use two deterministic version tokens:
   - Derived from partition metadata fingerprints for the requested `date_range`.
   - Only partitions intersecting the requested date scope contribute to the token.
   - This preserves cache entries for closed historical ranges when a new COBDATE is published outside the requested scope.
-- **`dim_version_token`** (for `/api/v1/datasets/{dataset_id}/query/picklist`)
+- **`dim_version_token`** (for `/api/v1/datasets/{dataset_id}/query/members`)
   - Derived from dataset config identity + field definitions, with optional external override via `QUERYSERVICE_DIM_VERSION_TOKEN`.
 
 These tokens align with the WORM invariants: fact changes occur at COBDATE boundaries, historical partitions are immutable once finalized, and dimension/reference updates are infrequent.
 
-## Dimension Dictionary Cache (`/api/v1/datasets/{dataset_id}/query/picklist`)
+## Dimension Dictionary Cache (`/api/v1/datasets/{dataset_id}/query/members`)
 
 Picklist / filter-dropdown queries are backed by a dedicated dimension cache
 with a longer default TTL and optional stale-while-revalidate behaviour,
@@ -153,7 +153,7 @@ on a fresh computation.
 
 ## Endpoint cache policy
 
-- `/api/v1/datasets/{dataset_id}/query/picklist`: aggressive cache policy (long TTL + optional stale-while-revalidate).
+- `/api/v1/datasets/{dataset_id}/query/members`: aggressive cache policy (long TTL + optional stale-while-revalidate).
 - `/api/v1/datasets/{dataset_id}/query/tuples`: moderate/aggressive fact cache policy using `fact_version_token`.
 - `/api/v1/datasets/{dataset_id}/query/cells`: conservative policy (effective TTL and item-size caps are stricter than tuples).
 

--- a/server/benchmarks/workloads.json
+++ b/server/benchmarks/workloads.json
@@ -6,10 +6,8 @@
       "path": "/api/v1/datasets/trades_v1/query/tuples",
       "warmup_requests": 2,
       "body": {
-        "query": {
-          "fields": [{"field": "symbol"}],
-          "paging": {"limit": 50, "offset": 0}
-        }
+        "fields": [{"field": "symbol"}],
+        "paging": {"limit": 50, "offset": 0}
       }
     },
     {
@@ -18,11 +16,9 @@
       "path": "/api/v1/datasets/trades_v1/query/tuples",
       "warmup_requests": 2,
       "body": {
-        "query": {
-          "fields": [{"field": "symbol"}],
-          "filters": [{"field": "symbol", "operator": "EXCLUDE", "values": ["AAPL"]}],
-          "paging": {"limit": 50, "offset": 0}
-        }
+        "fields": [{"field": "symbol"}],
+        "filters": [{"field": "symbol", "operator": "EXCLUDE", "values": ["AAPL"]}],
+        "paging": {"limit": 50, "offset": 0}
       }
     },
     {
@@ -31,12 +27,10 @@
       "path": "/api/v1/datasets/trades_v1/query/cells",
       "warmup_requests": 2,
       "body": {
-        "query": {
-          "axes": {
-            "rows": [{"field": "symbol"}],
-            "columns": [],
-            "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}]
-          }
+        "axes": {
+          "rows": [{"field": "symbol"}],
+          "columns": [],
+          "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}]
         }
       }
     },
@@ -46,41 +40,35 @@
       "path": "/api/v1/datasets/trades_v1/query/cells",
       "warmup_requests": 2,
       "body": {
-        "query": {
-          "axes": {
-            "rows": [{"field": "date"}],
-            "columns": [{"field": "symbol"}],
-            "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}]
-          }
+        "axes": {
+          "rows": [{"field": "date"}],
+          "columns": [{"field": "symbol"}],
+          "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}]
         }
       }
     },
     {
       "name": "picklist_symbol",
       "method": "POST",
-      "path": "/api/v1/datasets/trades_v1/query/picklist",
+      "path": "/api/v1/datasets/trades_v1/query/members",
       "warmup_requests": 2,
       "body": {
-        "query": {
-          "field": "symbol",
-          "search": "",
-          "filters": [],
-          "paging": {"limit": 100, "offset": 0}
-        }
+        "field": "symbol",
+        "search": "",
+        "filters": [],
+        "paging": {"limit": 100, "offset": 0}
       }
     },
     {
       "name": "picklist_symbol_search",
       "method": "POST",
-      "path": "/api/v1/datasets/trades_v1/query/picklist",
+      "path": "/api/v1/datasets/trades_v1/query/members",
       "warmup_requests": 2,
       "body": {
-        "query": {
-          "field": "symbol",
-          "search": "A*",
-          "filters": [],
-          "paging": {"limit": 100, "offset": 0}
-        }
+        "field": "symbol",
+        "search": "A*",
+        "filters": [],
+        "paging": {"limit": 100, "offset": 0}
       }
     },
     {

--- a/server/cache.py
+++ b/server/cache.py
@@ -55,7 +55,7 @@ def canonical_json(obj: Any) -> str:
 def build_cache_key(
     endpoint: str,
     dataset_id: str,
-    date_range: dict[str, Any],
+    date_range: dict[str, Any] | None,
     query_payload: dict[str, Any],
     fact_version_token: Any | None = None,
     dim_version_token: Any | None = None,

--- a/server/datasets.py
+++ b/server/datasets.py
@@ -550,6 +550,15 @@ def _infer_time_dimension(
             time_dimension["max"] = profile["time_max"]
     return time_dimension
 
+
+def get_time_dimension(dataset_id: str) -> dict[str, Any] | None:
+    """Return the configured or inferred time dimension metadata for a dataset."""
+    entry = get_dataset_entry(dataset_id)
+    if entry is None:
+        return None
+    source = get_dataset_source(dataset_id)
+    return _infer_time_dimension(entry, source, None)
+
 def _compute_dataset_profile(
     dataset_id: str,
     dataset_entry: dict[str, Any],
@@ -663,7 +672,7 @@ def build_dataset_links(dataset_id: str) -> dict[str, str]:
         "schema": f"{base}/schema",
         "tuples": f"{base}/query/tuples",
         "cells": f"{base}/query/cells",
-        "picklist": f"{base}/query/picklist",
+        "members": f"{base}/query/members",
     }
 
 

--- a/server/errors.py
+++ b/server/errors.py
@@ -73,6 +73,18 @@ class DatasetUnavailableError(AppError):
         )
 
 
+class DateRangeNotSupportedError(AppError):
+    """Raised when a client supplies date_range for a dataset without a time dimension."""
+
+    def __init__(self, dataset_id: str) -> None:
+        super().__init__(
+            code="DATE_RANGE_NOT_SUPPORTED",
+            message=f"Dataset does not support date_range filtering: {dataset_id}",
+            status_code=422,
+            details={"dataset_id": dataset_id},
+        )
+
+
 class DatasetConfigError(AppError):
     """Raised when a dataset entry is invalid or missing required source settings."""
 

--- a/server/models.py
+++ b/server/models.py
@@ -8,7 +8,7 @@ so invalid requests fail fast with clear 422 errors.
 from datetime import date
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from pydantic_core import PydanticCustomError
 
 from server.config import get_settings
@@ -166,11 +166,25 @@ class PagingSpec(BaseModel):
     offset: int = Field(default=0, ge=0)
 
 
+class WindowPagingSpec(BaseModel):
+    """Offset/limit window used by v1 cells requests."""
+
+    limit: int = Field(default=100, ge=1, le=MAX_PAGE_LIMIT)
+    offset: int = Field(default=0, ge=0)
+
+
 class WindowSpec(BaseModel):
     """Row/column window for virtualized cells requests."""
 
     start_index: int = Field(default=0, ge=0)
     count: int | None = Field(default=None, ge=1)
+
+
+class CellsWindowRequest(BaseModel):
+    """Top-level cells window request for row/column pagination."""
+
+    rows: WindowPagingSpec | None = None
+    columns: WindowPagingSpec | None = None
 
 
 class PagingResponse(BaseModel):
@@ -246,25 +260,53 @@ class ExportQueryBody(BaseModel):
 class QueryTuplesRequest(BaseModel):
     """POST /api/v1/datasets/{dataset_id}/query/tuples body."""
 
-    dataset_id: str
-    date_range: DateRange
-    query: TuplesQueryBody = TuplesQueryBody()
+    model_config = ConfigDict(extra="forbid")
+
+    date_range: DateRange | None = None
+    fields: list[TupleFieldSpec] | None = None
+    filters: list[TupleFilter] | None = None
+    paging: PagingSpec | None = None
+
+    @model_validator(mode="after")
+    def require_fields(self) -> "QueryTuplesRequest":
+        if not self.fields:
+            raise ValueError("fields must include at least one item")
+        return self
 
 
 class QueryCellsRequest(BaseModel):
     """POST /api/v1/datasets/{dataset_id}/query/cells body."""
 
-    dataset_id: str
-    date_range: DateRange
-    query: CellsQueryBody = CellsQueryBody()
+    model_config = ConfigDict(extra="forbid")
+
+    date_range: DateRange | None = None
+    axes: AxesSpec | None = None
+    filters: list[TupleFilter] | None = None
+    window: CellsWindowRequest | None = None
+
+    @model_validator(mode="after")
+    def require_axes(self) -> "QueryCellsRequest":
+        if self.axes is None:
+            raise ValueError("axes is required")
+        return self
 
 
 class QueryPicklistRequest(BaseModel):
-    """POST /api/v1/datasets/{dataset_id}/query/picklist body."""
+    """POST /api/v1/datasets/{dataset_id}/query/members body."""
 
-    dataset_id: str
-    date_range: DateRange
-    query: PicklistQueryBody = PicklistQueryBody()
+    model_config = ConfigDict(extra="forbid")
+
+    date_range: DateRange | None = None
+    field: str | None = None
+    search: str | None = ""
+    filters: list[TupleFilter] | None = None
+    paging: PagingSpec | None = None
+
+    @model_validator(mode="after")
+    def require_field(self) -> "QueryPicklistRequest":
+        if not self.field:
+            raise ValueError("field is required")
+        return self
 
 
 class ExportRequest(BaseModel):

--- a/server/query_builder.py
+++ b/server/query_builder.py
@@ -41,10 +41,10 @@ def validate_tuples_query_fields(query: TuplesQueryBody, schema_fields: set[str]
     errors: list[dict[str, Any]] = []
     for idx, f in enumerate(query.fields or []):
         if f.field not in schema_fields:
-            errors.append(_unknown_field_error(["body", "query", "fields", idx, "field"], f.field))
+            errors.append(_unknown_field_error(["body", "fields", idx, "field"], f.field))
     for idx, f in enumerate(query.filters or []):
         if f.field not in schema_fields:
-            errors.append(_unknown_field_error(["body", "query", "filters", idx, "field"], f.field))
+            errors.append(_unknown_field_error(["body", "filters", idx, "field"], f.field))
     _raise_if_unknown(errors)
 
 
@@ -60,7 +60,7 @@ def _validate_axes_fields(
             if item.field not in schema_fields:
                 errors.append(
                     _unknown_field_error(
-                        ["body", "query", "axes", axis_name, idx, "field"],
+                        ["body", "axes", axis_name, idx, "field"],
                         item.field,
                     )
                 )
@@ -73,7 +73,7 @@ def _validate_filter_fields(
 ) -> None:
     for idx, f in enumerate(filters or []):
         if f.field not in schema_fields:
-            errors.append(_unknown_field_error(["body", "query", "filters", idx, "field"], f.field))
+            errors.append(_unknown_field_error(["body", "filters", idx, "field"], f.field))
 
 
 def validate_cells_query_fields(query: CellsQueryBody, schema_fields: set[str]) -> None:
@@ -86,7 +86,7 @@ def validate_cells_query_fields(query: CellsQueryBody, schema_fields: set[str]) 
 def validate_picklist_query_fields(query: PicklistQueryBody, schema_fields: set[str]) -> None:
     errors: list[dict[str, Any]] = []
     if query.field and query.field not in schema_fields:
-        errors.append(_unknown_field_error(["body", "query", "field"], query.field))
+        errors.append(_unknown_field_error(["body", "field"], query.field))
     _validate_filter_fields(query.filters, errors, schema_fields)
     _raise_if_unknown(errors)
 
@@ -98,8 +98,10 @@ def validate_export_query_fields(query: ExportQueryBody, schema_fields: set[str]
     _raise_if_unknown(errors)
 
 
-def _build_date_clause(date_range: DateRange, params: list[Any]) -> str:
+def _build_date_clause(date_range: DateRange | None, params: list[Any]) -> str:
     """Build a WHERE clause fragment for the date range."""
+    if date_range is None:
+        return ""
     if isinstance(date_range, DateRangeSingle):
         params.append(date_range.date)
         return '"date" = ?'
@@ -141,7 +143,7 @@ def _build_filter_clauses(
 def build_tuples_sql(
     dataset_id: str,
     query: TuplesQueryBody,
-    date_range: DateRange,
+    date_range: DateRange | None,
     schema_fields: set[str],
 ) -> tuple[str, list[Any]]:
     """
@@ -206,7 +208,7 @@ def build_tuples_sql(
 def build_tuples_count_sql(
     dataset_id: str,
     query: TuplesQueryBody,
-    date_range: DateRange,
+    date_range: DateRange | None,
     schema_fields: set[str],
 ) -> tuple[str, list[Any]]:
     """Generate a COUNT query for total_count in tuples response."""
@@ -243,7 +245,7 @@ def build_tuples_count_sql(
 def build_cells_sql(
     dataset_id: str,
     query: CellsQueryBody,
-    date_range: DateRange,
+    date_range: DateRange | None,
     schema_fields: set[str],
     max_cells: int | None = None,
 ) -> tuple[str, list[Any]]:
@@ -368,7 +370,7 @@ def build_cells_sql(
 def build_picklist_sql(
     dataset_id: str,
     query: PicklistQueryBody,
-    date_range: DateRange,
+    date_range: DateRange | None,
     schema_fields: set[str],
 ) -> tuple[str, list[Any]]:
     """
@@ -421,7 +423,7 @@ def build_picklist_sql(
 def build_picklist_count_sql(
     dataset_id: str,
     query: PicklistQueryBody,
-    date_range: DateRange,
+    date_range: DateRange | None,
     schema_fields: set[str],
 ) -> tuple[str, list[Any]]:
     """Generate a COUNT query for total_count in picklist response."""

--- a/server/relation_builder.py
+++ b/server/relation_builder.py
@@ -41,7 +41,9 @@ class BaseRelation:
     requires_time_filter: bool = True
 
 
-def _dates_for_range(date_range: DateRange) -> list[str]:
+def _dates_for_range(date_range: DateRange | None) -> list[str]:
+    if date_range is None:
+        return []
     try:
         validate_date_range_span(date_range, get_settings().max_date_range_days)
     except DateRangeSpanLimitError as exc:
@@ -71,7 +73,7 @@ def _ensure_columns(required_columns: Iterable[str]) -> list[str]:
 def _time_filter_sql(
     column: str,
     filter_type: str,
-    date_range: DateRange,
+    date_range: DateRange | None,
     params: list[Any],
 ) -> str:
     quoted_col = quote_identifier(column)
@@ -132,6 +134,8 @@ def _build_parquet_source_relation(
     # When we have a time_filter and a single base path (no glob), expand to date-partition paths
     # so DuckDB gets concrete file patterns (S3 prefix listing may not work like a directory).
     if (
+        date_range is not None
+        and
         source.time_filter is not None
         and len(uris) == 1
         and "*" not in uris[0]
@@ -162,7 +166,7 @@ def _build_parquet_source_relation(
     where_parts: list[str] = []
     handles_date = False
     requires_time_filter = False
-    if source.time_filter is not None:
+    if source.time_filter is not None and date_range is not None:
         handles_date = True
         requires_time_filter = True
         where_parts.append(
@@ -186,7 +190,7 @@ def _build_parquet_source_relation(
 
 def _build_legacy_partition_relation(
     dataset_id: str,
-    date_range: DateRange,
+    date_range: DateRange | None,
     required_columns: Iterable[str],
 ) -> BaseRelation:
     settings = get_settings()
@@ -200,11 +204,17 @@ def _build_legacy_partition_relation(
     patterns: list[str] = []
     if base_path:
         root = Path(base_path)
-        for d in dates:
-            patterns.append(str(root / dataset_id / f"date={d}" / "*.parquet"))
+        if dates:
+            for d in dates:
+                patterns.append(str(root / dataset_id / f"date={d}" / "*.parquet"))
+        else:
+            patterns.append(str(root / dataset_id / "date=*" / "*.parquet"))
     else:
-        for d in dates:
-            patterns.append(build_partition_path(bucket, dataset_id, d) + "*.parquet")
+        if dates:
+            for d in dates:
+                patterns.append(build_partition_path(bucket, dataset_id, d) + "*.parquet")
+        else:
+            patterns.append(f"s3://{bucket}/{dataset_id}/date=*/*.parquet")
 
     missing: list[str] = []
     if base_path:
@@ -252,7 +262,7 @@ def required_relation_columns(dataset_id: str) -> set[str]:
 
 def build_base_relation(
     dataset_id: str,
-    date_range: DateRange,
+    date_range: DateRange | None,
     required_columns: Iterable[str],
 ) -> BaseRelation:
     """

--- a/server/routers/query.py
+++ b/server/routers/query.py
@@ -12,17 +12,25 @@ from server.auth import require_api_key
 from server.cache import build_cache_key, get_query_cache
 from server.config import get_settings
 from server.engine import QueryCancelHandle, db_manager
-from server.errors import CellsWindowTooLargeError, DatasetNotFoundError, ValidationAppError
+from server.errors import (
+    CellsWindowTooLargeError,
+    DatasetNotFoundError,
+    DateRangeNotSupportedError,
+)
 from server.models import (
+    CellsQueryBody,
     CellsResponse,
     PagingResponse,
     PagingSpec,
+    PicklistQueryBody,
     PicklistResponse,
     QueryCellsRequest,
     QueryPicklistRequest,
     QueryTuplesRequest,
     TupleItem,
+    TuplesQueryBody,
     TuplesResponse,
+    WindowSpec,
 )
 from server.query_budget import get_query_budget
 from server.query_builder import (
@@ -46,26 +54,6 @@ def _path_dataset_id(request: Request) -> str:
     raise RuntimeError("v1 query routes require a dataset_id path parameter")
 
 
-def _canonical_dataset_id(request: Request, body_dataset_id: str) -> str:
-    """Require the request body dataset id to match the v1 path dataset id."""
-    path_dataset_id = _path_dataset_id(request)
-    if body_dataset_id != path_dataset_id:
-        raise ValidationAppError(
-            [
-                {
-                    "loc": ["body", "dataset_id"],
-                    "msg": "dataset_id must match the dataset_id path parameter",
-                    "type": "value_error.dataset_id_mismatch",
-                    "ctx": {
-                        "path_dataset_id": path_dataset_id,
-                        "body_dataset_id": body_dataset_id,
-                    },
-                }
-            ]
-        )
-    return path_dataset_id
-
-
 def _time_filter_metadata(dataset_id: str) -> tuple[bool, str | None]:
     """Describe whether date_range is actively applied for dataset execution."""
     settings = get_settings()
@@ -77,6 +65,15 @@ def _time_filter_metadata(dataset_id: str) -> tuple[bool, str | None]:
     if source.time_filter is None:
         return False, None
     return True, source.time_filter.column
+
+
+def _ensure_date_range_supported(dataset_id: str, date_range) -> None:
+    if (
+        date_range is not None
+        and datasets.get_time_dimension(dataset_id) is None
+        and "date" not in datasets.get_schema_field_names(dataset_id)
+    ):
+        raise DateRangeNotSupportedError(dataset_id)
 
 
 async def _execute_with_budget(request: Request, coro_factory, cancel_fn=None):
@@ -96,14 +93,20 @@ async def post_query_tuples(
     _api_key: str = Depends(require_api_key),
 ) -> TuplesResponse:
     """POST /api/v1/datasets/{dataset_id}/query/tuples."""
-    dataset_id = _canonical_dataset_id(request, body.dataset_id)
-    body.dataset_id = dataset_id
+    dataset_id = _path_dataset_id(request)
     settings = get_settings()
     if datasets.get_schema(dataset_id) is None:
         raise DatasetNotFoundError(dataset_id)
+    _ensure_date_range_supported(dataset_id, body.date_range)
+
+    query = TuplesQueryBody(
+        fields=body.fields,
+        filters=body.filters,
+        paging=body.paging,
+    )
 
     schema_fields = datasets.get_schema_field_names(dataset_id)
-    paging = body.query.paging or PagingSpec(limit=settings.tuples_default_limit, offset=0)
+    paging = query.paging or PagingSpec(limit=settings.tuples_default_limit, offset=0)
 
     cache_status = "disabled"
     cache_source = "compute"
@@ -112,7 +115,7 @@ async def post_query_tuples(
 
     async def _execute() -> dict[str, object]:
         start = time.perf_counter()
-        sql, params = build_tuples_sql(dataset_id, body.query, body.date_range, schema_fields)
+        sql, params = build_tuples_sql(dataset_id, query, body.date_range, schema_fields)
 
         async def _run_query():
             return await db_manager.execute_sql_async(
@@ -131,7 +134,7 @@ async def post_query_tuples(
             items = []
 
         if total_count == 0 and paging.offset > 0:
-            count_sql, count_params = build_tuples_count_sql(dataset_id, body.query, body.date_range, schema_fields)
+            count_sql, count_params = build_tuples_count_sql(dataset_id, query, body.date_range, schema_fields)
             count_cancel_handle = QueryCancelHandle()
             count_rows = await db_manager.execute_sql_async(
                 count_sql,
@@ -161,8 +164,8 @@ async def post_query_tuples(
         cache_key = build_cache_key(
             "tuples",
             dataset_id,
-            body.date_range.model_dump(),
-            body.query.model_dump(),
+            body.date_range.model_dump() if body.date_range is not None else None,
+            query.model_dump(),
             fact_version_token=data_version_token,
         )
         result, meta = await cache.get_or_set(
@@ -212,15 +215,22 @@ async def post_query_cells(
     _api_key: str = Depends(require_api_key),
 ) -> CellsResponse:
     """POST /api/v1/datasets/{dataset_id}/query/cells."""
-    dataset_id = _canonical_dataset_id(request, body.dataset_id)
-    body.dataset_id = dataset_id
+    dataset_id = _path_dataset_id(request)
     settings = get_settings()
     if datasets.get_schema(dataset_id) is None:
         raise DatasetNotFoundError(dataset_id)
+    _ensure_date_range_supported(dataset_id, body.date_range)
+
+    query = CellsQueryBody(
+        rows=WindowSpec(start_index=body.window.rows.offset, count=body.window.rows.limit) if body.window and body.window.rows else None,
+        columns=WindowSpec(start_index=body.window.columns.offset, count=body.window.columns.limit) if body.window and body.window.columns else None,
+        axes=body.axes,
+        filters=body.filters,
+    )
 
     schema_fields = datasets.get_schema_field_names(dataset_id)
-    row_window = body.query.rows
-    col_window = body.query.columns
+    row_window = query.rows
+    col_window = query.columns
 
     row_count = row_window.count if row_window else None
     col_count = col_window.count if col_window else None
@@ -264,7 +274,7 @@ async def post_query_cells(
         start = time.perf_counter()
         effective_max = settings.max_cells_per_response
         sql, params = build_cells_sql(
-            dataset_id, body.query, body.date_range, schema_fields, max_cells=effective_max + 1
+            dataset_id, query, body.date_range, schema_fields, max_cells=effective_max + 1
         )
 
         async def _run_query():
@@ -281,7 +291,7 @@ async def post_query_cells(
             logger.warning(
                 "cells query cap exceeded",
                 extra={
-                    "dataset_id": body.dataset_id,
+                    "dataset_id": dataset_id,
                     "endpoint": "cells",
                     "cap": effective_max,
                     "returned_count": len(rows),
@@ -311,8 +321,8 @@ async def post_query_cells(
         cache_key = build_cache_key(
             "cells",
             dataset_id,
-            body.date_range.model_dump(),
-            body.query.model_dump(),
+            body.date_range.model_dump() if body.date_range is not None else None,
+            query.model_dump(),
             fact_version_token=data_version_token,
         )
         ttl = max(1.0, settings.cache_ttl_seconds / 2) if settings.cache_ttl_seconds else settings.cache_ttl_seconds
@@ -349,23 +359,30 @@ async def post_query_cells(
     return CellsResponse(cells=result["response"]["cells"])
 
 
-@router.post("/picklist", response_model=PicklistResponse)
+@router.post("/members", response_model=PicklistResponse)
 @limiter.limit(lambda: get_settings().rate_limit_query)
-async def post_query_picklist(
+async def post_query_members(
     request: Request,
     body: QueryPicklistRequest,
     response: Response,
     _api_key: str = Depends(require_api_key),
 ) -> PicklistResponse:
-    """POST /api/v1/datasets/{dataset_id}/query/picklist."""
-    dataset_id = _canonical_dataset_id(request, body.dataset_id)
-    body.dataset_id = dataset_id
+    """POST /api/v1/datasets/{dataset_id}/query/members."""
+    dataset_id = _path_dataset_id(request)
     settings = get_settings()
     if datasets.get_schema(dataset_id) is None:
         raise DatasetNotFoundError(dataset_id)
+    _ensure_date_range_supported(dataset_id, body.date_range)
+
+    query = PicklistQueryBody(
+        field=body.field,
+        search=body.search,
+        filters=body.filters,
+        paging=body.paging,
+    )
 
     schema_fields = datasets.get_schema_field_names(dataset_id)
-    paging = body.query.paging or PagingSpec(limit=settings.picklist_default_limit, offset=0)
+    paging = query.paging or PagingSpec(limit=settings.picklist_default_limit, offset=0)
 
     cache_status = "disabled"
     cache_source = "compute"
@@ -375,7 +392,7 @@ async def post_query_picklist(
 
     async def _execute() -> dict[str, object]:
         start = time.perf_counter()
-        sql, params = build_picklist_sql(dataset_id, body.query, body.date_range, schema_fields)
+        sql, params = build_picklist_sql(dataset_id, query, body.date_range, schema_fields)
 
         async def _run_query():
             return await db_manager.execute_sql_async(
@@ -394,7 +411,7 @@ async def post_query_picklist(
             values = []
 
         if total_count == 0 and paging.offset > 0:
-            count_sql, count_params = build_picklist_count_sql(dataset_id, body.query, body.date_range, schema_fields)
+            count_sql, count_params = build_picklist_count_sql(dataset_id, query, body.date_range, schema_fields)
             count_cancel_handle = QueryCancelHandle()
             count_rows = await db_manager.execute_sql_async(
                 count_sql,
@@ -422,10 +439,10 @@ async def post_query_picklist(
         cache = await get_query_cache()
         dim_version_token = datasets.get_dim_version_token(dataset_id)
         cache_key = build_cache_key(
-            "picklist",
+            "members",
             dataset_id,
-            body.date_range.model_dump(),
-            body.query.model_dump(),
+            body.date_range.model_dump() if body.date_range is not None else None,
+            query.model_dump(),
             dim_version_token=dim_version_token,
         )
         result, meta = await cache.get_or_set(
@@ -444,10 +461,10 @@ async def post_query_picklist(
     resp_body = result["response"]
     time_filter_applied, time_filter_column = _time_filter_metadata(dataset_id)
     logger.info(
-        "picklist query executed",
+        "members query executed",
         extra={
             "dataset_id": dataset_id,
-            "endpoint": "picklist",
+            "endpoint": "members",
             "duration_ms": round(result.get("duration_ms", 0.0), 2),
             "row_count": result.get("row_count", 0),
             "total_count": resp_body["total_count"],

--- a/server/tests/test_api_v1_routing.py
+++ b/server/tests/test_api_v1_routing.py
@@ -52,9 +52,9 @@ def test_versioned_schema_route(client: TestClient) -> None:
 
 def test_versioned_query_route_alias(client: TestClient) -> None:
     body = {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {"fields": [{"field": "symbol"}], "paging": {"limit": 10, "offset": 0}},
+        "fields": [{"field": "symbol"}],
+        "paging": {"limit": 10, "offset": 0},
     }
     r = client.post("/api/v1/datasets/trades_v1/query/tuples", json=body)
     assert r.status_code == 200

--- a/server/tests/test_auth.py
+++ b/server/tests/test_auth.py
@@ -10,17 +10,14 @@ INVALID_KEY = "wrong-key"
 _PROTECTED_ENDPOINTS = [
     ("GET", "/api/v1/datasets/trades_v1/schema", None, {}),
     ("POST", "/api/v1/datasets/trades_v1/query/tuples", {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {"axes": {"rows": [{"field": "symbol"}], "columns": [], "measures": []}},
+        "fields": [{"field": "symbol"}],
     }, {}),
     ("POST", "/api/v1/datasets/trades_v1/query/cells", {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {"axes": {"rows": [{"field": "symbol"}], "columns": [], "measures": [{"field": "volume", "aggregation": "SUM", "alias": "v"}]}},
+        "axes": {"rows": [{"field": "symbol"}], "columns": [], "measures": [{"field": "volume", "aggregation": "SUM", "alias": "v"}]},
     }, {}),
-    ("POST", "/api/v1/datasets/trades_v1/query/picklist", {
-        "dataset_id": "trades_v1",
+    ("POST", "/api/v1/datasets/trades_v1/query/members", {
         "date_range": {"type": "single", "date": "2026-03-01"},
         "field": "symbol",
     }, {}),

--- a/server/tests/test_correlation.py
+++ b/server/tests/test_correlation.py
@@ -10,9 +10,8 @@ from server.request_context import generate_request_id, get_request_id, set_requ
 
 def _query_body(**overrides):
     body = {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {"fields": [{"field": "symbol"}]},
+        "fields": [{"field": "symbol"}],
     }
     body.update(overrides)
     return body
@@ -61,7 +60,7 @@ class TestCorrelationIdMiddleware:
 
     def test_post_endpoint_gets_correlation_id(self, client: TestClient) -> None:
         body = _query_body()
-        r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
+        r = client.post("/api/v1/datasets/trades_v1/query/tuples", json=body)
         assert "X-Request-ID" in r.headers
         assert len(r.headers["X-Request-ID"]) > 0
 
@@ -70,7 +69,7 @@ class TestRequestMetadataHeaders:
     def test_request_id_header_propagates_to_tuples(self, client: TestClient) -> None:
         body = _query_body()
         r = client.post(
-            f"/api/v1/datasets/{body['dataset_id']}/query/tuples",
+            "/api/v1/datasets/trades_v1/query/tuples",
             json=body,
             headers={"X-Request-ID": "frontend-456"},
         )
@@ -78,17 +77,15 @@ class TestRequestMetadataHeaders:
 
     def test_request_id_header_propagates_to_cells(self, client: TestClient) -> None:
         body = {
-            "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2026-03-01"},
-            "query": {
-                "axes": {
-                    "rows": [{"field": "symbol"}],
-                    "measures": [{"field": "volume", "aggregation": "SUM", "alias": "vol"}],
-                },
+            "axes": {
+                "rows": [{"field": "symbol"}],
+                "columns": [],
+                "measures": [{"field": "volume", "aggregation": "SUM", "alias": "vol"}],
             },
         }
         r = client.post(
-            f"/api/v1/datasets/{body['dataset_id']}/query/cells",
+            "/api/v1/datasets/trades_v1/query/cells",
             json=body,
             headers={"X-Request-ID": "cells-trace-789"},
         )
@@ -96,12 +93,11 @@ class TestRequestMetadataHeaders:
 
     def test_request_id_header_propagates_to_picklist(self, client: TestClient) -> None:
         body = {
-            "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2026-03-01"},
-            "query": {"field": "symbol"},
+            "field": "symbol",
         }
         r = client.post(
-            f"/api/v1/datasets/{body['dataset_id']}/query/picklist",
+            "/api/v1/datasets/trades_v1/query/members",
             json=body,
             headers={"X-Request-ID": "picklist-trace-abc"},
         )
@@ -124,7 +120,7 @@ class TestRequestMetadataHeaders:
         body = _query_body()
         with caplog.at_level(logging.INFO, logger="query_service.access"):
             client.post(
-                f"/api/v1/datasets/{body['dataset_id']}/query/tuples",
+                "/api/v1/datasets/trades_v1/query/tuples",
                 json=body,
                 headers={"X-Client-Version": "huey-web/1.2.3"},
             )
@@ -136,7 +132,7 @@ class TestRequestMetadataHeaders:
     def test_no_request_id_header_generates_one(self, client: TestClient) -> None:
         body = _query_body()
         r = client.post(
-            f"/api/v1/datasets/{body['dataset_id']}/query/tuples",
+            "/api/v1/datasets/trades_v1/query/tuples",
             json=body,
         )
         assert len(r.headers["X-Request-ID"]) > 0

--- a/server/tests/test_datasets_api.py
+++ b/server/tests/test_datasets_api.py
@@ -12,7 +12,7 @@ def test_list_datasets_returns_links_and_cursor(client: TestClient) -> None:
     item = next(item for item in body["items"] if item["id"] == "trades_v1")
     assert item["links"]["self"] == "/api/v1/datasets/trades_v1"
     assert item["links"]["schema"] == "/api/v1/datasets/trades_v1/schema"
-    assert item["links"]["picklist"] == "/api/v1/datasets/trades_v1/query/picklist"
+    assert item["links"]["members"] == "/api/v1/datasets/trades_v1/query/members"
 
 
 def test_list_datasets_cursor_paginates(client: TestClient) -> None:

--- a/server/tests/test_error_contract.py
+++ b/server/tests/test_error_contract.py
@@ -34,11 +34,25 @@ def _clear_export_jobs():
         store._conn.commit()
 
 
-def _query_body(dataset_id: str = "trades_v1") -> dict:
+def _query_body(endpoint: str = "tuples") -> dict:
+    base = {"date_range": {"type": "single", "date": "2024-01-15"}}
+    if endpoint == "tuples":
+        return {
+            **base,
+            "fields": [{"field": "symbol"}],
+        }
+    if endpoint == "cells":
+        return {
+            **base,
+            "axes": {
+                "rows": [{"field": "symbol"}],
+                "columns": [],
+                "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_vol"}],
+            },
+        }
     return {
-        "dataset_id": dataset_id,
-        "date_range": {"type": "single", "date": "2024-01-15"},
-        "query": {},
+        **base,
+        "field": "symbol",
     }
 
 
@@ -50,7 +64,7 @@ def _export_body(dataset_id: str = "trades_v1") -> dict:
     }
 
 
-QUERY_ENDPOINTS = ("tuples", "cells", "picklist")
+QUERY_ENDPOINTS = ("tuples", "cells", "members")
 EXPORTS_ROOT = "/api/v1/exports"
 
 
@@ -71,7 +85,7 @@ class TestErrorResponseSchema:
 
     @pytest.mark.parametrize("endpoint", QUERY_ENDPOINTS)
     def test_query_404_envelope(self, client: TestClient, endpoint: str) -> None:
-        r = client.post(_query_path(endpoint, "no_such"), json=_query_body(dataset_id="no_such"))
+        r = client.post(_query_path(endpoint, "no_such"), json=_query_body(endpoint))
         assert r.status_code == 404
         body = r.json()
         assert body["code"] == "DATASET_NOT_FOUND"
@@ -165,21 +179,12 @@ class TestErrorResponseSchema:
 
         monkeypatch.setattr(query_router.db_manager, "execute_sql_async", execute_raise_unavailable)
 
-        body = _query_body(dataset_id="not_materialized_ds")
+        body = _query_body(endpoint)
         if endpoint == "tuples":
-            body["query"] = {"fields": [{"field": "symbol"}]}
-        elif endpoint == "picklist":
-            body["query"] = {"field": "symbol"}
-        else:
-            body["query"] = {
-                "axes": {
-                    "rows": [{"field": "symbol"}],
-                    "columns": [],
-                    "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_vol"}],
-                },
-            }
-
-        r = client.post(_query_path(endpoint, body["dataset_id"]), json=body)
+            body["fields"] = [{"field": "symbol"}]
+        elif endpoint == "members":
+            body["field"] = "symbol"
+        r = client.post(_query_path(endpoint, "not_materialized_ds"), json=body)
         assert r.status_code == 409
         payload = r.json()
         assert payload["code"] == "DATASET_UNAVAILABLE"
@@ -210,7 +215,7 @@ class TestValidationErrorEnvelope:
     """422 validation errors wrap Pydantic details in standard envelope."""
 
     def test_missing_required_field(self, client: TestClient) -> None:
-        r = client.post(_query_path("tuples"), json={"query": {}})
+        r = client.post(_query_path("tuples"), json={})
         assert r.status_code == 422
         body = r.json()
         assert body["code"] == "VALIDATION_ERROR"
@@ -221,8 +226,8 @@ class TestValidationErrorEnvelope:
 
     def test_invalid_date_format(self, client: TestClient) -> None:
         r = client.post(_query_path("tuples"), json={
-            "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "not-a-date"},
+            "fields": [{"field": "symbol"}],
         })
         assert r.status_code == 422
         body = r.json()
@@ -230,9 +235,9 @@ class TestValidationErrorEnvelope:
 
     def test_invalid_filter_operator(self, client: TestClient) -> None:
         r = client.post(_query_path("tuples"), json={
-            "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2024-01-15"},
-            "query": {"filters": [{"field": "symbol", "operator": "NOPE", "values": ["X"]}]},
+            "fields": [{"field": "symbol"}],
+            "filters": [{"field": "symbol", "operator": "NOPE", "values": ["X"]}],
         })
         assert r.status_code == 422
         body = r.json()
@@ -255,7 +260,7 @@ class TestRequestIdInErrors:
     def test_request_id_from_header(self, client: TestClient) -> None:
         r = client.post(
             _query_path("tuples", "no_such"),
-            json=_query_body(dataset_id="no_such"),
+            json=_query_body("tuples"),
             headers={"X-Request-ID": "trace-abc"},
         )
         assert r.status_code == 404
@@ -263,7 +268,7 @@ class TestRequestIdInErrors:
         assert body.get("request_id") == "trace-abc"
 
     def test_request_id_auto_generated(self, client: TestClient) -> None:
-        r = client.post(_query_path("tuples", "no_such"), json=_query_body(dataset_id="no_such"))
+        r = client.post(_query_path("tuples", "no_such"), json=_query_body("tuples"))
         assert r.status_code == 404
         body = r.json()
         assert "request_id" in body
@@ -330,9 +335,8 @@ class TestInternalErrorEnvelope:
         # raise_server_exceptions=False so we get the HTTP response instead of the re-raised exception
         no_raise_client = TestClient(app, raise_server_exceptions=False)
         r = no_raise_client.post(_query_path("cells"), json={
-            "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2026-03-01"},
-            "query": {"axes": {"rows": [{"field": "symbol"}], "columns": [], "measures": [{"field": "volume", "aggregation": "SUM", "alias": "v"}]}},
+            "axes": {"rows": [{"field": "symbol"}], "columns": [], "measures": [{"field": "volume", "aggregation": "SUM", "alias": "v"}]},
         })
         assert r.status_code == 500
         body = r.json()
@@ -360,16 +364,16 @@ class TestHappyPathUnchanged:
         assert "fields" in r.json()
 
     def test_query_tuples_success(self, client: TestClient) -> None:
-        r = client.post(_query_path("tuples"), json=_query_body())
+        r = client.post(_query_path("tuples"), json=_query_body("tuples"))
         assert r.status_code == 200
         assert "items" in r.json()
 
     def test_query_cells_success(self, client: TestClient) -> None:
-        r = client.post(_query_path("cells"), json=_query_body())
+        r = client.post(_query_path("cells"), json=_query_body("cells"))
         assert r.status_code == 200
         assert "cells" in r.json()
 
-    def test_query_picklist_success(self, client: TestClient) -> None:
-        r = client.post(_query_path("picklist"), json=_query_body())
+    def test_query_members_success(self, client: TestClient) -> None:
+        r = client.post(_query_path("members"), json=_query_body("members"))
         assert r.status_code == 200
         assert "values" in r.json()

--- a/server/tests/test_integration.py
+++ b/server/tests/test_integration.py
@@ -1,7 +1,7 @@
 """
 Backend integration tests: full API flow with real app and config.
 
-Exercises schema -> query (tuples, cells, picklist) -> export in sequence
+Exercises schema -> query (tuples, cells, members) -> export in sequence
 using the default dataset config (no S3 required).
 """
 
@@ -9,7 +9,7 @@ from fastapi.testclient import TestClient
 
 
 def test_full_api_flow(client: TestClient) -> None:
-    """Integration: GET schema -> POST tuples, cells, picklist -> POST export -> GET status."""
+    """Integration: GET schema -> POST tuples, cells, members -> POST export -> GET status."""
     dataset_id = "trades_v1"
     date_range = {"type": "single", "date": "2026-03-01"}
 
@@ -20,9 +20,9 @@ def test_full_api_flow(client: TestClient) -> None:
     assert len(schema["fields"]) > 0
 
     r_tuples = client.post(f"/api/v1/datasets/{dataset_id}/query/tuples", json={
-        "dataset_id": dataset_id,
         "date_range": date_range,
-        "query": {"fields": [{"field": "symbol"}], "paging": {"limit": 10, "offset": 0}},
+        "fields": [{"field": "symbol"}],
+        "paging": {"limit": 10, "offset": 0},
     })
     assert r_tuples.status_code == 200
     tuples_data = r_tuples.json()
@@ -30,14 +30,11 @@ def test_full_api_flow(client: TestClient) -> None:
     assert len(tuples_data["items"]) > 0
 
     r_cells = client.post(f"/api/v1/datasets/{dataset_id}/query/cells", json={
-        "dataset_id": dataset_id,
         "date_range": date_range,
-        "query": {
-            "axes": {
-                "rows": [{"field": "symbol"}],
-                "columns": [],
-                "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_vol"}],
-            },
+        "axes": {
+            "rows": [{"field": "symbol"}],
+            "columns": [],
+            "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_vol"}],
         },
     })
     assert r_cells.status_code == 200
@@ -45,10 +42,10 @@ def test_full_api_flow(client: TestClient) -> None:
     assert len(cells_data["cells"]) > 0
     assert "row_index" in cells_data["cells"][0]
 
-    r_picklist = client.post(f"/api/v1/datasets/{dataset_id}/query/picklist", json={
-        "dataset_id": dataset_id,
+    r_picklist = client.post(f"/api/v1/datasets/{dataset_id}/query/members", json={
         "date_range": date_range,
-        "query": {"field": "symbol", "paging": {"limit": 100, "offset": 0}},
+        "field": "symbol",
+        "paging": {"limit": 100, "offset": 0},
     })
     assert r_picklist.status_code == 200
     picklist_data = r_picklist.json()

--- a/server/tests/test_logging.py
+++ b/server/tests/test_logging.py
@@ -93,9 +93,8 @@ class TestAccessLogMiddleware:
     def test_logs_post_request(self, client: TestClient, capfd) -> None:
         setup_logging("INFO", "json")
         client.post("/api/v1/datasets/trades_v1/query/tuples", json={
-            "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2026-03-01"},
-            "query": {"fields": [{"field": "symbol"}]},
+            "fields": [{"field": "symbol"}],
         })
 
         output = capfd.readouterr().out
@@ -118,9 +117,8 @@ class TestQueryExecutionLogging:
     def test_tuples_query_logged(self, client: TestClient, capfd) -> None:
         setup_logging("INFO", "json")
         client.post("/api/v1/datasets/trades_v1/query/tuples", json={
-            "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2026-03-01"},
-            "query": {"fields": [{"field": "symbol"}]},
+            "fields": [{"field": "symbol"}],
         })
 
         output = capfd.readouterr().out
@@ -142,9 +140,8 @@ class TestQueryExecutionLogging:
     def test_cells_query_logged(self, client: TestClient, capfd) -> None:
         setup_logging("INFO", "json")
         client.post("/api/v1/datasets/trades_v1/query/cells", json={
-            "dataset_id": "trades_v1",
             "date_range": {"type": "single", "date": "2026-03-01"},
-            "query": {"axes": {"rows": [{"field": "symbol"}], "columns": [], "measures": []}},
+            "axes": {"rows": [{"field": "symbol"}], "columns": [], "measures": []},
         })
 
         output = capfd.readouterr().out
@@ -155,18 +152,17 @@ class TestQueryExecutionLogging:
         assert len(query_records) >= 1
         assert query_records[0]["endpoint"] == "cells"
 
-    def test_picklist_query_logged(self, client: TestClient, capfd) -> None:
+    def test_members_query_logged(self, client: TestClient, capfd) -> None:
         setup_logging("INFO", "json")
-        client.post("/api/v1/datasets/trades_v1/query/picklist", json={
-            "dataset_id": "trades_v1",
+        client.post("/api/v1/datasets/trades_v1/query/members", json={
             "date_range": {"type": "single", "date": "2026-03-01"},
-            "query": {"field": "symbol"},
+            "field": "symbol",
         })
 
         output = capfd.readouterr().out
         query_records = [
             json.loads(line) for line in output.strip().split("\n")
-            if "endpoint" in line and "picklist" in line
+            if "endpoint" in line and "members" in line
         ]
         assert len(query_records) >= 1
-        assert query_records[0]["endpoint"] == "picklist"
+        assert query_records[0]["endpoint"] == "members"

--- a/server/tests/test_models.py
+++ b/server/tests/test_models.py
@@ -8,6 +8,7 @@ from server.models import (
     AxesSpec,
     AxisField,
     CellsQueryBody,
+    CellsWindowRequest,
     DateRangeRange,
     DateRangeSingle,
     ExportQueryBody,
@@ -15,13 +16,11 @@ from server.models import (
     MeasureSpec,
     PagingResponse,
     PagingSpec,
-    PicklistQueryBody,
     QueryCellsRequest,
     QueryPicklistRequest,
     QueryTuplesRequest,
     TupleFieldSpec,
     TupleFilter,
-    TuplesQueryBody,
 )
 
 
@@ -203,66 +202,70 @@ class TestExportQueryBody:
 class TestQueryTuplesRequest:
     def test_valid_full(self) -> None:
         req = QueryTuplesRequest(
-            dataset_id="trades_v1",
             date_range={"type": "single", "date": "2026-03-01"},
-            query={"axis": "rows", "fields": [{"field": "symbol"}], "paging": {"limit": 10, "offset": 0}},
+            fields=[{"field": "symbol"}],
+            paging={"limit": 10, "offset": 0},
         )
-        assert req.dataset_id == "trades_v1"
         assert isinstance(req.date_range, DateRangeSingle)
-        assert isinstance(req.query, TuplesQueryBody)
-        assert req.query.axis == "rows"
-        assert req.query.paging.limit == 10
+        assert req.fields[0].field == "symbol"
+        assert req.paging.limit == 10
 
     def test_empty_query(self) -> None:
-        req = QueryTuplesRequest(
-            dataset_id="trades_v1",
-            date_range={"type": "single", "date": "2026-03-01"},
-            query={},
-        )
-        assert req.query.axis is None
-        assert req.query.paging is None
+        with pytest.raises(ValidationError):
+            QueryTuplesRequest(
+                date_range={"type": "single", "date": "2026-03-01"},
+            )
 
     def test_default_query(self) -> None:
-        req = QueryTuplesRequest(
-            dataset_id="trades_v1",
-            date_range={"type": "single", "date": "2026-03-01"},
-        )
-        assert req.query.axis is None
-
-    def test_missing_date_range(self) -> None:
         with pytest.raises(ValidationError):
-            QueryTuplesRequest(dataset_id="trades_v1", query={})
+            QueryTuplesRequest(date_range={"type": "single", "date": "2026-03-01"})
+
+    def test_missing_date_range_allowed(self) -> None:
+        req = QueryTuplesRequest(fields=[{"field": "symbol"}])
+        assert req.date_range is None
+
+    def test_dataset_id_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            QueryTuplesRequest(dataset_id="trades_v1", fields=[{"field": "symbol"}])
 
 
 class TestQueryCellsRequest:
     def test_valid_full(self) -> None:
         req = QueryCellsRequest(
-            dataset_id="trades_v1",
             date_range={"type": "range", "start": "2026-01-01", "end": "2026-03-01"},
-            query={
-                "rows": {"start_index": 0, "count": 10},
-                "columns": {"start_index": 0, "count": 5},
-                "axes": {"rows": [], "columns": [], "measures": []},
-                "filters": [],
+            window={
+                "rows": {"offset": 0, "limit": 10},
+                "columns": {"offset": 0, "limit": 5},
             },
+            axes={"rows": [], "columns": [], "measures": []},
+            filters=[],
         )
-        assert isinstance(req.query, CellsQueryBody)
-        assert req.query.rows is not None
-        assert req.query.rows.start_index == 0
-        assert req.query.rows.count == 10
+        assert isinstance(req.window, CellsWindowRequest)
+        assert req.window.rows is not None
+        assert req.window.rows.offset == 0
+        assert req.window.rows.limit == 10
+
+    def test_missing_date_range_allowed(self) -> None:
+        req = QueryCellsRequest(axes={"rows": [], "columns": [], "measures": []})
+        assert req.date_range is None
 
 
 class TestQueryPicklistRequest:
     def test_valid_full(self) -> None:
         req = QueryPicklistRequest(
-            dataset_id="trades_v1",
             date_range={"type": "single", "date": "2026-03-01"},
-            query={"field": "symbol", "search": "AA*", "filters": [], "paging": {"limit": 50, "offset": 0}},
+            field="symbol",
+            search="AA*",
+            filters=[],
+            paging={"limit": 50, "offset": 0},
         )
-        assert isinstance(req.query, PicklistQueryBody)
-        assert req.query.field == "symbol"
-        assert req.query.search == "AA*"
-        assert req.query.paging.limit == 50
+        assert req.field == "symbol"
+        assert req.search == "AA*"
+        assert req.paging.limit == 50
+
+    def test_missing_date_range_allowed(self) -> None:
+        req = QueryPicklistRequest(field="symbol")
+        assert req.date_range is None
 
 
 class TestExportRequest:

--- a/server/tests/test_query_budget.py
+++ b/server/tests/test_query_budget.py
@@ -47,9 +47,8 @@ def settings_override(monkeypatch):
 
 def _cells_body():
     return {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {"axes": {"rows": [{"field": "symbol"}], "columns": [], "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}]}},
+        "axes": {"rows": [{"field": "symbol"}], "columns": [], "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}]},
     }
 
 
@@ -57,7 +56,7 @@ def test_query_timeout_response(client: TestClient, settings_override) -> None:
     """Queries exceeding the timeout return a 504 with QUERY_TIMEOUT."""
     settings_override(query_timeout_seconds=0.0001)
     request_body = _cells_body()
-    r = client.post(f"/api/v1/datasets/{request_body['dataset_id']}/query/cells", json=request_body)
+    r = client.post("/api/v1/datasets/trades_v1/query/cells", json=request_body)
     assert r.status_code == 504
     body = r.json()
     assert body["code"] == "QUERY_TIMEOUT"
@@ -83,15 +82,14 @@ def test_queue_depth_rejects_overflow(
     monkeypatch.setattr(db_manager, "execute_sql_async", slow_execute)
 
     request_body = {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {"axes": {"rows": [{"field": "symbol"}], "columns": [], "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}]}},
+        "axes": {"rows": [{"field": "symbol"}], "columns": [], "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}]},
     }
 
     def first_request():
         # Separate clients avoid TestClient internal request serialization,
         # which can make this concurrency test nondeterministic.
-        return first_client.post(f"/api/v1/datasets/{request_body['dataset_id']}/query/cells", json=request_body)
+        return first_client.post("/api/v1/datasets/trades_v1/query/cells", json=request_body)
 
     first_client = None
     second_client = None
@@ -103,7 +101,7 @@ def test_queue_depth_rejects_overflow(
             # Wait until the first request has definitely acquired the budget slot
             # before sending the second, so the queue overflow is guaranteed.
             assert in_execute.wait(timeout=5)
-            second_result = second_client.post(f"/api/v1/datasets/{request_body['dataset_id']}/query/cells", json=request_body)
+            second_result = second_client.post("/api/v1/datasets/trades_v1/query/cells", json=request_body)
             first_result = first.result(timeout=10)
     finally:
         if first_client is not None:
@@ -177,11 +175,11 @@ def test_timing_out_one_request_does_not_break_other_concurrent_requests(
         with ThreadPoolExecutor(max_workers=1) as pool:
             first = pool.submit(
                 first_client.post,
-                f"/api/v1/datasets/{request_body['dataset_id']}/query/cells",
+                "/api/v1/datasets/trades_v1/query/cells",
                 json=request_body,
             )
             assert first_started.wait(timeout=5)
-            second_result = second_client.post(f"/api/v1/datasets/{request_body['dataset_id']}/query/cells", json=request_body)
+            second_result = second_client.post("/api/v1/datasets/trades_v1/query/cells", json=request_body)
             first_result = first.result(timeout=10)
     finally:
         if first_client is not None:

--- a/server/tests/test_query_cache_api.py
+++ b/server/tests/test_query_cache_api.py
@@ -44,6 +44,33 @@ def _enable_cache(monkeypatch, *, max_item_bytes: int | None = None) -> None:
     asyncio.run(reset_query_cache())
 
 
+def _tuples_body() -> dict:
+    return {
+        "date_range": {"type": "single", "date": "2026-03-01"},
+        "fields": [{"field": "symbol"}],
+        "paging": {"limit": 10, "offset": 0},
+    }
+
+
+def _members_body() -> dict:
+    return {
+        "date_range": {"type": "single", "date": "2026-03-01"},
+        "field": "symbol",
+        "paging": {"limit": 5, "offset": 0},
+    }
+
+
+def _cells_body() -> dict:
+    return {
+        "date_range": {"type": "single", "date": "2026-03-01"},
+        "axes": {
+            "rows": [{"field": "symbol"}],
+            "columns": [],
+            "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}],
+        },
+    }
+
+
 def test_tuples_cache_hit(monkeypatch, client: TestClient) -> None:
     _enable_cache(monkeypatch)
     call_count = {"n": 0}
@@ -55,13 +82,9 @@ def test_tuples_cache_hit(monkeypatch, client: TestClient) -> None:
 
     monkeypatch.setattr(db_manager, "execute_sql_async", counted)
 
-    body = {
-        "dataset_id": "trades_v1",
-        "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {"fields": [{"field": "symbol"}], "paging": {"limit": 10, "offset": 0}},
-    }
-    r1 = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
-    r2 = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
+    body = _tuples_body()
+    r1 = client.post("/api/v1/datasets/trades_v1/query/tuples", json=body)
+    r2 = client.post("/api/v1/datasets/trades_v1/query/tuples", json=body)
     assert r1.status_code == 200
     assert r2.status_code == 200
     assert r1.json() == r2.json()
@@ -79,13 +102,9 @@ def test_picklist_cache_hit(monkeypatch, client: TestClient) -> None:
 
     monkeypatch.setattr(db_manager, "execute_sql_async", counted)
 
-    body = {
-        "dataset_id": "trades_v1",
-        "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {"field": "symbol", "paging": {"limit": 5, "offset": 0}},
-    }
-    r1 = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
-    r2 = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
+    body = _members_body()
+    r1 = client.post("/api/v1/datasets/trades_v1/query/members", json=body)
+    r2 = client.post("/api/v1/datasets/trades_v1/query/members", json=body)
     assert r1.status_code == 200
     assert r2.status_code == 200
     assert r1.json() == r2.json()
@@ -103,19 +122,9 @@ def test_cells_cache_hit(monkeypatch, client: TestClient) -> None:
 
     monkeypatch.setattr(db_manager, "execute_sql_async", counted)
 
-    body = {
-        "dataset_id": "trades_v1",
-        "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {
-            "axes": {
-                "rows": [{"field": "symbol"}],
-                "columns": [],
-                "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}],
-            }
-        },
-    }
-    r1 = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
-    r2 = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
+    body = _cells_body()
+    r1 = client.post("/api/v1/datasets/trades_v1/query/cells", json=body)
+    r2 = client.post("/api/v1/datasets/trades_v1/query/cells", json=body)
     assert r1.status_code == 200
     assert r2.status_code == 200
     assert r1.json()["cells"]
@@ -134,19 +143,9 @@ def test_cells_not_cached_when_too_large(monkeypatch, client: TestClient) -> Non
 
     monkeypatch.setattr(db_manager, "execute_sql_async", counted)
 
-    body = {
-        "dataset_id": "trades_v1",
-        "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {
-            "axes": {
-                "rows": [{"field": "symbol"}],
-                "columns": [],
-                "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}],
-            }
-        },
-    }
-    r1 = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
-    r2 = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
+    body = _cells_body()
+    r1 = client.post("/api/v1/datasets/trades_v1/query/cells", json=body)
+    r2 = client.post("/api/v1/datasets/trades_v1/query/cells", json=body)
     assert r1.status_code == 200
     assert r2.status_code == 200
     assert r1.json()["cells"]
@@ -169,13 +168,9 @@ def test_picklist_dim_version_token_cache_hit(monkeypatch, client: TestClient) -
 
     monkeypatch.setattr(db_manager, "execute_sql_async", counted)
 
-    body = {
-        "dataset_id": "trades_v1",
-        "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {"field": "symbol", "paging": {"limit": 5, "offset": 0}},
-    }
-    r1 = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
-    r2 = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
+    body = _members_body()
+    r1 = client.post("/api/v1/datasets/trades_v1/query/members", json=body)
+    r2 = client.post("/api/v1/datasets/trades_v1/query/members", json=body)
     assert r1.status_code == 200
     assert r2.status_code == 200
     # Second request must be a cache hit – DB should only be called once.
@@ -193,22 +188,18 @@ def test_cache_miss_when_data_version_token_changes(monkeypatch, client: TestCli
 
     monkeypatch.setattr(db_manager, "execute_sql_async", counted)
 
-    body = {
-        "dataset_id": "trades_v1",
-        "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {"fields": [{"field": "symbol"}], "paging": {"limit": 10, "offset": 0}},
-    }
+    body = _tuples_body()
     datasets.set_partition_metadata(
         "trades_v1",
         {"partitions": [{"date": "2026-03-01", "files": [{"path": "p1.parquet", "size": 100, "etag": "e1"}]}]},
     )
-    r1 = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
+    r1 = client.post("/api/v1/datasets/trades_v1/query/tuples", json=body)
 
     datasets.set_partition_metadata(
         "trades_v1",
         {"partitions": [{"date": "2026-03-01", "files": [{"path": "p1.parquet", "size": 101, "etag": "e1"}]}]},
     )
-    r2 = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
+    r2 = client.post("/api/v1/datasets/trades_v1/query/tuples", json=body)
 
     assert r1.status_code == 200
     assert r2.status_code == 200
@@ -228,23 +219,19 @@ def test_picklist_dim_version_token_cache_miss_on_token_change(monkeypatch, clie
 
     monkeypatch.setattr(db_manager, "execute_sql_async", counted)
 
-    body = {
-        "dataset_id": "trades_v1",
-        "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {"field": "symbol", "paging": {"limit": 5, "offset": 0}},
-    }
+    body = _members_body()
 
     # First request with token v1.
     monkeypatch.setenv("QUERYSERVICE_DIM_VERSION_TOKEN", "token-v1")
     get_settings.cache_clear()
-    r1 = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
+    r1 = client.post("/api/v1/datasets/trades_v1/query/members", json=body)
     assert r1.status_code == 200
     assert call_count["n"] == 1
 
     # Change the token – the cache key changes, so this is a miss.
     monkeypatch.setenv("QUERYSERVICE_DIM_VERSION_TOKEN", "token-v2")
     get_settings.cache_clear()
-    r2 = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
+    r2 = client.post("/api/v1/datasets/trades_v1/query/members", json=body)
     assert r2.status_code == 200
     assert call_count["n"] == 2  # DB called again due to key change
 
@@ -262,21 +249,17 @@ def test_dim_version_token_change_does_not_invalidate_fact_cache(monkeypatch, cl
 
     monkeypatch.setattr(db_manager, "execute_sql_async", counted)
 
-    body = {
-        "dataset_id": "trades_v1",
-        "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {"fields": [{"field": "symbol"}], "paging": {"limit": 10, "offset": 0}},
-    }
+    body = _tuples_body()
 
     monkeypatch.setenv("QUERYSERVICE_DIM_VERSION_TOKEN", "dim-v1")
     get_settings.cache_clear()
-    r1 = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
+    r1 = client.post("/api/v1/datasets/trades_v1/query/tuples", json=body)
     assert r1.status_code == 200
     assert r1.json().get("items")
     assert call_count["n"] == 1
 
     monkeypatch.setenv("QUERYSERVICE_DIM_VERSION_TOKEN", "dim-v2")
     get_settings.cache_clear()
-    r2 = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
+    r2 = client.post("/api/v1/datasets/trades_v1/query/tuples", json=body)
     assert r2.status_code == 200
     assert call_count["n"] == 1

--- a/server/tests/test_query_cells_api.py
+++ b/server/tests/test_query_cells_api.py
@@ -8,18 +8,16 @@ from server.engine import db_manager
 
 
 def test_query_cells_returns_aggregated_data(client: TestClient) -> None:
+    dataset_id = "trades_v1"
     body = {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {
-            "axes": {
-                "rows": [{"field": "symbol"}],
-                "columns": [],
-                "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}],
-            },
+        "axes": {
+            "rows": [{"field": "symbol"}],
+            "columns": [],
+            "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}],
         },
     }
-    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
+    r = client.post(f"/api/v1/datasets/{dataset_id}/query/cells", json=body)
     assert r.status_code == 200
     data = r.json()
     assert len(data["cells"]) > 0
@@ -30,24 +28,22 @@ def test_query_cells_returns_aggregated_data(client: TestClient) -> None:
 
 
 def test_query_cells_multiple_aggregations(client: TestClient) -> None:
+    dataset_id = "trades_v1"
     body = {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {
-            "axes": {
-                "rows": [{"field": "symbol"}],
-                "columns": [],
-                "measures": [
-                    {"field": "volume", "aggregation": "SUM", "alias": "sum_vol"},
-                    {"field": "volume", "aggregation": "AVG", "alias": "avg_vol"},
-                    {"field": "volume", "aggregation": "MIN", "alias": "min_vol"},
-                    {"field": "volume", "aggregation": "MAX", "alias": "max_vol"},
-                    {"field": "volume", "aggregation": "COUNT", "alias": "cnt_vol"},
-                ],
-            },
+        "axes": {
+            "rows": [{"field": "symbol"}],
+            "columns": [],
+            "measures": [
+                {"field": "volume", "aggregation": "SUM", "alias": "sum_vol"},
+                {"field": "volume", "aggregation": "AVG", "alias": "avg_vol"},
+                {"field": "volume", "aggregation": "MIN", "alias": "min_vol"},
+                {"field": "volume", "aggregation": "MAX", "alias": "max_vol"},
+                {"field": "volume", "aggregation": "COUNT", "alias": "cnt_vol"},
+            ],
         },
     }
-    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
+    r = client.post(f"/api/v1/datasets/{dataset_id}/query/cells", json=body)
     assert r.status_code == 200
     cells = r.json()["cells"]
     assert len(cells) > 0
@@ -56,19 +52,17 @@ def test_query_cells_multiple_aggregations(client: TestClient) -> None:
 
 
 def test_query_cells_with_filter(client: TestClient) -> None:
+    dataset_id = "trades_v1"
     body = {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {
-            "axes": {
-                "rows": [{"field": "symbol"}],
-                "columns": [],
-                "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}],
-            },
-            "filters": [{"field": "symbol", "operator": "INCLUDE", "values": ["AAPL"]}],
+        "axes": {
+            "rows": [{"field": "symbol"}],
+            "columns": [],
+            "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}],
         },
+        "filters": [{"field": "symbol", "operator": "INCLUDE", "values": ["AAPL"]}],
     }
-    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
+    r = client.post(f"/api/v1/datasets/{dataset_id}/query/cells", json=body)
     assert r.status_code == 200
     cells = r.json()["cells"]
     assert len(cells) == 1
@@ -76,36 +70,30 @@ def test_query_cells_with_filter(client: TestClient) -> None:
 
 
 def test_query_cells_empty_axes_returns_empty(client: TestClient) -> None:
-    body = {
-        "dataset_id": "trades_v1",
-        "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {"axes": {"rows": [], "columns": [], "measures": []}},
-    }
-    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
+    body = {"date_range": {"type": "single", "date": "2026-03-01"}, "axes": {"rows": [], "columns": [], "measures": []}}
+    r = client.post("/api/v1/datasets/trades_v1/query/cells", json=body)
     assert r.status_code == 200
     assert r.json()["cells"] == []
 
 
 def test_query_cells_dataset_not_found(client: TestClient) -> None:
-    body = {"dataset_id": "nonexistent", "date_range": {"type": "single", "date": "2026-03-01"}, "query": {}}
-    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
+    body = {"date_range": {"type": "single", "date": "2026-03-01"}, "axes": {"rows": [], "columns": [], "measures": []}}
+    r = client.post("/api/v1/datasets/nonexistent/query/cells", json=body)
     assert r.status_code == 404
 
 
 def test_query_cells_row_window_limits_results(client: TestClient) -> None:
+    dataset_id = "trades_v1"
     body = {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {
-            "rows": {"start_index": 0, "count": 1},
-            "axes": {
-                "rows": [{"field": "symbol"}],
-                "columns": [],
-                "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}],
-            },
+        "window": {"rows": {"offset": 0, "limit": 1}},
+        "axes": {
+            "rows": [{"field": "symbol"}],
+            "columns": [],
+            "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}],
         },
     }
-    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
+    r = client.post(f"/api/v1/datasets/{dataset_id}/query/cells", json=body)
     assert r.status_code == 200
     cells = r.json()["cells"]
     assert len(cells) == 1
@@ -117,19 +105,18 @@ def test_query_cells_window_too_large_returns_error(client: TestClient, monkeypa
     settings = get_settings()
     monkeypatch.setattr(settings, "max_cells_per_response", 1, raising=False)
     body = {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {
-            "rows": {"start_index": 0, "count": 2},
-            "columns": {"start_index": 0, "count": 2},
-            "axes": {
-                "rows": [{"field": "symbol"}],
-                "columns": [{"field": "date"}],
-                "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}],
-            },
+        "window": {
+            "rows": {"offset": 0, "limit": 2},
+            "columns": {"offset": 0, "limit": 2},
+        },
+        "axes": {
+            "rows": [{"field": "symbol"}],
+            "columns": [{"field": "date"}],
+            "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}],
         },
     }
-    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
+    r = client.post("/api/v1/datasets/trades_v1/query/cells", json=body)
     assert r.status_code == 400
     data = r.json()
     assert data["code"] == "CELLS_WINDOW_TOO_LARGE"
@@ -140,17 +127,14 @@ def test_query_cells_no_windows_cap_enforced(client: TestClient, monkeypatch: py
     settings = get_settings()
     monkeypatch.setattr(settings, "max_cells_per_response", 1, raising=False)
     body = {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {
-            "axes": {
-                "rows": [{"field": "symbol"}],
-                "columns": [],
-                "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}],
-            },
+        "axes": {
+            "rows": [{"field": "symbol"}],
+            "columns": [],
+            "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}],
         },
     }
-    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
+    r = client.post("/api/v1/datasets/trades_v1/query/cells", json=body)
     assert r.status_code == 400
     data = r.json()
     assert data["code"] == "CELLS_WINDOW_TOO_LARGE"
@@ -168,18 +152,15 @@ def test_query_cells_row_window_only_cap_enforced(client: TestClient, monkeypatc
     settings = get_settings()
     monkeypatch.setattr(settings, "max_cells_per_response", 1, raising=False)
     body = {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "range", "start": "2026-03-01", "end": "2026-03-02"},
-        "query": {
-            "rows": {"start_index": 0, "count": 1},
-            "axes": {
-                "rows": [{"field": "symbol"}],
-                "columns": [{"field": "date"}],
-                "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}],
-            },
+        "window": {"rows": {"offset": 0, "limit": 1}},
+        "axes": {
+            "rows": [{"field": "symbol"}],
+            "columns": [{"field": "date"}],
+            "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}],
         },
     }
-    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
+    r = client.post("/api/v1/datasets/trades_v1/query/cells", json=body)
     assert r.status_code == 400
     assert r.json()["code"] == "CELLS_WINDOW_TOO_LARGE"
 
@@ -194,18 +175,15 @@ def test_query_cells_col_window_only_cap_enforced(client: TestClient, monkeypatc
     settings = get_settings()
     monkeypatch.setattr(settings, "max_cells_per_response", 1, raising=False)
     body = {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {
-            "columns": {"start_index": 0, "count": 1},
-            "axes": {
-                "rows": [{"field": "symbol"}],
-                "columns": [{"field": "date"}],
-                "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}],
-            },
+        "window": {"columns": {"offset": 0, "limit": 1}},
+        "axes": {
+            "rows": [{"field": "symbol"}],
+            "columns": [{"field": "date"}],
+            "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}],
         },
     }
-    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
+    r = client.post("/api/v1/datasets/trades_v1/query/cells", json=body)
     assert r.status_code == 400
     assert r.json()["code"] == "CELLS_WINDOW_TOO_LARGE"
 
@@ -215,17 +193,14 @@ def test_query_cells_within_cap_succeeds(client: TestClient, monkeypatch: pytest
     settings = get_settings()
     monkeypatch.setattr(settings, "max_cells_per_response", 10000, raising=False)
     body = {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {
-            "axes": {
-                "rows": [{"field": "symbol"}],
-                "columns": [],
-                "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}],
-            },
+        "axes": {
+            "rows": [{"field": "symbol"}],
+            "columns": [],
+            "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}],
         },
     }
-    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
+    r = client.post("/api/v1/datasets/trades_v1/query/cells", json=body)
     assert r.status_code == 200
     assert len(r.json()["cells"]) > 0
 
@@ -241,17 +216,14 @@ def test_cells_executes_sql_exactly_once(monkeypatch, client: TestClient) -> Non
 
     monkeypatch.setattr(db_manager, "execute_sql_async", counted)
     body = {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {
-            "axes": {
-                "rows": [{"field": "symbol"}],
-                "columns": [],
-                "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}],
-            },
+        "axes": {
+            "rows": [{"field": "symbol"}],
+            "columns": [],
+            "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}],
         },
     }
-    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
+    r = client.post("/api/v1/datasets/trades_v1/query/cells", json=body)
     assert r.status_code == 200
     assert call_count["n"] == 1, (
         "Expected exactly 1 SQL execution for /api/v1/datasets/{dataset_id}/query/cells, "

--- a/server/tests/test_query_partitioned_api.py
+++ b/server/tests/test_query_partitioned_api.py
@@ -45,31 +45,28 @@ def partitioned_empty_base_path(monkeypatch, tmp_path: Path) -> None:
 
 def _cells_body() -> dict:
     return {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {
-            "axes": {
-                "rows": [{"field": "symbol"}],
-                "columns": [],
-                "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}],
-            }
+        "axes": {
+            "rows": [{"field": "symbol"}],
+            "columns": [],
+            "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}],
         },
     }
 
 
 def _tuples_body() -> dict:
     return {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {"fields": [{"field": "symbol"}], "paging": {"limit": 10, "offset": 0}},
+        "fields": [{"field": "symbol"}],
+        "paging": {"limit": 10, "offset": 0},
     }
 
 
 def _picklist_body() -> dict:
     return {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {"field": "symbol", "paging": {"limit": 10, "offset": 0}},
+        "field": "symbol",
+        "paging": {"limit": 10, "offset": 0},
     }
 
 
@@ -103,7 +100,7 @@ def test_partition_config_error_cells_no_bucket_or_path(
     """When execution_mode=parquet_partitioned but no bucket/path is set,
     the v1 cells endpoint returns 500 PARTITION_CONFIG_ERROR."""
     body = _cells_body()
-    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
+    r = client.post("/api/v1/datasets/trades_v1/query/cells", json=body)
     assert r.status_code == 500
     data = r.json()
     assert data["code"] == "PARTITION_CONFIG_ERROR"
@@ -114,7 +111,7 @@ def test_partition_config_error_tuples_no_bucket_or_path(
 ) -> None:
     """Same PARTITION_CONFIG_ERROR check for the v1 tuples endpoint."""
     body = _tuples_body()
-    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
+    r = client.post("/api/v1/datasets/trades_v1/query/tuples", json=body)
     assert r.status_code == 500
     data = r.json()
     assert data["code"] == "PARTITION_CONFIG_ERROR"
@@ -125,7 +122,7 @@ def test_partition_config_error_picklist_no_bucket_or_path(
 ) -> None:
     """Same PARTITION_CONFIG_ERROR check for the v1 picklist endpoint."""
     body = _picklist_body()
-    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
+    r = client.post("/api/v1/datasets/trades_v1/query/members", json=body)
     assert r.status_code == 500
     data = r.json()
     assert data["code"] == "PARTITION_CONFIG_ERROR"
@@ -138,7 +135,7 @@ def test_partition_not_found_cells_missing_date(
     requested date partition directory does not exist, the v1 cells endpoint returns
     404 PARTITION_NOT_FOUND."""
     body = _cells_body()
-    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/cells", json=body)
+    r = client.post("/api/v1/datasets/trades_v1/query/cells", json=body)
     assert r.status_code == 404
     data = r.json()
     assert data["code"] == "PARTITION_NOT_FOUND"
@@ -151,7 +148,7 @@ def test_partition_not_found_tuples_missing_date(
 ) -> None:
     """Same PARTITION_NOT_FOUND check for the v1 tuples endpoint."""
     body = _tuples_body()
-    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
+    r = client.post("/api/v1/datasets/trades_v1/query/tuples", json=body)
     assert r.status_code == 404
     data = r.json()
     assert data["code"] == "PARTITION_NOT_FOUND"
@@ -162,7 +159,7 @@ def test_partition_not_found_picklist_missing_date(
 ) -> None:
     """Same PARTITION_NOT_FOUND check for the v1 picklist endpoint."""
     body = _picklist_body()
-    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
+    r = client.post("/api/v1/datasets/trades_v1/query/members", json=body)
     assert r.status_code == 404
     data = r.json()
     assert data["code"] == "PARTITION_NOT_FOUND"

--- a/server/tests/test_query_partitioned_api.py
+++ b/server/tests/test_query_partitioned_api.py
@@ -120,7 +120,7 @@ def test_partition_config_error_tuples_no_bucket_or_path(
 def test_partition_config_error_picklist_no_bucket_or_path(
     partitioned_no_storage, client: TestClient
 ) -> None:
-    """Same PARTITION_CONFIG_ERROR check for the v1 picklist endpoint."""
+    """Same PARTITION_CONFIG_ERROR check for the v1 members endpoint."""
     body = _picklist_body()
     r = client.post("/api/v1/datasets/trades_v1/query/members", json=body)
     assert r.status_code == 500
@@ -157,7 +157,7 @@ def test_partition_not_found_tuples_missing_date(
 def test_partition_not_found_picklist_missing_date(
     partitioned_empty_base_path, client: TestClient
 ) -> None:
-    """Same PARTITION_NOT_FOUND check for the v1 picklist endpoint."""
+    """Same PARTITION_NOT_FOUND check for the v1 members endpoint."""
     body = _picklist_body()
     r = client.post("/api/v1/datasets/trades_v1/query/members", json=body)
     assert r.status_code == 404

--- a/server/tests/test_query_picklist_api.py
+++ b/server/tests/test_query_picklist_api.py
@@ -1,17 +1,18 @@
-"""Tests for POST /api/v1/datasets/{dataset_id}/query/picklist."""
+"""Tests for POST /api/v1/datasets/{dataset_id}/query/members."""
 
 from fastapi.testclient import TestClient
 
 from server.engine import db_manager
 
 
-def test_query_picklist_returns_values(client: TestClient) -> None:
+def test_query_members_returns_values(client: TestClient) -> None:
+    dataset_id = "trades_v1"
     body = {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {"field": "symbol", "paging": {"limit": 100, "offset": 0}},
+        "field": "symbol",
+        "paging": {"limit": 100, "offset": 0},
     }
-    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
+    r = client.post(f"/api/v1/datasets/{dataset_id}/query/members", json=body)
     assert r.status_code == 200
     data = r.json()
     assert data["total_count"] > 0
@@ -23,13 +24,15 @@ def test_query_picklist_returns_values(client: TestClient) -> None:
         assert "label" in v
 
 
-def test_query_picklist_search_wildcard(client: TestClient) -> None:
+def test_query_members_search_wildcard(client: TestClient) -> None:
+    dataset_id = "trades_v1"
     body = {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {"field": "symbol", "search": "A*", "paging": {"limit": 100, "offset": 0}},
+        "field": "symbol",
+        "search": "A*",
+        "paging": {"limit": 100, "offset": 0},
     }
-    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
+    r = client.post(f"/api/v1/datasets/{dataset_id}/query/members", json=body)
     assert r.status_code == 200
     data = r.json()
     values = [v["value"] for v in data["values"]]
@@ -38,34 +41,30 @@ def test_query_picklist_search_wildcard(client: TestClient) -> None:
     assert "AMZN" in values
 
 
-def test_query_picklist_with_filter(client: TestClient) -> None:
+def test_query_members_with_filter(client: TestClient) -> None:
+    dataset_id = "trades_v1"
     body = {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "range", "start": "2026-03-01", "end": "2026-03-02"},
-        "query": {
-            "field": "symbol",
-            "filters": [{"field": "symbol", "operator": "EXCLUDE", "values": ["AAPL"]}],
-            "paging": {"limit": 100, "offset": 0},
-        },
+        "field": "symbol",
+        "filters": [{"field": "symbol", "operator": "EXCLUDE", "values": ["AAPL"]}],
+        "paging": {"limit": 100, "offset": 0},
     }
-    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
+    r = client.post(f"/api/v1/datasets/{dataset_id}/query/members", json=body)
     assert r.status_code == 200
     values = [v["value"] for v in r.json()["values"]]
     assert "AAPL" not in values
 
 
-def test_query_picklist_with_search_and_between_filter(client: TestClient) -> None:
+def test_query_members_with_search_and_between_filter(client: TestClient) -> None:
+    dataset_id = "trades_v1"
     body = {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "range", "start": "2026-03-01", "end": "2026-03-02"},
-        "query": {
-            "field": "symbol",
-            "search": "AA*",
-            "filters": [{"field": "volume", "operator": "BETWEEN", "values": [1000, 3000]}],
-            "paging": {"limit": 10, "offset": 0},
-        },
+        "field": "symbol",
+        "search": "AA*",
+        "filters": [{"field": "volume", "operator": "BETWEEN", "values": [1000, 3000]}],
+        "paging": {"limit": 10, "offset": 0},
     }
-    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
+    r = client.post(f"/api/v1/datasets/{dataset_id}/query/members", json=body)
     assert r.status_code == 200
     data = r.json()
     assert data["total_count"] == 1
@@ -73,26 +72,28 @@ def test_query_picklist_with_search_and_between_filter(client: TestClient) -> No
     assert [v["value"] for v in data["values"]] == ["AAPL"]
 
 
-def test_query_picklist_paging(client: TestClient) -> None:
+def test_query_members_paging(client: TestClient) -> None:
+    dataset_id = "trades_v1"
     body = {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {"field": "symbol", "paging": {"limit": 2, "offset": 0}},
+        "field": "symbol",
+        "paging": {"limit": 2, "offset": 0},
     }
-    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
+    r = client.post(f"/api/v1/datasets/{dataset_id}/query/members", json=body)
     assert r.status_code == 200
     data = r.json()
     assert data["paging"]["returned"] == 2
     assert data["total_count"] == 5
 
 
-def test_query_picklist_paging_limit_one(client: TestClient) -> None:
+def test_query_members_paging_limit_one(client: TestClient) -> None:
+    dataset_id = "trades_v1"
     body = {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {"field": "symbol", "paging": {"limit": 1, "offset": 0}},
+        "field": "symbol",
+        "paging": {"limit": 1, "offset": 0},
     }
-    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
+    r = client.post(f"/api/v1/datasets/{dataset_id}/query/members", json=body)
     assert r.status_code == 200
     data = r.json()
     assert data["paging"]["limit"] == 1
@@ -100,13 +101,14 @@ def test_query_picklist_paging_limit_one(client: TestClient) -> None:
     assert data["total_count"] >= data["paging"]["returned"]
 
 
-def test_query_picklist_empty_page_reports_total(client: TestClient) -> None:
+def test_query_members_empty_page_reports_total(client: TestClient) -> None:
+    dataset_id = "trades_v1"
     body = {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {"field": "symbol", "paging": {"limit": 5, "offset": 10}},
+        "field": "symbol",
+        "paging": {"limit": 5, "offset": 10},
     }
-    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
+    r = client.post(f"/api/v1/datasets/{dataset_id}/query/members", json=body)
     assert r.status_code == 200
     data = r.json()
     assert data["values"] == []
@@ -114,14 +116,14 @@ def test_query_picklist_empty_page_reports_total(client: TestClient) -> None:
     assert data["total_count"] == 5
 
 
-def test_query_picklist_dataset_not_found(client: TestClient) -> None:
-    body = {"dataset_id": "nonexistent", "date_range": {"type": "single", "date": "2026-03-01"}, "query": {}}
-    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
+def test_query_members_dataset_not_found(client: TestClient) -> None:
+    body = {"date_range": {"type": "single", "date": "2026-03-01"}, "field": "symbol"}
+    r = client.post("/api/v1/datasets/nonexistent/query/members", json=body)
     assert r.status_code == 404
 
 
-def test_picklist_executes_sql_exactly_once(monkeypatch, client: TestClient) -> None:
-    """Regression guard: the v1 picklist endpoint must call execute_sql_async exactly once per request."""
+def test_members_executes_sql_exactly_once(monkeypatch, client: TestClient) -> None:
+    """Regression guard: the v1 members endpoint must call execute_sql_async exactly once per request."""
     call_count = {"n": 0}
     original = db_manager.execute_sql_async
 
@@ -131,13 +133,13 @@ def test_picklist_executes_sql_exactly_once(monkeypatch, client: TestClient) -> 
 
     monkeypatch.setattr(db_manager, "execute_sql_async", counted)
     body = {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {"field": "symbol", "paging": {"limit": 10, "offset": 0}},
+        "field": "symbol",
+        "paging": {"limit": 10, "offset": 0},
     }
-    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/picklist", json=body)
+    r = client.post("/api/v1/datasets/trades_v1/query/members", json=body)
     assert r.status_code == 200
     assert call_count["n"] == 1, (
-        "Expected exactly 1 SQL execution for /api/v1/datasets/{dataset_id}/query/picklist, "
+        "Expected exactly 1 SQL execution for /api/v1/datasets/{dataset_id}/query/members, "
         f"got {call_count['n']}"
     )

--- a/server/tests/test_query_tuples_api.py
+++ b/server/tests/test_query_tuples_api.py
@@ -6,12 +6,13 @@ from server.engine import db_manager
 
 
 def test_query_tuples_returns_results(client: TestClient) -> None:
+    dataset_id = "trades_v1"
     body = {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {"fields": [{"field": "symbol"}], "paging": {"limit": 10, "offset": 0}},
+        "fields": [{"field": "symbol"}],
+        "paging": {"limit": 10, "offset": 0},
     }
-    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
+    r = client.post(f"/api/v1/datasets/{dataset_id}/query/tuples", json=body)
     assert r.status_code == 200
     data = r.json()
     assert data["total_count"] > 0
@@ -22,16 +23,14 @@ def test_query_tuples_returns_results(client: TestClient) -> None:
 
 
 def test_query_tuples_with_include_filter(client: TestClient) -> None:
+    dataset_id = "trades_v1"
     body = {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {
-            "fields": [{"field": "symbol"}],
-            "filters": [{"field": "symbol", "operator": "INCLUDE", "values": ["AAPL", "GOOG"]}],
-            "paging": {"limit": 10, "offset": 0},
-        },
+        "fields": [{"field": "symbol"}],
+        "filters": [{"field": "symbol", "operator": "INCLUDE", "values": ["AAPL", "GOOG"]}],
+        "paging": {"limit": 10, "offset": 0},
     }
-    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
+    r = client.post(f"/api/v1/datasets/{dataset_id}/query/tuples", json=body)
     assert r.status_code == 200
     data = r.json()
     assert data["total_count"] == 2
@@ -40,16 +39,14 @@ def test_query_tuples_with_include_filter(client: TestClient) -> None:
 
 
 def test_query_tuples_with_exclude_filter(client: TestClient) -> None:
+    dataset_id = "trades_v1"
     body = {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {
-            "fields": [{"field": "symbol"}],
-            "filters": [{"field": "symbol", "operator": "EXCLUDE", "values": ["AAPL"]}],
-            "paging": {"limit": 10, "offset": 0},
-        },
+        "fields": [{"field": "symbol"}],
+        "filters": [{"field": "symbol", "operator": "EXCLUDE", "values": ["AAPL"]}],
+        "paging": {"limit": 10, "offset": 0},
     }
-    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
+    r = client.post(f"/api/v1/datasets/{dataset_id}/query/tuples", json=body)
     assert r.status_code == 200
     data = r.json()
     symbols = {item["values"][0] for item in data["items"]}
@@ -58,24 +55,26 @@ def test_query_tuples_with_exclude_filter(client: TestClient) -> None:
 
 
 def test_query_tuples_date_range(client: TestClient) -> None:
+    dataset_id = "trades_v1"
     body = {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "range", "start": "2026-03-01", "end": "2026-03-02"},
-        "query": {"fields": [{"field": "symbol"}], "paging": {"limit": 10, "offset": 0}},
+        "fields": [{"field": "symbol"}],
+        "paging": {"limit": 10, "offset": 0},
     }
-    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
+    r = client.post(f"/api/v1/datasets/{dataset_id}/query/tuples", json=body)
     assert r.status_code == 200
     data = r.json()
     assert data["total_count"] == 5
 
 
 def test_query_tuples_paging(client: TestClient) -> None:
+    dataset_id = "trades_v1"
     body = {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {"fields": [{"field": "symbol"}], "paging": {"limit": 2, "offset": 0}},
+        "fields": [{"field": "symbol"}],
+        "paging": {"limit": 2, "offset": 0},
     }
-    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
+    r = client.post(f"/api/v1/datasets/{dataset_id}/query/tuples", json=body)
     assert r.status_code == 200
     data = r.json()
     assert data["paging"]["returned"] == 2
@@ -83,12 +82,13 @@ def test_query_tuples_paging(client: TestClient) -> None:
 
 
 def test_query_tuples_paging_limit_one(client: TestClient) -> None:
+    dataset_id = "trades_v1"
     body = {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {"fields": [{"field": "symbol", "sort": "ASC"}], "paging": {"limit": 1, "offset": 0}},
+        "fields": [{"field": "symbol", "sort": "ASC"}],
+        "paging": {"limit": 1, "offset": 0},
     }
-    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
+    r = client.post(f"/api/v1/datasets/{dataset_id}/query/tuples", json=body)
     assert r.status_code == 200
     data = r.json()
     assert data["paging"]["limit"] == 1
@@ -97,14 +97,15 @@ def test_query_tuples_paging_limit_one(client: TestClient) -> None:
 
 
 def test_query_tuples_paging_offset(client: TestClient) -> None:
+    dataset_id = "trades_v1"
     body_page1 = {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {"fields": [{"field": "symbol", "sort": "ASC"}], "paging": {"limit": 2, "offset": 0}},
+        "fields": [{"field": "symbol", "sort": "ASC"}],
+        "paging": {"limit": 2, "offset": 0},
     }
-    body_page2 = {**body_page1, "query": {**body_page1["query"], "paging": {"limit": 2, "offset": 2}}}
-    r1 = client.post(f"/api/v1/datasets/{body_page1['dataset_id']}/query/tuples", json=body_page1)
-    r2 = client.post(f"/api/v1/datasets/{body_page2['dataset_id']}/query/tuples", json=body_page2)
+    body_page2 = {**body_page1, "paging": {"limit": 2, "offset": 2}}
+    r1 = client.post(f"/api/v1/datasets/{dataset_id}/query/tuples", json=body_page1)
+    r2 = client.post(f"/api/v1/datasets/{dataset_id}/query/tuples", json=body_page2)
     page1_symbols = {item["values"][0] for item in r1.json()["items"]}
     page2_symbols = {item["values"][0] for item in r2.json()["items"]}
     assert page1_symbols.isdisjoint(page2_symbols)
@@ -112,14 +113,13 @@ def test_query_tuples_paging_offset(client: TestClient) -> None:
 
 def test_query_tuples_paging_offset_limit_one(client: TestClient) -> None:
     base_query = {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {"fields": [{"field": "symbol", "sort": "ASC"}]},
+        "fields": [{"field": "symbol", "sort": "ASC"}],
     }
-    body_page1 = {**base_query, "query": {**base_query["query"], "paging": {"limit": 1, "offset": 0}}}
-    body_page2 = {**base_query, "query": {**base_query["query"], "paging": {"limit": 1, "offset": 1}}}
-    r1 = client.post(f"/api/v1/datasets/{body_page1['dataset_id']}/query/tuples", json=body_page1)
-    r2 = client.post(f"/api/v1/datasets/{body_page2['dataset_id']}/query/tuples", json=body_page2)
+    body_page1 = {**base_query, "paging": {"limit": 1, "offset": 0}}
+    body_page2 = {**base_query, "paging": {"limit": 1, "offset": 1}}
+    r1 = client.post("/api/v1/datasets/trades_v1/query/tuples", json=body_page1)
+    r2 = client.post("/api/v1/datasets/trades_v1/query/tuples", json=body_page2)
     assert r1.status_code == 200
     assert r2.status_code == 200
     data1 = r1.json()
@@ -131,12 +131,13 @@ def test_query_tuples_paging_offset_limit_one(client: TestClient) -> None:
 
 
 def test_query_tuples_empty_page_reports_total(client: TestClient) -> None:
+    dataset_id = "trades_v1"
     body = {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {"fields": [{"field": "symbol"}], "paging": {"limit": 10, "offset": 10}},
+        "fields": [{"field": "symbol"}],
+        "paging": {"limit": 10, "offset": 10},
     }
-    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
+    r = client.post(f"/api/v1/datasets/{dataset_id}/query/tuples", json=body)
     assert r.status_code == 200
     data = r.json()
     assert data["items"] == []
@@ -145,24 +146,21 @@ def test_query_tuples_empty_page_reports_total(client: TestClient) -> None:
 
 
 def test_query_tuples_sort_desc(client: TestClient) -> None:
+    dataset_id = "trades_v1"
     body = {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {"fields": [{"field": "symbol", "sort": "DESC"}], "paging": {"limit": 10, "offset": 0}},
+        "fields": [{"field": "symbol", "sort": "DESC"}],
+        "paging": {"limit": 10, "offset": 0},
     }
-    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
+    r = client.post(f"/api/v1/datasets/{dataset_id}/query/tuples", json=body)
     assert r.status_code == 200
     symbols = [item["values"][0] for item in r.json()["items"]]
     assert symbols == sorted(symbols, reverse=True)
 
 
 def test_query_tuples_dataset_not_found(client: TestClient) -> None:
-    body = {
-        "dataset_id": "nonexistent",
-        "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {},
-    }
-    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
+    body = {"date_range": {"type": "single", "date": "2026-03-01"}, "fields": [{"field": "symbol"}]}
+    r = client.post("/api/v1/datasets/nonexistent/query/tuples", json=body)
     assert r.status_code == 404
 
 
@@ -178,11 +176,11 @@ def test_tuples_executes_sql_exactly_once(monkeypatch, client: TestClient) -> No
 
     monkeypatch.setattr(db_manager, "execute_sql_async", counted)
     body = {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
-        "query": {"fields": [{"field": "symbol"}], "paging": {"limit": 10, "offset": 0}},
+        "fields": [{"field": "symbol"}],
+        "paging": {"limit": 10, "offset": 0},
     }
-    r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
+    r = client.post("/api/v1/datasets/trades_v1/query/tuples", json=body)
     assert r.status_code == 200
     assert call_count["n"] == 1, (
         "Expected exactly 1 SQL execution for /api/v1/datasets/{dataset_id}/query/tuples, "

--- a/server/tests/test_rate_limiting.py
+++ b/server/tests/test_rate_limiting.py
@@ -26,9 +26,8 @@ def rate_limited_client(monkeypatch) -> TestClient:
 
 def _query_body() -> dict:
     return {
-        "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-01-01"},
-        "query": {},
+        "fields": [{"field": "symbol"}],
     }
 
 
@@ -51,24 +50,24 @@ def _export_body() -> dict:
 
 def test_rate_limit_exceeded(rate_limited_client: TestClient) -> None:
     body = _query_body()
-    first = rate_limited_client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
+    first = rate_limited_client.post("/api/v1/datasets/trades_v1/query/tuples", json=body)
     assert first.headers["X-API-Version"] == "1"
     assert "X-RateLimit-Limit" in first.headers
     assert "X-RateLimit-Remaining" in first.headers
     assert "X-RateLimit-Reset" in first.headers
-    second = rate_limited_client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
+    second = rate_limited_client.post("/api/v1/datasets/trades_v1/query/tuples", json=body)
     assert "X-RateLimit-Limit" in second.headers
 
-    response = rate_limited_client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
+    response = rate_limited_client.post("/api/v1/datasets/trades_v1/query/tuples", json=body)
     assert response.status_code == 429
 
 
 def test_rate_limit_returns_retry_after(rate_limited_client: TestClient) -> None:
     body = _query_body()
-    rate_limited_client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
-    rate_limited_client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
+    rate_limited_client.post("/api/v1/datasets/trades_v1/query/tuples", json=body)
+    rate_limited_client.post("/api/v1/datasets/trades_v1/query/tuples", json=body)
 
-    response = rate_limited_client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
+    response = rate_limited_client.post("/api/v1/datasets/trades_v1/query/tuples", json=body)
     assert response.status_code == 429
     assert response.headers["X-API-Version"] == "1"
     retry_after = response.headers.get("Retry-After")
@@ -110,7 +109,7 @@ def test_rate_limiting_disabled(monkeypatch) -> None:
         # Query: two calls exceed the "1/minute" limit but limiting is off
         for _ in range(2):
             body = _query_body()
-            r = client.post(f"/api/v1/datasets/{body['dataset_id']}/query/tuples", json=body)
+            r = client.post("/api/v1/datasets/trades_v1/query/tuples", json=body)
             assert r.status_code == 200
         # Export: two calls exceed the "1/minute" limit but limiting is off
         for _ in range(2):

--- a/server/tests/test_validation_errors.py
+++ b/server/tests/test_validation_errors.py
@@ -1,45 +1,46 @@
-"""
-Consolidated tests for request validation (422 errors) across all endpoints.
-
-All Pydantic validation error tests live here. Endpoint-specific test files
-focus on happy-path / business-logic tests only.
-"""
+"""Validation tests for v1 query and export request contracts."""
 
 import pytest
 from fastapi.testclient import TestClient
 
 from server.config import get_settings
 
-QUERY_ENDPOINTS = ["tuples", "cells", "picklist"]
-ALL_POST_ENDPOINTS = [*QUERY_ENDPOINTS, "export"]
+QUERY_ENDPOINTS = ["tuples", "cells", "members"]
 EXPORTS_ROOT = "/api/v1/exports"
 
-_BASE_BODY = {
-    "dataset_id": "trades_v1",
-    "date_range": {"type": "single", "date": "2026-03-01"},
-    "query": {},
-}
 
-
-def _body(**query_overrides):
-    """Build a valid base body with query overrides."""
-    body = {**_BASE_BODY, "query": {**_BASE_BODY["query"], **query_overrides}}
-    return body
+def _post_path(endpoint: str, dataset_id: str = "trades_v1") -> str:
+    if endpoint == "tuples":
+        return f"/api/v1/datasets/{dataset_id}/query/tuples"
+    if endpoint == "cells":
+        return f"/api/v1/datasets/{dataset_id}/query/cells"
+    if endpoint == "members":
+        return f"/api/v1/datasets/{dataset_id}/query/members"
+    return EXPORTS_ROOT
 
 
 def _valid_body_for(endpoint: str) -> dict:
     if endpoint == "tuples":
-        return _body(fields=[{"field": "symbol"}], paging={"limit": 10, "offset": 0})
+        return {
+            "fields": [{"field": "symbol"}],
+            "paging": {"limit": 10, "offset": 0},
+            "date_range": {"type": "single", "date": "2026-03-01"},
+        }
     if endpoint == "cells":
-        return _body(
-            axes={
+        return {
+            "axes": {
                 "rows": [{"field": "symbol"}],
                 "columns": [],
                 "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}],
-            }
-        )
-    if endpoint == "picklist":
-        return _body(field="symbol", paging={"limit": 10, "offset": 0})
+            },
+            "date_range": {"type": "single", "date": "2026-03-01"},
+        }
+    if endpoint == "members":
+        return {
+            "field": "symbol",
+            "paging": {"limit": 10, "offset": 0},
+            "date_range": {"type": "single", "date": "2026-03-01"},
+        }
     return {
         "dataset_id": "trades_v1",
         "date_range": {"type": "single", "date": "2026-03-01"},
@@ -47,120 +48,24 @@ def _valid_body_for(endpoint: str) -> dict:
     }
 
 
-def _post_path(endpoint: str, body: dict) -> str:
-    dataset_id = body.get("dataset_id", "trades_v1")
-    if endpoint == "tuples":
-        return f"/api/v1/datasets/{dataset_id}/query/tuples"
-    if endpoint == "cells":
-        return f"/api/v1/datasets/{dataset_id}/query/cells"
-    if endpoint == "picklist":
-        return f"/api/v1/datasets/{dataset_id}/query/picklist"
-    return EXPORTS_ROOT
-
-
-@pytest.mark.parametrize("endpoint", ALL_POST_ENDPOINTS)
-class TestCommonValidation:
-    """Validation scenarios shared across all POST endpoints."""
-
+@pytest.mark.parametrize("endpoint", QUERY_ENDPOINTS)
+class TestCommonQueryValidation:
     def test_empty_body(self, client: TestClient, endpoint: str) -> None:
-        r = client.post(_post_path(endpoint, {}), json={})
+        r = client.post(_post_path(endpoint), json={})
         assert r.status_code == 422
 
-    def test_missing_dataset_id(self, client: TestClient, endpoint: str) -> None:
-        r = client.post(_post_path(endpoint, {}), json={
-            "date_range": {"type": "single", "date": "2026-01-01"},
-            "query": {},
-        })
+    def test_rejects_dataset_id_in_body(self, client: TestClient, endpoint: str) -> None:
+        body = _valid_body_for(endpoint)
+        body["dataset_id"] = "trades_v1"
+        r = client.post(_post_path(endpoint), json=body)
         assert r.status_code == 422
+        error = r.json()["details"]["errors"][0]
+        assert error["loc"] == ["body", "dataset_id"]
+        assert error["type"] == "extra_forbidden"
 
-    def test_dataset_id_wrong_type(self, client: TestClient, endpoint: str) -> None:
-        body = {
-            "dataset_id": 123,
-            "date_range": {"type": "single", "date": "2026-01-01"},
-            "query": {},
-        }
-        r = client.post(_post_path(endpoint, body), json=body)
-        assert r.status_code == 422
-
-    def test_date_range_null(self, client: TestClient, endpoint: str) -> None:
-        body = {
-            "dataset_id": "trades_v1",
-            "date_range": None,
-            "query": {},
-        }
-        r = client.post(_post_path(endpoint, body), json=body)
-        assert r.status_code == 422
-
-    def test_date_range_empty_object(self, client: TestClient, endpoint: str) -> None:
-        body = {
-            "dataset_id": "trades_v1",
-            "date_range": {},
-            "query": {},
-        }
-        r = client.post(_post_path(endpoint, body), json=body)
-        assert r.status_code == 422
-
-    def test_date_range_unknown_type(self, client: TestClient, endpoint: str) -> None:
-        body = {
-            "dataset_id": "trades_v1",
-            "date_range": {"type": "weekly", "date": "2026-01-01"},
-            "query": {},
-        }
-        r = client.post(_post_path(endpoint, body), json=body)
-        assert r.status_code == 422
-
-    def test_date_bad_format(self, client: TestClient, endpoint: str) -> None:
-        body = {
-            "dataset_id": "trades_v1",
-            "date_range": {"type": "single", "date": "not-a-date"},
-            "query": {},
-        }
-        r = client.post(_post_path(endpoint, body), json=body)
-        assert r.status_code == 422
-
-    def test_date_invalid_calendar_value(self, client: TestClient, endpoint: str) -> None:
-        body = {
-            "dataset_id": "trades_v1",
-            "date_range": {"type": "single", "date": "2026-02-30"},
-            "query": {},
-        }
-        r = client.post(_post_path(endpoint, body), json=body)
-        assert r.status_code == 422
-
-    def test_date_range_inverted(self, client: TestClient, endpoint: str) -> None:
-        body = {
-            "dataset_id": "trades_v1",
-            "date_range": {"type": "range", "start": "2026-12-01", "end": "2026-01-01"},
-            "query": {},
-        }
-        r = client.post(_post_path(endpoint, body), json=body)
-        assert r.status_code == 422
-
-    def test_date_range_missing_end(self, client: TestClient, endpoint: str) -> None:
-        body = {
-            "dataset_id": "trades_v1",
-            "date_range": {"type": "range", "start": "2026-01-01"},
-            "query": {},
-        }
-        r = client.post(_post_path(endpoint, body), json=body)
-        assert r.status_code == 422
-
-    def test_date_range_missing_date_field(self, client: TestClient, endpoint: str) -> None:
-        body = {
-            "dataset_id": "trades_v1",
-            "date_range": {"type": "single"},
-            "query": {},
-        }
-        r = client.post(_post_path(endpoint, body), json=body)
-        assert r.status_code == 422
-
-    def test_date_range_invalid_calendar_value(self, client: TestClient, endpoint: str) -> None:
-        body = {
-            "dataset_id": "trades_v1",
-            "date_range": {"type": "range", "start": "2026-01-01", "end": "2026-13-01"},
-            "query": {},
-        }
-        r = client.post(_post_path(endpoint, body), json=body)
+    def test_rejects_nested_query_wrapper(self, client: TestClient, endpoint: str) -> None:
+        body = {"query": _valid_body_for(endpoint)}
+        r = client.post(_post_path(endpoint), json=body)
         assert r.status_code == 422
 
     def test_date_range_at_span_limit(self, monkeypatch, client: TestClient, endpoint: str) -> None:
@@ -169,7 +74,7 @@ class TestCommonValidation:
         try:
             body = _valid_body_for(endpoint)
             body["date_range"] = {"type": "range", "start": "2026-03-01", "end": "2026-03-02"}
-            r = client.post(_post_path(endpoint, body), json=body)
+            r = client.post(_post_path(endpoint), json=body)
         finally:
             get_settings.cache_clear()
         assert r.status_code < 400
@@ -180,307 +85,103 @@ class TestCommonValidation:
         monkeypatch.setenv("QUERYSERVICE_MAX_DATE_RANGE_DAYS", "2")
         get_settings.cache_clear()
         try:
-            request_body = _valid_body_for(endpoint)
-            request_body["date_range"] = {"type": "range", "start": "2026-03-01", "end": "2026-03-03"}
-            r = client.post(_post_path(endpoint, request_body), json=request_body)
+            body = _valid_body_for(endpoint)
+            body["date_range"] = {"type": "range", "start": "2026-03-01", "end": "2026-03-03"}
+            r = client.post(_post_path(endpoint), json=body)
         finally:
             get_settings.cache_clear()
         assert r.status_code == 422
-        resp_body = r.json()
-        assert resp_body["code"] == "VALIDATION_ERROR"
-        assert resp_body["details"]["errors"][0]["ctx"] == {"requested_days": 3, "max_days": 2}
-        assert "exceeds configured max of 2" in resp_body["details"]["errors"][0]["msg"]
-
-    def test_not_json(self, client: TestClient, endpoint: str) -> None:
-        r = client.post(_post_path(endpoint, {}), content="not json", headers={"Content-Type": "application/json"})
-        assert r.status_code == 422
-
-
-class TestFilterValidation:
-    """Filter operator and value validation."""
-
-    def test_filter_missing_operator(self, client: TestClient) -> None:
-        body = {
-            "dataset_id": "trades_v1",
-            "date_range": {"type": "single", "date": "2026-03-01"},
-            "query": {
-                "fields": [{"field": "symbol"}],
-                "filters": [{"field": "symbol", "values": ["AAPL"]}],
-            },
-        }
-        r = client.post(_post_path("tuples", body), json=body)
-        assert r.status_code == 422
-
-
-class TestVersionedDatasetIdValidation:
-    @pytest.mark.parametrize("endpoint", QUERY_ENDPOINTS)
-    def test_dataset_id_must_match_path(self, client: TestClient, endpoint: str) -> None:
-        body = _valid_body_for(endpoint)
-        body["dataset_id"] = "trades_v1"
-        r = client.post(f"/api/v1/datasets/other_ds/query/{endpoint}", json=body)
-        assert r.status_code == 422
         payload = r.json()
         assert payload["code"] == "VALIDATION_ERROR"
-        error = payload["details"]["errors"][0]
-        assert error["loc"] == ["body", "dataset_id"]
-        assert error["type"] == "value_error.dataset_id_mismatch"
-        assert error["ctx"] == {
-            "path_dataset_id": "other_ds",
-            "body_dataset_id": "trades_v1",
-        }
-
-    def test_filter_missing_values(self, client: TestClient) -> None:
-        body = {
-            "dataset_id": "trades_v1",
-            "date_range": {"type": "single", "date": "2026-03-01"},
-            "query": {
-                "fields": [{"field": "symbol"}],
-                "filters": [{"field": "symbol", "operator": "INCLUDE"}],
-            },
-        }
-        r = client.post(_post_path("tuples", body), json=body)
-        assert r.status_code == 422
-
-    def test_invalid_operator_rejected(self, client: TestClient) -> None:
-        body = {
-            "dataset_id": "trades_v1",
-            "date_range": {"type": "single", "date": "2026-03-01"},
-            "query": {
-                "fields": [{"field": "symbol"}],
-                "filters": [{"field": "symbol", "operator": "INVALID", "values": ["x"]}],
-            },
-        }
-        r = client.post(_post_path("tuples", body), json=body)
-        assert r.status_code == 422
-
-    def test_lowercase_operator_rejected(self, client: TestClient) -> None:
-        body = {
-            "dataset_id": "trades_v1",
-            "date_range": {"type": "single", "date": "2026-03-01"},
-            "query": {
-                "fields": [{"field": "symbol"}],
-                "filters": [{"field": "symbol", "operator": "include", "values": ["x"]}],
-            },
-        }
-        r = client.post(_post_path("tuples", body), json=body)
-        assert r.status_code == 422
+        assert payload["details"]["errors"][0]["ctx"] == {"requested_days": 3, "max_days": 2}
 
 
-class TestSortValidation:
-    """Sort direction validation."""
-
+class TestTuplesValidation:
     def test_invalid_sort_rejected(self, client: TestClient) -> None:
-        body = {
-            "dataset_id": "trades_v1",
-            "date_range": {"type": "single", "date": "2026-03-01"},
-            "query": {
-                "fields": [{"field": "symbol", "sort": "RANDOM"}],
-            },
+        body = _valid_body_for("tuples")
+        body["fields"] = [{"field": "symbol", "sort": "RANDOM"}]
+        r = client.post(_post_path("tuples"), json=body)
+        assert r.status_code == 422
+
+    def test_unknown_tuples_field_rejected(self, client: TestClient) -> None:
+        body = _valid_body_for("tuples")
+        body["fields"] = [{"field": "not_a_field"}]
+        r = client.post(_post_path("tuples"), json=body)
+        assert r.status_code == 422
+        assert r.json()["details"]["errors"][0]["loc"] == ["body", "fields", 0, "field"]
+
+    def test_unknown_filter_field_rejected(self, client: TestClient) -> None:
+        body = _valid_body_for("tuples")
+        body["filters"] = [{"field": "not_a_field", "operator": "INCLUDE", "values": ["AAPL"]}]
+        r = client.post(_post_path("tuples"), json=body)
+        assert r.status_code == 422
+        assert r.json()["details"]["errors"][0]["loc"] == ["body", "filters", 0, "field"]
+
+    def test_limit_bounds_rejected(self, client: TestClient) -> None:
+        body = _valid_body_for("tuples")
+        body["paging"] = {"limit": 0, "offset": 0}
+        r = client.post(_post_path("tuples"), json=body)
+        assert r.status_code == 422
+
+
+class TestCellsValidation:
+    def test_missing_axes_rejected(self, client: TestClient) -> None:
+        body = {"date_range": {"type": "single", "date": "2026-03-01"}}
+        r = client.post(_post_path("cells"), json=body)
+        assert r.status_code == 422
+
+    def test_unknown_cells_axis_or_measure_rejected(self, client: TestClient) -> None:
+        body = _valid_body_for("cells")
+        body["axes"] = {
+            "rows": [{"field": "not_a_field"}],
+            "columns": [],
+            "measures": [{"field": "also_not_a_field", "aggregation": "SUM", "alias": "bad"}],
         }
-        r = client.post(_post_path("tuples", body), json=body)
+        r = client.post(_post_path("cells"), json=body)
         assert r.status_code == 422
+        assert len(r.json()["details"]["errors"]) == 2
 
-    def test_lowercase_sort_rejected(self, client: TestClient) -> None:
-        body = {
-            "dataset_id": "trades_v1",
-            "date_range": {"type": "single", "date": "2026-03-01"},
-            "query": {
-                "fields": [{"field": "symbol", "sort": "asc"}],
-            },
-        }
-        r = client.post(_post_path("tuples", body), json=body)
+    def test_invalid_aggregation_rejected(self, client: TestClient) -> None:
+        body = _valid_body_for("cells")
+        body["axes"]["measures"] = [{"field": "volume", "aggregation": "INVALID"}]
+        r = client.post(_post_path("cells"), json=body)
         assert r.status_code == 422
 
 
-class TestPagingValidation:
-    """Paging bounds validation across tuples and picklist endpoints."""
-
-    @pytest.mark.parametrize("endpoint", ["tuples", "picklist"])
-    def test_limit_zero_rejected(self, client: TestClient, endpoint: str) -> None:
-        body = {
-            "dataset_id": "trades_v1",
-            "date_range": {"type": "single", "date": "2026-03-01"},
-            "query": {"fields": [{"field": "symbol"}], "field": "symbol", "paging": {"limit": 0}},
-        }
-        r = client.post(_post_path(endpoint, body), json=body)
+class TestMembersValidation:
+    def test_unknown_members_field_rejected(self, client: TestClient) -> None:
+        body = _valid_body_for("members")
+        body["field"] = "not_a_field"
+        r = client.post(_post_path("members"), json=body)
         assert r.status_code == 422
+        assert r.json()["details"]["errors"][0]["loc"] == ["body", "field"]
 
-    @pytest.mark.parametrize("endpoint", ["tuples", "picklist"])
-    def test_limit_negative_rejected(self, client: TestClient, endpoint: str) -> None:
-        body = {
-            "dataset_id": "trades_v1",
-            "date_range": {"type": "single", "date": "2026-03-01"},
-            "query": {"fields": [{"field": "symbol"}], "field": "symbol", "paging": {"limit": -5}},
-        }
-        r = client.post(_post_path(endpoint, body), json=body)
+    def test_offset_negative_rejected(self, client: TestClient) -> None:
+        body = _valid_body_for("members")
+        body["paging"] = {"limit": 10, "offset": -1}
+        r = client.post(_post_path("members"), json=body)
         assert r.status_code == 422
-
-    @pytest.mark.parametrize("endpoint", ["tuples", "picklist"])
-    def test_limit_exceeds_max_rejected(self, client: TestClient, endpoint: str) -> None:
-        body = {
-            "dataset_id": "trades_v1",
-            "date_range": {"type": "single", "date": "2026-03-01"},
-            "query": {"fields": [{"field": "symbol"}], "field": "symbol", "paging": {"limit": 10001}},
-        }
-        r = client.post(_post_path(endpoint, body), json=body)
-        assert r.status_code == 422
-
-    @pytest.mark.parametrize("endpoint", ["tuples", "picklist"])
-    def test_offset_negative_rejected(self, client: TestClient, endpoint: str) -> None:
-        body = {
-            "dataset_id": "trades_v1",
-            "date_range": {"type": "single", "date": "2026-03-01"},
-            "query": {"fields": [{"field": "symbol"}], "field": "symbol", "paging": {"offset": -1}},
-        }
-        r = client.post(_post_path(endpoint, body), json=body)
-        assert r.status_code == 422
-
-
-class TestAxesValidation:
-    """Typed axes model validation — invalid aggregation rejected at parse time."""
-
-    def test_invalid_aggregation_in_cells_rejected(self, client: TestClient) -> None:
-        body = {
-            "dataset_id": "trades_v1",
-            "date_range": {"type": "single", "date": "2026-03-01"},
-            "query": {
-                "axes": {
-                    "rows": [{"field": "symbol"}],
-                    "measures": [{"field": "volume", "aggregation": "INVALID"}],
-                },
-            },
-        }
-        r = client.post(_post_path("cells", body), json=body)
-        assert r.status_code == 422
-        body = r.json()
-        assert body["code"] == "VALIDATION_ERROR"
-
-    def test_invalid_aggregation_in_export_rejected(self, client: TestClient) -> None:
-        r = client.post("/api/v1/exports", json={
-            "dataset_id": "trades_v1",
-            "date_range": {"type": "single", "date": "2026-03-01"},
-            "query": {
-                "axes": {
-                    "rows": [{"field": "symbol"}],
-                    "measures": [{"field": "volume", "aggregation": "MEDIAN"}],
-                },
-            },
-        })
-        assert r.status_code == 422
-        body = r.json()
-        assert body["code"] == "VALIDATION_ERROR"
 
 
 class TestExportValidation:
-    """Export-specific field validation."""
-
     def test_invalid_format_rejected(self, client: TestClient) -> None:
-        r = client.post("/api/v1/exports", json={
-            "dataset_id": "trades_v1",
-            "date_range": {"type": "single", "date": "2026-03-01"},
-            "query": {"format": "xlsx"},
-        })
-        assert r.status_code == 422
-
-    def test_max_rows_zero_rejected(self, client: TestClient) -> None:
-        r = client.post("/api/v1/exports", json={
-            "dataset_id": "trades_v1",
-            "date_range": {"type": "single", "date": "2026-03-01"},
-            "query": {"max_rows": 0},
-        })
-        assert r.status_code == 422
-
-    def test_max_rows_negative_rejected(self, client: TestClient) -> None:
-        r = client.post("/api/v1/exports", json={
-            "dataset_id": "trades_v1",
-            "date_range": {"type": "single", "date": "2026-03-01"},
-            "query": {"max_rows": -10},
-        })
+        r = client.post(
+            EXPORTS_ROOT,
+            json={
+                "dataset_id": "trades_v1",
+                "date_range": {"type": "single", "date": "2026-03-01"},
+                "query": {"format": "xlsx"},
+            },
+        )
         assert r.status_code == 422
 
     def test_max_rows_exceeds_limit_rejected(self, client: TestClient) -> None:
-        r = client.post("/api/v1/exports", json={
-            "dataset_id": "trades_v1",
-            "date_range": {"type": "single", "date": "2026-03-01"},
-            "query": {"max_rows": 100001},
-        })
-        assert r.status_code == 422
-
-
-class TestSchemaValidation:
-    def test_missing_dataset_id_param(self, client: TestClient) -> None:
-        r = client.get("/api/v1/datasets//schema")
-        assert r.status_code == 404
-
-
-class TestUnknownSchemaFields:
-    def test_unknown_tuples_field_rejected(self, client: TestClient) -> None:
-        body = {
-            "dataset_id": "trades_v1",
-            "date_range": {"type": "single", "date": "2026-03-01"},
-            "query": {"fields": [{"field": "not_a_field"}]},
-        }
-        r = client.post(_post_path("tuples", body), json=body)
-        assert r.status_code == 422
-        body = r.json()
-        assert body["code"] == "VALIDATION_ERROR"
-        assert body["details"]["errors"][0]["loc"] == ["body", "query", "fields", 0, "field"]
-
-    def test_unknown_filter_field_rejected(self, client: TestClient) -> None:
-        body = {
-            "dataset_id": "trades_v1",
-            "date_range": {"type": "single", "date": "2026-03-01"},
-            "query": {
-                "fields": [{"field": "symbol"}],
-                "filters": [{"field": "not_a_field", "operator": "INCLUDE", "values": ["AAPL"]}],
+        r = client.post(
+            EXPORTS_ROOT,
+            json={
+                "dataset_id": "trades_v1",
+                "date_range": {"type": "single", "date": "2026-03-01"},
+                "query": {"max_rows": 100001},
             },
-        }
-        r = client.post(_post_path("tuples", body), json=body)
+        )
         assert r.status_code == 422
-        body = r.json()
-        assert body["code"] == "VALIDATION_ERROR"
-        assert body["details"]["errors"][0]["loc"] == ["body", "query", "filters", 0, "field"]
-
-    def test_unknown_cells_axis_or_measure_rejected(self, client: TestClient) -> None:
-        body = {
-            "dataset_id": "trades_v1",
-            "date_range": {"type": "single", "date": "2026-03-01"},
-            "query": {
-                "axes": {
-                    "rows": [{"field": "not_a_field"}],
-                    "columns": [],
-                    "measures": [{"field": "also_not_a_field", "aggregation": "SUM", "alias": "bad"}],
-                },
-            },
-        }
-        r = client.post(_post_path("cells", body), json=body)
-        assert r.status_code == 422
-        body = r.json()
-        assert body["code"] == "VALIDATION_ERROR"
-        assert len(body["details"]["errors"]) == 2
-
-    def test_unknown_picklist_field_rejected(self, client: TestClient) -> None:
-        body = {
-            "dataset_id": "trades_v1",
-            "date_range": {"type": "single", "date": "2026-03-01"},
-            "query": {"field": "not_a_field"},
-        }
-        r = client.post(_post_path("picklist", body), json=body)
-        assert r.status_code == 422
-        body = r.json()
-        assert body["code"] == "VALIDATION_ERROR"
-        assert body["details"]["errors"][0]["loc"] == ["body", "query", "field"]
-
-    def test_unknown_export_field_rejected(self, client: TestClient) -> None:
-        r = client.post("/api/v1/exports", json={
-            "dataset_id": "trades_v1",
-            "date_range": {"type": "single", "date": "2026-03-01"},
-            "query": {
-                "format": "csv",
-                "axes": {"rows": [{"field": "not_a_field"}], "measures": []},
-            },
-        })
-        assert r.status_code == 422
-        body = r.json()
-        assert body["code"] == "VALIDATION_ERROR"
-        assert body["details"]["errors"][0]["loc"] == ["body", "query", "axes", "rows", 0, "field"]

--- a/src/DataSource/remote/RemoteDatasource.js
+++ b/src/DataSource/remote/RemoteDatasource.js
@@ -31,12 +31,14 @@ function normalizeDateRange(dateRange) {
   return { type: 'single', date };
 }
 
-function buildEnvelope(datasetId, dateRange, query) {
-  return {
-    dataset_id: datasetId,
-    date_range: normalizeDateRange(dateRange),
-    query: query || {}
+function buildRequestBody(dateRange, query) {
+  const body = {
+    ...(query || {})
   };
+  if (dateRange) {
+    body.date_range = normalizeDateRange(dateRange);
+  }
+  return body;
 }
 
 function buildDatasetPath(datasource, suffix) {
@@ -108,13 +110,12 @@ class RemoteConnection {
   }
 
   fetchTuples(dateRange, query, clientContext) {
-    const datasetId = this.#datasource.getDatasetId();
-    const envelope = buildEnvelope(datasetId, dateRange, query);
+    const requestBody = buildRequestBody(dateRange, query);
     this.#abortController = new AbortController();
     return fetch(buildDatasetPath(this.#datasource, '/query/tuples'), {
       method: 'POST',
       headers: buildHeaders(this.#datasource, true, clientContext),
-      body: JSON.stringify(envelope),
+      body: JSON.stringify(requestBody),
       signal: this.#abortController.signal
     }).then((res) => {
       if (!res.ok) {
@@ -134,13 +135,12 @@ class RemoteConnection {
   }
 
   fetchCells(dateRange, query, clientContext) {
-    const datasetId = this.#datasource.getDatasetId();
-    const envelope = buildEnvelope(datasetId, dateRange, query);
+    const requestBody = buildRequestBody(dateRange, query);
     this.#abortController = new AbortController();
     return fetch(buildDatasetPath(this.#datasource, '/query/cells'), {
       method: 'POST',
       headers: buildHeaders(this.#datasource, true, clientContext),
-      body: JSON.stringify(envelope),
+      body: JSON.stringify(requestBody),
       signal: this.#abortController.signal
     }).then((res) => {
       if (!res.ok) {
@@ -160,13 +160,12 @@ class RemoteConnection {
   }
 
   fetchPicklist(dateRange, query, clientContext) {
-    const datasetId = this.#datasource.getDatasetId();
-    const envelope = buildEnvelope(datasetId, dateRange, query);
+    const requestBody = buildRequestBody(dateRange, query);
     this.#abortController = new AbortController();
-    return fetch(buildDatasetPath(this.#datasource, '/query/picklist'), {
+    return fetch(buildDatasetPath(this.#datasource, '/query/members'), {
       method: 'POST',
       headers: buildHeaders(this.#datasource, true, clientContext),
-      body: JSON.stringify(envelope),
+      body: JSON.stringify(requestBody),
       signal: this.#abortController.signal
     }).then((res) => {
       if (!res.ok) {

--- a/src/DataSource/remote/RemoteQueryAdapter.js
+++ b/src/DataSource/remote/RemoteQueryAdapter.js
@@ -14,11 +14,6 @@ export class RemoteQueryAdapter {
     max: 'MAX'
   };
 
-  /** Default date when query model has no date range; use a date that matches common sample data. */
-  static #createDefaultDateRange() {
-    return { type: 'single', date: '2026-03-01' };
-  }
-
   static getDateRange(queryModel) {
     if (queryModel && typeof queryModel.getDateRange === 'function') {
       const queryModelDateRange = queryModel.getDateRange();
@@ -26,7 +21,7 @@ export class RemoteQueryAdapter {
         return queryModelDateRange;
       }
     }
-    return RemoteQueryAdapter.#createDefaultDateRange();
+    return undefined;
   }
 
   static #getRemoteFieldForAxisItem(axisItem, context) {
@@ -198,8 +193,10 @@ export class RemoteQueryAdapter {
     const filters = RemoteQueryAdapter.toRemoteFilters(queryModel.getFiltersAxis().getItems(), 'cells');
 
     return {
-      rows: { start_index: 0, count: Math.max(1, rowCount || 0) },
-      columns: { start_index: 0, count: Math.max(1, colCount || 0) },
+      window: {
+        rows: { offset: 0, limit: Math.max(1, rowCount || 0) },
+        columns: { offset: 0, limit: Math.max(1, colCount || 0) }
+      },
       axes: {
         rows: rowsAxisItems.map((item) => {
           return { field: RemoteQueryAdapter.#getRemoteFieldForAxisItem(item, 'cells rows') };

--- a/src/DataSource/remote/RemoteQueryAdapter.js
+++ b/src/DataSource/remote/RemoteQueryAdapter.js
@@ -180,7 +180,6 @@ export class RemoteQueryAdapter {
     const filters = RemoteQueryAdapter.toRemoteFilters(queryModel.getFiltersAxis().getItems(), 'tuples');
 
     return {
-      axis: axisId,
       fields: fields,
       filters: filters,
       paging: { limit: limit, offset: offset }

--- a/tests/test_backend_benchmark_runner.py
+++ b/tests/test_backend_benchmark_runner.py
@@ -17,7 +17,7 @@ class _BenchmarkHandler(BaseHTTPRequestHandler):
         if self.path in {
             "/api/v1/datasets/trades_v1/query/tuples",
             "/api/v1/datasets/trades_v1/query/cells",
-            "/api/v1/datasets/trades_v1/query/picklist",
+            "/api/v1/datasets/trades_v1/query/members",
             "/api/v1/exports",
         }:
             payload = b'{"ok":true}'

--- a/tests/ui/remote-mode.spec.js
+++ b/tests/ui/remote-mode.spec.js
@@ -54,7 +54,7 @@ test.describe('Remote mode UI', () => {
     await page.route('**/api/v1/datasets/*/schema', (route) => route.fulfill({ status: 200, body: JSON.stringify(schemaResponse) }));
     await page.route('**/api/v1/datasets/*/query/tuples', (route) => route.fulfill({ status: 200, body: JSON.stringify(tuplesResponse) }));
     await page.route('**/api/v1/datasets/*/query/cells', (route) => route.fulfill({ status: 200, body: JSON.stringify(cellsResponse) }));
-    await page.route('**/api/v1/datasets/*/query/picklist', (route) => route.fulfill({ status: 200, body: JSON.stringify({ total_count: 3, values: [{ value: 'AAPL', label: 'AAPL' }], paging: { limit: 100, offset: 0, returned: 1 } }) }));
+    await page.route('**/api/v1/datasets/*/query/members', (route) => route.fulfill({ status: 200, body: JSON.stringify({ total_count: 3, values: [{ value: 'AAPL', label: 'AAPL' }], paging: { limit: 100, offset: 0, returned: 1 } }) }));
 
     await waitForAppReady(page);
     await expect(page.locator('#addRemoteDatasource')).toBeVisible({ timeout: 10000 });

--- a/tests/unit/dataset-cache-limits.test.js
+++ b/tests/unit/dataset-cache-limits.test.js
@@ -192,8 +192,8 @@ describe('DataSet cache limits', () => {
     const connection = {
       fetchCells(dateRange, query) {
         fetchCellsCallCount += 1;
-        const rowCount = query.rows.count || 1;
-        const colCount = query.columns.count || 1;
+        const rowCount = query.window?.rows?.limit || 1;
+        const colCount = query.window?.columns?.limit || 1;
         const cells = [];
         for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
           for (let columnIndex = 0; columnIndex < colCount; columnIndex++) {
@@ -287,8 +287,8 @@ describe('DataSet cache limits', () => {
     const connection = {
       fetchCells(dateRange, query) {
         fetchCellsCallCount += 1;
-        const rowCount = query.rows.count || 1;
-        const colCount = query.columns.count || 1;
+        const rowCount = query.window?.rows?.limit || 1;
+        const colCount = query.window?.columns?.limit || 1;
         const cells = [];
         for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
           for (let columnIndex = 0; columnIndex < colCount; columnIndex++) {
@@ -392,8 +392,8 @@ describe('DataSet cache limits', () => {
     const connection = {
       fetchCells(dateRange, query) {
         fetchCellsCallCount += 1;
-        const rowCount = query.rows.count || 1;
-        const colCount = query.columns.count || 1;
+        const rowCount = query.window?.rows?.limit || 1;
+        const colCount = query.window?.columns?.limit || 1;
         const cells = [];
         for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
           for (let columnIndex = 0; columnIndex < colCount; columnIndex++) {

--- a/tests/unit/remote-query-adapter.test.js
+++ b/tests/unit/remote-query-adapter.test.js
@@ -126,10 +126,8 @@ describe('RemoteQueryAdapter', () => {
     }).toThrow('does not support aggregator');
   });
 
-  test('falls back to single-date range when query model has no date range', () => {
+  test('returns undefined when query model has no date range', () => {
     const dateRange = RemoteQueryAdapter.getDateRange({});
-    expect(dateRange.type).toBe('single');
-    expect(typeof dateRange.date).toBe('string');
-    expect(dateRange.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(dateRange).toBeUndefined();
   });
 });


### PR DESCRIPTION
Implements #407 as part of #403.

Summary:
- move query request bodies to the new top-level v1 shapes
- remove `dataset_id` from query bodies and use the path parameter only
- make `date_range` optional on query endpoints
- rename `/query/picklist` to `/query/members`
- update remote datasource client/adapter, benchmarks, docs, and tests to the new contract
- add `DATE_RANGE_NOT_SUPPORTED` for datasets without a time dimension

Validation:
- `./.venv-server/bin/ruff check server/`
- `./.venv-server/bin/pytest server/tests -q`
- `./.venv-server/bin/pytest tests/test_backend_benchmark_runner.py -q`
- `npm run lint:js`