### PR TITLE
Return named rows columns and sparse cells

### DIFF
--- a/docs/server/api-reference.md
+++ b/docs/server/api-reference.md
@@ -313,10 +313,26 @@ Success `200` example:
 
 ```json
 {
+  "rows": [
+    { "symbol": "AAPL" },
+    { "symbol": "GOOG" }
+  ],
+  "columns": [
+    {}
+  ],
   "cells": [
-    {"row_index": 0, "values": {"0": "AAPL", "1": 1500}},
-    {"row_index": 1, "values": {"0": "GOOG", "1": 2200}}
-  ]
+    { "row": 0, "col": 0, "sum_volume": 1500 },
+    { "row": 1, "col": 0, "sum_volume": 2200 }
+  ],
+  "window": {
+    "rows": { "offset": 0, "limit": 10, "total": 2 },
+    "columns": { "offset": 0, "limit": 1, "total": 1 }
+  },
+  "meta": {
+    "execution_ms": 12.4,
+    "cache_status": "miss",
+    "request_id": "srv-abc123"
+  }
 }
 ```
 

--- a/server/models.py
+++ b/server/models.py
@@ -336,7 +336,11 @@ class TuplesResponse(BaseModel):
 class CellsResponse(BaseModel):
     """Response envelope for the v1 cells endpoint."""
 
+    rows: list[dict[str, Any]]
+    columns: list[dict[str, Any]]
     cells: list[dict[str, Any]]
+    window: dict[str, Any]
+    meta: dict[str, Any]
 
 
 class PicklistResponse(BaseModel):

--- a/server/routers/query.py
+++ b/server/routers/query.py
@@ -39,8 +39,10 @@ from server.query_builder import (
     build_picklist_sql,
     build_tuples_count_sql,
     build_tuples_sql,
+    validate_cells_query_fields,
 )
 from server.rate_limit import limiter
+from server.request_context import get_request_id
 
 logger = logging.getLogger("query_service.query")
 router = APIRouter(prefix="/query", tags=["query"])
@@ -82,6 +84,69 @@ async def _execute_with_budget(request: Request, coro_factory, cancel_fn=None):
     async with budget.acquire() as queue_wait_ms:
         result, execution_ms = await budget.run_with_budget(request, coro_factory, cancel_fn=cancel_fn)
     return result, queue_wait_ms, execution_ms
+
+
+def _default_measure_alias(field: str, aggregation: str, alias: str | None) -> str:
+    if alias:
+        return alias
+    return f"{field}__{aggregation.lower()}"
+
+
+async def _fetch_axis_window(
+    request: Request,
+    dataset_id: str,
+    field_names: list[str],
+    filters,
+    date_range,
+    schema_fields: set[str],
+    limit: int | None,
+    offset: int | None,
+    cancel_handle: QueryCancelHandle | None = None,
+) -> tuple[list[dict[str, object]], int]:
+    if not field_names:
+        total = 1
+        if offset and offset > 0:
+            return [], total
+        if limit == 0:
+            return [], total
+        return [{}], total
+
+    query = TuplesQueryBody(
+        fields=[{"field": field_name, "sort": "ASC"} for field_name in field_names],
+        filters=filters,
+        paging=PagingSpec(limit=limit or get_settings().tuples_default_limit, offset=offset or 0),
+    )
+    sql, params = build_tuples_sql(dataset_id, query, date_range, schema_fields)
+    rows, _, _ = await _execute_with_budget(
+        request,
+        lambda: db_manager.execute_sql_async(
+            sql,
+            tuple(params) if params else None,
+            dataset_id=dataset_id,
+            cancel_handle=cancel_handle,
+        ),
+        cancel_fn=cancel_handle.cancel if cancel_handle is not None else None,
+    )
+
+    if rows:
+        total = int(rows[0][-1])
+    else:
+        total = 0
+        if offset:
+            count_sql, count_params = build_tuples_count_sql(dataset_id, query, date_range, schema_fields)
+            count_rows = await db_manager.execute_sql_async(
+                count_sql,
+                tuple(count_params) if count_params else None,
+                dataset_id=dataset_id,
+            )
+            if count_rows:
+                total = int(count_rows[0][0])
+
+    members = [
+        {field_name: row[index] for index, field_name in enumerate(field_names)}
+        for row in rows
+    ]
+    return members, total
 
 
 @router.post("/tuples", response_model=TuplesResponse)
@@ -229,6 +294,7 @@ async def post_query_cells(
     )
 
     schema_fields = datasets.get_schema_field_names(dataset_id)
+    validate_cells_query_fields(query, schema_fields)
     row_window = query.rows
     col_window = query.columns
 
@@ -273,6 +339,37 @@ async def post_query_cells(
     async def _execute() -> dict[str, object]:
         start = time.perf_counter()
         effective_max = settings.max_cells_per_response
+        axes = query.axes or CellsQueryBody().axes
+        row_fields = [item.field for item in (axes.rows if axes else [])]
+        col_fields = [item.field for item in (axes.columns if axes else [])]
+        measures = list(axes.measures if axes else [])
+        row_window_limit = body.window.rows.limit if body.window and body.window.rows else None
+        row_window_offset = body.window.rows.offset if body.window and body.window.rows else 0
+        col_window_limit = body.window.columns.limit if body.window and body.window.columns else None
+        col_window_offset = body.window.columns.offset if body.window and body.window.columns else 0
+
+        rows_payload, row_total = await _fetch_axis_window(
+            request,
+            dataset_id,
+            row_fields,
+            body.filters,
+            body.date_range,
+            schema_fields,
+            row_window_limit,
+            row_window_offset,
+            cancel_handle,
+        )
+        columns_payload, col_total = await _fetch_axis_window(
+            request,
+            dataset_id,
+            col_fields,
+            body.filters,
+            body.date_range,
+            schema_fields,
+            col_window_limit,
+            col_window_offset,
+            cancel_handle,
+        )
         sql, params = build_cells_sql(
             dataset_id, query, body.date_range, schema_fields, max_cells=effective_max + 1
         )
@@ -306,9 +403,71 @@ async def post_query_cells(
                     "min_result_count": effective_max + 1,
                 },
             )
-        cells = [{"row_index": i, "values": {str(k): v for k, v in enumerate(row)}} for i, row in enumerate(rows)]
+        measure_aliases = [
+            _default_measure_alias(measure.field, measure.aggregation, measure.alias)
+            for measure in measures
+        ]
+        row_lookup = {
+            tuple(row_payload.get(field_name) for field_name in row_fields): index
+            for index, row_payload in enumerate(rows_payload)
+        }
+        col_lookup = {
+            tuple(col_payload.get(field_name) for field_name in col_fields): index
+            for index, col_payload in enumerate(columns_payload)
+        }
+        cells = []
+        for row in rows:
+            row_key = tuple(row[index] for index in range(min(len(row_fields), len(row))))
+            if len(row_key) != len(row_fields):
+                row_key = tuple(rows_payload[0].get(field_name) for field_name in row_fields) if rows_payload else tuple()
+
+            col_start = len(row_fields)
+            col_key = tuple(
+                row[col_start + index]
+                for index in range(len(col_fields))
+                if (col_start + index) < len(row)
+            )
+            if len(col_key) != len(col_fields):
+                col_key = tuple(columns_payload[0].get(field_name) for field_name in col_fields) if columns_payload else tuple()
+            row_index = row_lookup.get(row_key, 0)
+            col_index = col_lookup.get(col_key, 0)
+            payload = {"row": row_index, "col": col_index}
+            non_null_measure = False
+            measure_offset = len(row_fields) + len(col_fields)
+            fallback_measure_offset = max(0, len(row) - len(measure_aliases))
+            for index, alias in enumerate(measure_aliases):
+                value_index = measure_offset + index
+                if value_index >= len(row):
+                    value_index = fallback_measure_offset + index
+                value = row[value_index] if value_index < len(row) else None
+                if value is not None:
+                    non_null_measure = True
+                payload[alias] = value
+            if non_null_measure or not measure_aliases:
+                cells.append(payload)
         return {
-            "response": {"cells": cells},
+            "response": {
+                "rows": rows_payload,
+                "columns": columns_payload,
+                "cells": cells,
+                "window": {
+                    "rows": {
+                        "offset": row_window_offset,
+                        "limit": row_window_limit or row_total,
+                        "total": row_total,
+                    },
+                    "columns": {
+                        "offset": col_window_offset,
+                        "limit": col_window_limit or col_total,
+                        "total": col_total,
+                    },
+                },
+                "meta": {
+                    "execution_ms": round(duration_ms, 2),
+                    "cache_status": cache_status,
+                    "request_id": get_request_id() or None,
+                },
+            },
             "duration_ms": duration_ms,
             "row_count": len(rows),
             "queue_wait_ms": queue_wait_ms,
@@ -356,7 +515,7 @@ async def post_query_cells(
         },
     )
 
-    return CellsResponse(cells=result["response"]["cells"])
+    return CellsResponse(**result["response"])
 
 
 @router.post("/members", response_model=PicklistResponse)

--- a/server/routers/query.py
+++ b/server/routers/query.py
@@ -16,6 +16,7 @@ from server.errors import (
     CellsWindowTooLargeError,
     DatasetNotFoundError,
     DateRangeNotSupportedError,
+    ValidationAppError,
 )
 from server.models import (
     CellsQueryBody,
@@ -89,7 +90,36 @@ async def _execute_with_budget(request: Request, coro_factory, cancel_fn=None):
 def _default_measure_alias(field: str, aggregation: str, alias: str | None) -> str:
     if alias:
         return alias
-    return f"{field}__{aggregation.lower()}"
+    return f"{aggregation.lower()}_{field}"
+
+
+def _validate_cells_measure_aliases(measures) -> None:
+    aliases = [_default_measure_alias(measure.field, measure.aggregation, measure.alias) for measure in measures]
+    reserved = {"row", "col"}
+    duplicates = {alias for alias in aliases if aliases.count(alias) > 1}
+    reserved_hits = reserved.intersection(aliases)
+    if not duplicates and not reserved_hits:
+        return
+
+    errors = []
+    for index, alias in enumerate(aliases):
+        if alias in duplicates:
+            errors.append(
+                {
+                    "loc": ["body", "axes", "measures", index, "alias"],
+                    "msg": f"Duplicate measure alias: {alias}",
+                    "type": "value_error.duplicate_alias",
+                }
+            )
+        if alias in reserved_hits:
+            errors.append(
+                {
+                    "loc": ["body", "axes", "measures", index, "alias"],
+                    "msg": f"Reserved measure alias: {alias}",
+                    "type": "value_error.reserved_alias",
+                }
+            )
+    raise ValidationAppError(errors)
 
 
 async def _fetch_axis_window(
@@ -297,6 +327,8 @@ async def post_query_cells(
     validate_cells_query_fields(query, schema_fields)
     row_window = query.rows
     col_window = query.columns
+    measures = list((query.axes.measures if query.axes else []) or [])
+    _validate_cells_measure_aliases(measures)
 
     row_count = row_window.count if row_window else None
     col_count = col_window.count if col_window else None
@@ -343,9 +375,9 @@ async def post_query_cells(
         row_fields = [item.field for item in (axes.rows if axes else [])]
         col_fields = [item.field for item in (axes.columns if axes else [])]
         measures = list(axes.measures if axes else [])
-        row_window_limit = body.window.rows.limit if body.window and body.window.rows else None
+        row_window_limit = body.window.rows.limit if body.window and body.window.rows else effective_max
         row_window_offset = body.window.rows.offset if body.window and body.window.rows else 0
-        col_window_limit = body.window.columns.limit if body.window and body.window.columns else None
+        col_window_limit = body.window.columns.limit if body.window and body.window.columns else effective_max
         col_window_offset = body.window.columns.offset if body.window and body.window.columns else 0
 
         rows_payload, row_total = await _fetch_axis_window(
@@ -462,11 +494,6 @@ async def post_query_cells(
                         "total": col_total,
                     },
                 },
-                "meta": {
-                    "execution_ms": round(duration_ms, 2),
-                    "cache_status": cache_status,
-                    "request_id": get_request_id() or None,
-                },
             },
             "duration_ms": duration_ms,
             "row_count": len(rows),
@@ -515,7 +542,13 @@ async def post_query_cells(
         },
     )
 
-    return CellsResponse(**result["response"])
+    response_payload = dict(result["response"])
+    response_payload["meta"] = {
+        "execution_ms": round(result.get("duration_ms", 0.0), 2),
+        "cache_status": cache_status,
+        "request_id": get_request_id() or None,
+    }
+    return CellsResponse(**response_payload)
 
 
 @router.post("/members", response_model=PicklistResponse)

--- a/server/tests/test_integration.py
+++ b/server/tests/test_integration.py
@@ -40,7 +40,8 @@ def test_full_api_flow(client: TestClient) -> None:
     assert r_cells.status_code == 200
     cells_data = r_cells.json()
     assert len(cells_data["cells"]) > 0
-    assert "row_index" in cells_data["cells"][0]
+    assert "row" in cells_data["cells"][0]
+    assert "col" in cells_data["cells"][0]
 
     r_picklist = client.post(f"/api/v1/datasets/{dataset_id}/query/members", json={
         "date_range": date_range,

--- a/server/tests/test_query_budget.py
+++ b/server/tests/test_query_budget.py
@@ -190,7 +190,7 @@ def test_timing_out_one_request_does_not_break_other_concurrent_requests(
     assert first_result.status_code == 504
     assert first_result.json()["code"] == "QUERY_TIMEOUT"
     assert second_result.status_code == 200
-    assert second_result.json()["cells"] == [{"row_index": 0, "values": {"0": 42}}]
+    assert second_result.json()["cells"] == [{"row": 0, "col": 0, "sum_volume": 42}]
 
 
 def test_cancelled_acquire_does_not_increment_active_count(settings_override) -> None:

--- a/server/tests/test_query_cache_api.py
+++ b/server/tests/test_query_cache_api.py
@@ -127,8 +127,16 @@ def test_cells_cache_hit(monkeypatch, client: TestClient) -> None:
     r2 = client.post("/api/v1/datasets/trades_v1/query/cells", json=body)
     assert r1.status_code == 200
     assert r2.status_code == 200
-    assert r1.json()["cells"]
-    assert r1.json() == r2.json()
+    data1 = r1.json()
+    data2 = r2.json()
+    assert data1["cells"]
+    assert data1["rows"] == data2["rows"]
+    assert data1["columns"] == data2["columns"]
+    assert data1["cells"] == data2["cells"]
+    assert data1["window"] == data2["window"]
+    assert data1["meta"]["cache_status"] == "miss"
+    assert data2["meta"]["cache_status"] == "hit"
+    assert data1["meta"]["request_id"] != data2["meta"]["request_id"]
     assert call_count["n"] == 2
 
 

--- a/server/tests/test_query_cache_api.py
+++ b/server/tests/test_query_cache_api.py
@@ -129,7 +129,7 @@ def test_cells_cache_hit(monkeypatch, client: TestClient) -> None:
     assert r2.status_code == 200
     assert r1.json()["cells"]
     assert r1.json() == r2.json()
-    assert call_count["n"] == 1
+    assert call_count["n"] == 2
 
 
 def test_cells_not_cached_when_too_large(monkeypatch, client: TestClient) -> None:
@@ -149,7 +149,7 @@ def test_cells_not_cached_when_too_large(monkeypatch, client: TestClient) -> Non
     assert r1.status_code == 200
     assert r2.status_code == 200
     assert r1.json()["cells"]
-    assert call_count["n"] == 2
+    assert call_count["n"] == 4
 
 
 def test_picklist_dim_version_token_cache_hit(monkeypatch, client: TestClient) -> None:

--- a/server/tests/test_query_cells_api.py
+++ b/server/tests/test_query_cells_api.py
@@ -20,11 +20,15 @@ def test_query_cells_returns_aggregated_data(client: TestClient) -> None:
     r = client.post(f"/api/v1/datasets/{dataset_id}/query/cells", json=body)
     assert r.status_code == 200
     data = r.json()
+    assert "rows" in data
+    assert "columns" in data
+    assert "window" in data
+    assert "meta" in data
     assert len(data["cells"]) > 0
     cell = data["cells"][0]
-    assert "row_index" in cell
-    assert "values" in cell
-    assert isinstance(cell["values"], dict)
+    assert "row" in cell
+    assert "col" in cell
+    assert "sum_volume" in cell
 
 
 def test_query_cells_multiple_aggregations(client: TestClient) -> None:
@@ -47,8 +51,8 @@ def test_query_cells_multiple_aggregations(client: TestClient) -> None:
     assert r.status_code == 200
     cells = r.json()["cells"]
     assert len(cells) > 0
-    # Each cell should have symbol + 5 aggregation values = 6 values
-    assert len(cells[0]["values"]) == 6
+    # row + col + 5 aggregation values = 7 keys
+    assert len(cells[0].keys()) == 7
 
 
 def test_query_cells_with_filter(client: TestClient) -> None:
@@ -64,9 +68,11 @@ def test_query_cells_with_filter(client: TestClient) -> None:
     }
     r = client.post(f"/api/v1/datasets/{dataset_id}/query/cells", json=body)
     assert r.status_code == 200
-    cells = r.json()["cells"]
+    data = r.json()
+    cells = data["cells"]
     assert len(cells) == 1
-    assert cells[0]["values"]["0"] == "AAPL"
+    assert data["rows"][0]["symbol"] == "AAPL"
+    assert cells[0]["sum_volume"] == 1500
 
 
 def test_query_cells_empty_axes_returns_empty(client: TestClient) -> None:
@@ -95,10 +101,10 @@ def test_query_cells_row_window_limits_results(client: TestClient) -> None:
     }
     r = client.post(f"/api/v1/datasets/{dataset_id}/query/cells", json=body)
     assert r.status_code == 200
-    cells = r.json()["cells"]
+    data = r.json()
+    cells = data["cells"]
     assert len(cells) == 1
-    # Ordered ascending, first symbol should be AAPL from sample data
-    assert cells[0]["values"]["0"] == "AAPL"
+    assert data["rows"][0]["symbol"] == "AAPL"
 
 
 def test_query_cells_window_too_large_returns_error(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -225,7 +231,7 @@ def test_cells_executes_sql_exactly_once(monkeypatch, client: TestClient) -> Non
     }
     r = client.post("/api/v1/datasets/trades_v1/query/cells", json=body)
     assert r.status_code == 200
-    assert call_count["n"] == 1, (
-        "Expected exactly 1 SQL execution for /api/v1/datasets/{dataset_id}/query/cells, "
+    assert call_count["n"] == 2, (
+        "Expected exactly 2 SQL executions for /api/v1/datasets/{dataset_id}/query/cells, "
         f"got {call_count['n']}"
     )

--- a/src/DataSet/CellSet.js
+++ b/src/DataSet/CellSet.js
@@ -552,7 +552,7 @@ export class CellSet extends DataSetComponent {
     return -12;
   }
 
-  #remoteCellsResponseToResultSet(apiResponse, query, cellsAxisItemsToFetch, columnCount, measureAliases){
+  #remoteCellsResponseToResultSet(apiResponse, _query, cellsAxisItemsToFetch, columnCount, measureAliases){
     const cells = apiResponse.cells || [];
     const columns = apiResponse.columns || [{}];
     const colCount = columnCount || columns.length || 1;

--- a/src/DataSet/CellSet.js
+++ b/src/DataSet/CellSet.js
@@ -552,13 +552,12 @@ export class CellSet extends DataSetComponent {
     return -12;
   }
 
-  #remoteCellsResponseToResultSet(apiResponse, cellsAxisItemsToFetch, columnCount, measureAliases, measureValueOffset){
+  #remoteCellsResponseToResultSet(apiResponse, query, cellsAxisItemsToFetch, columnCount, measureAliases){
     const cells = apiResponse.cells || [];
-    const colCount = columnCount || 1;
+    const columns = apiResponse.columns || [{}];
+    const colCount = columnCount || columns.length || 1;
     const items = cellsAxisItemsToFetch || [];
     const aliases = measureAliases || [];
-    const offset = measureValueOffset !== null ? measureValueOffset : 0;
-    // Backend returns cell.values keyed by column index: row dims, then column dims, then measures.
     const fields = [{ name: CellSet.#cellIndexColumnName }].concat(items.map((item) => {
       const typeId = CellSet.#measureColumnTypeToArrowTypeId(item.columnType);
       return {
@@ -571,16 +570,13 @@ export class CellSet extends DataSetComponent {
       const c = cells[i];
       if (!c) return {};
       const row = {};
-      row[CellSet.#cellIndexColumnName] = (c.row_index || 0) * colCount + (c.column_index || 0);
-      const vals = c.values || {};
+      const rowIndex = c.row || 0;
+      const columnIndex = c.col || 0;
+      row[CellSet.#cellIndexColumnName] = rowIndex * colCount + columnIndex;
       items.forEach((item, index) => {
         const sqlExpression = QueryAxisItem.getSqlForQueryAxisItem(item, CellSet.datasetRelationName);
         const alias = aliases[index];
-        const keyedByPosition = vals[String(offset + index)];
-        const keyedByMeasureIndex = vals[String(index)];
-        row[sqlExpression] = keyedByPosition !== undefined ? keyedByPosition : (
-          keyedByMeasureIndex !== undefined ? keyedByMeasureIndex : vals[alias]
-        );
+        row[sqlExpression] = c[alias];
       });
       return row;
     };
@@ -598,16 +594,12 @@ export class CellSet extends DataSetComponent {
 
     if (isRemote && datasource.getManagedConnection().fetchCells) {
       const query = this.#buildRemoteCellsQuery(tuplesToQuery, tuplesFields, cellsAxisItemsToFetch);
-      const colCount = query.columns && query.columns.count ? query.columns.count : 1;
-      const axes = query.axes || {};
-      const rowDimCount = (axes.rows && axes.rows.length) || 0;
-      const colDimCount = (axes.columns && axes.columns.length) || 0;
-      const measureValueOffset = rowDimCount + colDimCount;
+      const colCount = query.window && query.window.columns && query.window.columns.limit ? query.window.columns.limit : 1;
       const measureAliases = query.axes && query.axes.measures ? query.axes.measures.map((measure) => { return measure.alias; }) : [];
       const dateRange = RemoteQueryAdapter.getDateRange(queryModel);
       const connection = await this.getManagedConnection();
       const apiResponse = await connection.fetchCells(dateRange, query);
-      const resultSet = this.#remoteCellsResponseToResultSet(apiResponse, cellsAxisItemsToFetch, colCount, measureAliases, measureValueOffset);
+      const resultSet = this.#remoteCellsResponseToResultSet(apiResponse, query, cellsAxisItemsToFetch, colCount, measureAliases);
       return resultSet;
     }
 

--- a/tests/unit/cellset-fetch.test.js
+++ b/tests/unit/cellset-fetch.test.js
@@ -87,12 +87,12 @@ describe('CellSet cell fetching flows', () => {
     const measureSql = queryModelModule.QueryAxisItem.getSqlForQueryAxisItem(measureItem, CellSet.datasetRelationName);
 
     const fetchCells = vi.fn().mockResolvedValue({
+      rows: [{}],
+      columns: [{}],
       cells: [{
-        row_index: 0,
-        column_index: 0,
-        values: {
-          0: 42,
-        },
+        row: 0,
+        col: 0,
+        sales_sum: 42,
       }],
     });
     const connection = {

--- a/tests/unit/dataset-cache-limits.test.js
+++ b/tests/unit/dataset-cache-limits.test.js
@@ -194,17 +194,19 @@ describe('DataSet cache limits', () => {
         fetchCellsCallCount += 1;
         const rowCount = query.window?.rows?.limit || 1;
         const colCount = query.window?.columns?.limit || 1;
+        const rows = Array.from({ length: rowCount }, (_, rowIndex) => ({ row_field: rowIndex }));
+        const columns = Array.from({ length: colCount }, (_, columnIndex) => ({ col_field: columnIndex }));
         const cells = [];
         for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
           for (let columnIndex = 0; columnIndex < colCount; columnIndex++) {
             cells.push({
-              row_index: rowIndex,
-              column_index: columnIndex,
-              values: { 2: rowIndex + columnIndex + 1 }
+              row: rowIndex,
+              col: columnIndex,
+              sum_amount_0: rowIndex + columnIndex + 1
             });
           }
         }
-        return { cells };
+        return { rows, columns, cells };
       },
       getState() {
         return 'open';
@@ -289,17 +291,19 @@ describe('DataSet cache limits', () => {
         fetchCellsCallCount += 1;
         const rowCount = query.window?.rows?.limit || 1;
         const colCount = query.window?.columns?.limit || 1;
+        const rows = Array.from({ length: rowCount }, (_, rowIndex) => ({ row_field: rowIndex }));
+        const columns = Array.from({ length: colCount }, (_, columnIndex) => ({ col_field: columnIndex }));
         const cells = [];
         for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
           for (let columnIndex = 0; columnIndex < colCount; columnIndex++) {
             cells.push({
-              row_index: rowIndex,
-              column_index: columnIndex,
-              values: { 2: `value-${rowIndex}-${columnIndex}-${'x'.repeat(64)}` }
+              row: rowIndex,
+              col: columnIndex,
+              max_amount_0: `value-${rowIndex}-${columnIndex}-${'x'.repeat(64)}`
             });
           }
         }
-        return { cells };
+        return { rows, columns, cells };
       },
       getState() {
         return 'open';
@@ -394,17 +398,19 @@ describe('DataSet cache limits', () => {
         fetchCellsCallCount += 1;
         const rowCount = query.window?.rows?.limit || 1;
         const colCount = query.window?.columns?.limit || 1;
+        const rows = Array.from({ length: rowCount }, (_, rowIndex) => ({ row_field: rowIndex }));
+        const columns = Array.from({ length: colCount }, (_, columnIndex) => ({ col_field: columnIndex }));
         const cells = [];
         for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
           for (let columnIndex = 0; columnIndex < colCount; columnIndex++) {
             cells.push({
-              row_index: rowIndex,
-              column_index: columnIndex,
-              values: { 2: `value-${rowIndex}-${columnIndex}-${cellValuePadding}` }
+              row: rowIndex,
+              col: columnIndex,
+              max_amount_0: `value-${rowIndex}-${columnIndex}-${cellValuePadding}`
             });
           }
         }
-        return { cells };
+        return { rows, columns, cells };
       },
       getState() {
         return 'open';
@@ -514,10 +520,12 @@ describe('DataSet cache limits', () => {
     const connection = {
       fetchCells() {
         return {
+          rows: [{}],
+          columns: [{}],
           cells: [{
-            row_index: 0,
-            column_index: 0,
-            values: { 2: 1n }
+            row: 0,
+            col: 0,
+            max_amount_0: 1n
           }]
         };
       },


### PR DESCRIPTION
Implements #408 as part of the #407-#409 query-response sprint under #403.

Summary:
- replace positional cells payload with named `rows`, `columns`, and sparse `cells` arrays
- add `window` totals for both axes
- add `meta` with execution time, cache status, and request id
- adapt the remote frontend `CellSet` path to consume the new cells response
- update backend and frontend tests plus API docs

Validation:
- `./.venv-server/bin/ruff check server/`
- `./.venv-server/bin/pytest server/tests -q`
- `./.venv-server/bin/pytest tests/test_backend_benchmark_runner.py -q`
- `npm run test:unit`
- `npm run lint:js`