### PR TITLE
Return counted members and named tuples

### DIFF
--- a/docs/huey-large-scale-olap-tech-spec.md
+++ b/docs/huey-large-scale-olap-tech-spec.md
@@ -140,13 +140,18 @@ Fetch **row or column headers** (tuples) for one axis.
 {
   "total_count": 12345,
   "items": [
-    { "values": ["AAPL"], "grouping_id": 0 },
-    { "values": ["GOOG"], "grouping_id": 0 }
+    { "symbol": "AAPL", "grouping_id": 0 },
+    { "symbol": "GOOG", "grouping_id": 0 }
   ],
   "paging": {
     "limit": 200,
     "offset": 0,
     "returned": 200
+  },
+  "meta": {
+    "execution_ms": 12,
+    "cache_status": "miss",
+    "request_id": "srv-a1b2c3d4"
   }
 }
 ```
@@ -234,15 +239,21 @@ Fetch distinct values for a field to populate the filter UI.
 
 ```json
 {
+  "field": "symbol",
   "total_count": 4321,
-  "values": [
-    { "value": "AAPL", "label": "AAPL" },
-    { "value": "AAL",  "label": "AAL"  }
+  "items": [
+    { "value": "AAPL", "count": 1200 },
+    { "value": "AAL",  "count": 540 }
   ],
   "paging": {
     "limit": 100,
     "offset": 0,
     "returned": 100
+  },
+  "meta": {
+    "execution_ms": 4,
+    "cache_status": "hit",
+    "request_id": "srv-c3d4e5f6"
   }
 }
 ```
@@ -471,4 +482,3 @@ Huey should keep its current WASM-based datasource for local/small file usage, s
   - S3 throttling and transient failures.
   - Engine restarts while queries are in flight.
   - QueryService rolling upgrades and failure scenarios.
-

--- a/docs/server/api-reference.md
+++ b/docs/server/api-reference.md
@@ -260,8 +260,13 @@ Success `200` example:
 ```json
 {
   "total_count": 2,
-  "items": [{"values": ["AAPL"]}, {"values": ["GOOG"]}],
-  "paging": {"limit": 10, "offset": 0, "returned": 2}
+  "items": [{"symbol": "AAPL"}, {"symbol": "GOOG"}],
+  "paging": {"limit": 10, "offset": 0, "returned": 2},
+  "meta": {
+    "execution_ms": 4.1,
+    "cache_status": "miss",
+    "request_id": "srv-tuples123"
+  }
 }
 ```
 
@@ -374,9 +379,15 @@ Success `200` example:
 
 ```json
 {
+  "field": "symbol",
   "total_count": 2,
-  "values": [{"value": "AAPL", "label": "AAPL"}, {"value": "AMZN", "label": "AMZN"}],
-  "paging": {"limit": 10, "offset": 0, "returned": 2}
+  "items": [{"value": "AAPL", "count": 2}, {"value": "AMZN", "count": 1}],
+  "paging": {"limit": 10, "offset": 0, "returned": 2},
+  "meta": {
+    "execution_ms": 3.8,
+    "cache_status": "hit",
+    "request_id": "srv-members123"
+  }
 }
 ```
 

--- a/server/models.py
+++ b/server/models.py
@@ -195,6 +195,14 @@ class PagingResponse(BaseModel):
     returned: int
 
 
+class MetaResponse(BaseModel):
+    """Common query execution metadata returned by v1 query endpoints."""
+
+    execution_ms: float
+    cache_status: str
+    request_id: str | None = None
+
+
 # --- Axes models ---
 class AxisField(BaseModel):
     """A dimension field referenced in a cells or export query axis."""
@@ -330,7 +338,8 @@ class ExportSubmitRequest(BaseModel):
 class TupleItem(BaseModel):
     """Single tuple row returned by the v1 tuples endpoint."""
 
-    values: list[Any]
+    model_config = ConfigDict(extra="allow")
+
     grouping_id: int | None = None  # reserved: tech spec grouping sets
 
 
@@ -340,6 +349,7 @@ class TuplesResponse(BaseModel):
     total_count: int
     items: list[TupleItem]
     paging: PagingResponse
+    meta: MetaResponse
 
 
 class CellsResponse(BaseModel):
@@ -349,15 +359,24 @@ class CellsResponse(BaseModel):
     columns: list[dict[str, Any]]
     cells: list[dict[str, Any]]
     window: dict[str, Any]
-    meta: dict[str, Any]
+    meta: MetaResponse
+
+
+class MemberItem(BaseModel):
+    """Single member row returned by the v1 members endpoint."""
+
+    value: Any
+    count: int
 
 
 class PicklistResponse(BaseModel):
-    """Response envelope for the v1 picklist endpoint."""
+    """Response envelope for the v1 members endpoint."""
 
+    field: str
     total_count: int
-    values: list[dict[str, str]]
+    items: list[MemberItem]
     paging: PagingResponse
+    meta: MetaResponse
 
 
 class ExportLinks(BaseModel):

--- a/server/prewarm.py
+++ b/server/prewarm.py
@@ -1,7 +1,7 @@
-"""Dimension cache prewarming for hot picklist fields.
+"""Dimension cache prewarming for hot members fields.
 
 Reads ``QUERYSERVICE_DIM_PREWARM_FIELDS`` (a CSV of ``dataset_id:field`` pairs)
-and executes a picklist query for each field at startup, storing the results in
+and executes a members query for each field at startup, storing the results in
 the dimension cache so the first real request is served from cache.
 """
 
@@ -12,7 +12,7 @@ logger = logging.getLogger("query_service.prewarm")
 
 
 async def prewarm_dim_fields() -> None:
-    """Execute picklist queries for configured hot fields and warm the cache.
+    """Execute members queries for configured hot fields and warm the cache.
 
     Called as a background task during application startup.  Failures are
     logged but never propagated so they cannot break the startup sequence.
@@ -69,25 +69,25 @@ async def prewarm_dim_fields() -> None:
 
             if rows:
                 total_count = int(rows[0][-1])
-                values = [{"value": str(row[0]), "label": str(row[0])} for row in rows]
+                items = [{"value": row[0], "count": int(row[1])} for row in rows]
             else:
                 total_count = 0
-                values = []
+                items = []
 
             paging = {
                 "limit": settings.picklist_default_limit,
                 "offset": 0,
-                "returned": len(values),
+                "returned": len(items),
             }
             result = {
-                "response": {"total_count": total_count, "values": values, "paging": paging},
+                "response": {"field": query.field, "total_count": total_count, "items": items, "paging": paging},
                 "duration_ms": 0.0,
                 "row_count": len(rows) if rows else 0,
             }
 
             dim_token = get_dim_version_token(dataset_id)
             cache_key = build_cache_key(
-                "picklist",
+                "members",
                 dataset_id,
                 date_range.model_dump(),
                 query.model_dump(),

--- a/server/query_builder.py
+++ b/server/query_builder.py
@@ -411,9 +411,12 @@ def build_picklist_sql(
     limit = paging.limit if paging else 100
     offset = paging.offset if paging else 0
 
-    base_sql = f"SELECT DISTINCT {col} AS value FROM {table}{where_clause}"
+    base_sql = (
+        f"SELECT {col} AS value, COUNT(*) AS value_count "
+        f"FROM {table}{where_clause} GROUP BY {col}"
+    )
     sql_body = (
-        f"SELECT value, COUNT(*) OVER() AS __count__ "
+        f"SELECT value, value_count, COUNT(*) OVER() AS __count__ "
         f"FROM ({base_sql}) AS distinct_values ORDER BY value LIMIT {limit} OFFSET {offset}"
     )
     sql = f"{base.cte_sql + ' ' if base.cte_sql else ''}{sql_body}"

--- a/server/routers/query.py
+++ b/server/routers/query.py
@@ -71,6 +71,15 @@ def _time_filter_metadata(dataset_id: str) -> tuple[bool, str | None]:
     return True, source.time_filter.column
 
 
+def _create_meta_response(result: dict[str, object], cache_status: str) -> MetaResponse:
+    """Build per-response query metadata outside cached payloads."""
+    return MetaResponse(
+        execution_ms=round(float(result.get("duration_ms", 0.0)), 2),
+        cache_status=cache_status,
+        request_id=get_request_id() or None,
+    )
+
+
 def _ensure_date_range_supported(dataset_id: str, date_range) -> None:
     if (
         date_range is not None
@@ -303,11 +312,7 @@ async def post_query_tuples(
         total_count=resp_body["total_count"],
         items=[TupleItem(**item) for item in resp_body["items"]],
         paging=PagingResponse(**resp_body["paging"]),
-        meta=MetaResponse(
-            execution_ms=round(result.get("duration_ms", 0.0), 2),
-            cache_status=cache_status,
-            request_id=get_request_id() or None,
-        ),
+        meta=_create_meta_response(result, cache_status),
     )
 
 
@@ -553,11 +558,7 @@ async def post_query_cells(
     )
 
     response_payload = dict(result["response"])
-    response_payload["meta"] = MetaResponse(
-        execution_ms=round(result.get("duration_ms", 0.0), 2),
-        cache_status=cache_status,
-        request_id=get_request_id() or None,
-    )
+    response_payload["meta"] = _create_meta_response(result, cache_status)
     return CellsResponse(**response_payload)
 
 
@@ -686,9 +687,5 @@ async def post_query_members(
         total_count=resp_body["total_count"],
         items=resp_body["items"],
         paging=PagingResponse(**resp_body["paging"]),
-        meta=MetaResponse(
-            execution_ms=round(result.get("duration_ms", 0.0), 2),
-            cache_status=cache_status,
-            request_id=get_request_id() or None,
-        ),
+        meta=_create_meta_response(result, cache_status),
     )

--- a/server/routers/query.py
+++ b/server/routers/query.py
@@ -21,6 +21,7 @@ from server.errors import (
 from server.models import (
     CellsQueryBody,
     CellsResponse,
+    MetaResponse,
     PagingResponse,
     PagingSpec,
     PicklistQueryBody,
@@ -221,9 +222,13 @@ async def post_query_tuples(
             )
 
         rows, queue_wait_ms, execution_ms = await _execute_with_budget(request, _run_query, cancel_fn=cancel_handle.cancel)
+        field_names = [field.field for field in (query.fields or [])]
         if rows:
             total_count = int(rows[0][-1])
-            items = [{"values": list(row[:-1])} for row in rows]
+            items = [
+                {field_name: row[index] for index, field_name in enumerate(field_names)}
+                for row in rows
+            ]
         else:
             total_count = 0
             items = []
@@ -298,6 +303,11 @@ async def post_query_tuples(
         total_count=resp_body["total_count"],
         items=[TupleItem(**item) for item in resp_body["items"]],
         paging=PagingResponse(**resp_body["paging"]),
+        meta=MetaResponse(
+            execution_ms=round(result.get("duration_ms", 0.0), 2),
+            cache_status=cache_status,
+            request_id=get_request_id() or None,
+        ),
     )
 
 
@@ -543,11 +553,11 @@ async def post_query_cells(
     )
 
     response_payload = dict(result["response"])
-    response_payload["meta"] = {
-        "execution_ms": round(result.get("duration_ms", 0.0), 2),
-        "cache_status": cache_status,
-        "request_id": get_request_id() or None,
-    }
+    response_payload["meta"] = MetaResponse(
+        execution_ms=round(result.get("duration_ms", 0.0), 2),
+        cache_status=cache_status,
+        request_id=get_request_id() or None,
+    )
     return CellsResponse(**response_payload)
 
 
@@ -597,10 +607,10 @@ async def post_query_members(
         rows, queue_wait_ms, execution_ms = await _execute_with_budget(request, _run_query, cancel_fn=cancel_handle.cancel)
         if rows:
             total_count = int(rows[0][-1])
-            values = [{"value": str(row[0]), "label": str(row[0])} for row in rows]
+            items = [{"value": row[0], "count": int(row[1])} for row in rows]
         else:
             total_count = 0
-            values = []
+            items = []
 
         if total_count == 0 and paging.offset > 0:
             count_sql, count_params = build_picklist_count_sql(dataset_id, query, body.date_range, schema_fields)
@@ -617,12 +627,13 @@ async def post_query_members(
         duration_ms = (time.perf_counter() - start) * 1000
         return {
             "response": {
+                "field": query.field,
                 "total_count": total_count,
-                "values": values,
-                "paging": {"limit": paging.limit, "offset": paging.offset, "returned": len(values)},
+                "items": items,
+                "paging": {"limit": paging.limit, "offset": paging.offset, "returned": len(items)},
             },
             "duration_ms": duration_ms,
-            "row_count": len(values),
+            "row_count": len(items),
             "queue_wait_ms": queue_wait_ms,
             "execution_ms": execution_ms,
         }
@@ -671,7 +682,13 @@ async def post_query_members(
     )
 
     return PicklistResponse(
+        field=resp_body["field"],
         total_count=resp_body["total_count"],
-        values=resp_body["values"],
+        items=resp_body["items"],
         paging=PagingResponse(**resp_body["paging"]),
+        meta=MetaResponse(
+            execution_ms=round(result.get("duration_ms", 0.0), 2),
+            cache_status=cache_status,
+            request_id=get_request_id() or None,
+        ),
     )

--- a/server/tests/test_error_contract.py
+++ b/server/tests/test_error_contract.py
@@ -378,4 +378,4 @@ class TestHappyPathUnchanged:
     def test_query_members_success(self, client: TestClient) -> None:
         r = client.post(_query_path("members"), json=_query_body("members"))
         assert r.status_code == 200
-        assert "values" in r.json()
+        assert "items" in r.json()

--- a/server/tests/test_integration.py
+++ b/server/tests/test_integration.py
@@ -51,7 +51,7 @@ def test_full_api_flow(client: TestClient) -> None:
     assert r_picklist.status_code == 200
     picklist_data = r_picklist.json()
     assert picklist_data["total_count"] > 0
-    assert len(picklist_data["values"]) > 0
+    assert len(picklist_data["items"]) > 0
 
     r_export = client.post(f"/api/v1/datasets/{dataset_id}/exports", json={
         "date_range": date_range,

--- a/server/tests/test_models.py
+++ b/server/tests/test_models.py
@@ -8,6 +8,7 @@ from server.models import (
     AxesSpec,
     AxisField,
     CellsQueryBody,
+    CellsResponse,
     CellsWindowRequest,
     DateRangeRange,
     DateRangeSingle,
@@ -15,13 +16,18 @@ from server.models import (
     ExportRequest,
     ExportSubmitRequest,
     MeasureSpec,
+    MemberItem,
+    MetaResponse,
     PagingResponse,
     PagingSpec,
+    PicklistResponse,
     QueryCellsRequest,
     QueryPicklistRequest,
     QueryTuplesRequest,
     TupleFieldSpec,
     TupleFilter,
+    TupleItem,
+    TuplesResponse,
 )
 
 
@@ -364,3 +370,39 @@ class TestPagingModels:
     def test_paging_response(self) -> None:
         pr = PagingResponse(limit=10, offset=5, returned=3)
         assert pr.returned == 3
+
+
+class TestResponseModels:
+    def test_meta_response(self) -> None:
+        meta = MetaResponse(execution_ms=12.5, cache_status="miss", request_id="req-1")
+        assert meta.cache_status == "miss"
+        assert meta.request_id == "req-1"
+
+    def test_tuples_response_accepts_named_items(self) -> None:
+        response = TuplesResponse(
+            total_count=2,
+            items=[TupleItem(symbol="AAPL"), TupleItem(symbol="GOOG")],
+            paging=PagingResponse(limit=10, offset=0, returned=2),
+            meta=MetaResponse(execution_ms=1.2, cache_status="hit", request_id="req-2"),
+        )
+        assert response.items[0].model_dump()["symbol"] == "AAPL"
+
+    def test_members_response_uses_items_with_counts(self) -> None:
+        response = PicklistResponse(
+            field="symbol",
+            total_count=2,
+            items=[MemberItem(value="AAPL", count=2)],
+            paging=PagingResponse(limit=10, offset=0, returned=1),
+            meta=MetaResponse(execution_ms=1.1, cache_status="miss", request_id="req-3"),
+        )
+        assert response.items[0].count == 2
+
+    def test_cells_response_uses_shared_meta_model(self) -> None:
+        response = CellsResponse(
+            rows=[{"symbol": "AAPL"}],
+            columns=[{}],
+            cells=[{"row": 0, "col": 0, "sum_volume": 1500}],
+            window={"rows": {"offset": 0, "limit": 1, "total": 1}, "columns": {"offset": 0, "limit": 1, "total": 1}},
+            meta=MetaResponse(execution_ms=2.0, cache_status="disabled", request_id=None),
+        )
+        assert response.meta.cache_status == "disabled"

--- a/server/tests/test_prewarm.py
+++ b/server/tests/test_prewarm.py
@@ -1,0 +1,73 @@
+"""Tests for dimension-cache prewarming."""
+
+import asyncio
+from types import SimpleNamespace
+
+import server.cache as cache_module
+import server.config as config_module
+import server.datasets as datasets_module
+import server.engine as engine_module
+import server.query_builder as query_builder_module
+from server.prewarm import prewarm_dim_fields
+
+
+class _FakeCache:
+    def __init__(self):
+        self.calls = []
+
+    async def get_or_set(self, cache_key, loader, **kwargs):
+        value = await loader()
+        self.calls.append({"cache_key": cache_key, "value": value, "kwargs": kwargs})
+        return value, None
+
+
+def test_prewarm_members_uses_members_cache_key_and_response_shape(monkeypatch) -> None:
+    captured = {"build_cache_key": None}
+    fake_cache = _FakeCache()
+
+    monkeypatch.setattr(
+        config_module,
+        "get_settings",
+        lambda: SimpleNamespace(
+            dim_prewarm_fields="trades_v1:symbol",
+            picklist_default_limit=100,
+            dim_cache_ttl_seconds=60,
+            dim_stale_ttl_seconds=30,
+            cache_max_item_bytes=1024 * 1024,
+        ),
+    )
+    async def _get_query_cache():
+        return fake_cache
+
+    monkeypatch.setattr(cache_module, "get_query_cache", _get_query_cache)
+    monkeypatch.setattr(datasets_module, "get_schema_field_names", lambda dataset_id: {"symbol"} if dataset_id == "trades_v1" else set())
+    monkeypatch.setattr(datasets_module, "get_dim_version_token", lambda _dataset_id: "dim-v1")
+    monkeypatch.setattr(query_builder_module, "build_picklist_sql", lambda *_args, **_kwargs: ("SELECT 1", []))
+
+    async def _execute_sql_async(*_args, **_kwargs):
+        return [("AAPL", 2, 3), ("GOOG", 1, 3)]
+
+    monkeypatch.setattr(engine_module.db_manager, "execute_sql_async", _execute_sql_async)
+
+    def _build_cache_key(endpoint, dataset_id, date_range, query_payload, **kwargs):
+        captured["build_cache_key"] = {
+            "endpoint": endpoint,
+            "dataset_id": dataset_id,
+            "date_range": date_range,
+            "query_payload": query_payload,
+            "kwargs": kwargs,
+        }
+        return "members-cache-key"
+
+    monkeypatch.setattr(cache_module, "build_cache_key", _build_cache_key)
+
+    asyncio.run(prewarm_dim_fields())
+
+    assert captured["build_cache_key"] is not None
+    assert captured["build_cache_key"]["endpoint"] == "members"
+    assert captured["build_cache_key"]["dataset_id"] == "trades_v1"
+    assert fake_cache.calls
+    payload = fake_cache.calls[0]["value"]["response"]
+    assert payload["field"] == "symbol"
+    assert payload["items"] == [{"value": "AAPL", "count": 2}, {"value": "GOOG", "count": 1}]
+    assert payload["paging"]["returned"] == 2

--- a/server/tests/test_query_builder.py
+++ b/server/tests/test_query_builder.py
@@ -270,11 +270,11 @@ class TestBuildCellsSql:
 
 
 class TestBuildPicklistSql:
-    def test_basic_distinct(self) -> None:
+    def test_basic_distinct_with_counts(self) -> None:
         query = PicklistQueryBody(field="symbol", paging=PagingSpec(limit=50, offset=0))
         sql, params = build_picklist_sql("trades_v1", query, DR_SINGLE, SCHEMA_FIELDS)
-        assert "DISTINCT" in sql
         assert '"symbol"' in sql
+        assert "COUNT(*) AS value_count" in sql
         assert "LIMIT 50" in sql
         assert "COUNT(*) OVER()" in sql
 

--- a/server/tests/test_query_cache_api.py
+++ b/server/tests/test_query_cache_api.py
@@ -87,7 +87,14 @@ def test_tuples_cache_hit(monkeypatch, client: TestClient) -> None:
     r2 = client.post("/api/v1/datasets/trades_v1/query/tuples", json=body)
     assert r1.status_code == 200
     assert r2.status_code == 200
-    assert r1.json() == r2.json()
+    data1 = r1.json()
+    data2 = r2.json()
+    assert data1["items"] == data2["items"]
+    assert data1["paging"] == data2["paging"]
+    assert data1["total_count"] == data2["total_count"]
+    assert data1["meta"]["cache_status"] == "miss"
+    assert data2["meta"]["cache_status"] == "hit"
+    assert data1["meta"]["request_id"] != data2["meta"]["request_id"]
     assert call_count["n"] == 1
 
 
@@ -107,7 +114,15 @@ def test_picklist_cache_hit(monkeypatch, client: TestClient) -> None:
     r2 = client.post("/api/v1/datasets/trades_v1/query/members", json=body)
     assert r1.status_code == 200
     assert r2.status_code == 200
-    assert r1.json() == r2.json()
+    data1 = r1.json()
+    data2 = r2.json()
+    assert data1["field"] == data2["field"]
+    assert data1["items"] == data2["items"]
+    assert data1["paging"] == data2["paging"]
+    assert data1["total_count"] == data2["total_count"]
+    assert data1["meta"]["cache_status"] == "miss"
+    assert data2["meta"]["cache_status"] == "hit"
+    assert data1["meta"]["request_id"] != data2["meta"]["request_id"]
     assert call_count["n"] == 1
 
 

--- a/server/tests/test_query_picklist_api.py
+++ b/server/tests/test_query_picklist_api.py
@@ -5,7 +5,7 @@ from fastapi.testclient import TestClient
 from server.engine import db_manager
 
 
-def test_query_members_returns_values(client: TestClient) -> None:
+def test_query_members_returns_items(client: TestClient) -> None:
     dataset_id = "trades_v1"
     body = {
         "date_range": {"type": "single", "date": "2026-03-01"},
@@ -15,13 +15,15 @@ def test_query_members_returns_values(client: TestClient) -> None:
     r = client.post(f"/api/v1/datasets/{dataset_id}/query/members", json=body)
     assert r.status_code == 200
     data = r.json()
+    assert data["field"] == "symbol"
     assert data["total_count"] > 0
-    assert len(data["values"]) > 0
-    values = [v["value"] for v in data["values"]]
+    assert len(data["items"]) > 0
+    assert "meta" in data
+    values = [v["value"] for v in data["items"]]
     assert "AAPL" in values
-    for v in data["values"]:
+    for v in data["items"]:
         assert "value" in v
-        assert "label" in v
+        assert "count" in v
 
 
 def test_query_members_search_wildcard(client: TestClient) -> None:
@@ -35,7 +37,7 @@ def test_query_members_search_wildcard(client: TestClient) -> None:
     r = client.post(f"/api/v1/datasets/{dataset_id}/query/members", json=body)
     assert r.status_code == 200
     data = r.json()
-    values = [v["value"] for v in data["values"]]
+    values = [v["value"] for v in data["items"]]
     assert all(v.startswith("A") for v in values)
     assert "AAPL" in values
     assert "AMZN" in values
@@ -51,7 +53,7 @@ def test_query_members_with_filter(client: TestClient) -> None:
     }
     r = client.post(f"/api/v1/datasets/{dataset_id}/query/members", json=body)
     assert r.status_code == 200
-    values = [v["value"] for v in r.json()["values"]]
+    values = [v["value"] for v in r.json()["items"]]
     assert "AAPL" not in values
 
 
@@ -69,7 +71,20 @@ def test_query_members_with_search_and_between_filter(client: TestClient) -> Non
     data = r.json()
     assert data["total_count"] == 1
     assert data["paging"]["returned"] == 1
-    assert [v["value"] for v in data["values"]] == ["AAPL"]
+    assert [v["value"] for v in data["items"]] == ["AAPL"]
+
+
+def test_query_members_returns_counts_in_current_filter_context(client: TestClient) -> None:
+    body = {
+        "date_range": {"type": "range", "start": "2026-03-01", "end": "2026-03-02"},
+        "field": "symbol",
+        "filters": [{"field": "volume", "operator": "BETWEEN", "values": [1500, 2200]}],
+        "paging": {"limit": 10, "offset": 0},
+    }
+    r = client.post("/api/v1/datasets/trades_v1/query/members", json=body)
+    assert r.status_code == 200
+    items = {item["value"]: item["count"] for item in r.json()["items"]}
+    assert items == {"AAPL": 2, "GOOG": 2, "MSFT": 2}
 
 
 def test_query_members_paging(client: TestClient) -> None:
@@ -111,7 +126,7 @@ def test_query_members_empty_page_reports_total(client: TestClient) -> None:
     r = client.post(f"/api/v1/datasets/{dataset_id}/query/members", json=body)
     assert r.status_code == 200
     data = r.json()
-    assert data["values"] == []
+    assert data["items"] == []
     assert data["paging"]["returned"] == 0
     assert data["total_count"] == 5
 

--- a/server/tests/test_query_tuples_api.py
+++ b/server/tests/test_query_tuples_api.py
@@ -18,7 +18,8 @@ def test_query_tuples_returns_results(client: TestClient) -> None:
     assert data["total_count"] > 0
     assert len(data["items"]) > 0
     assert data["paging"]["returned"] == len(data["items"])
-    symbols = [item["values"][0] for item in data["items"]]
+    assert "meta" in data
+    symbols = [item["symbol"] for item in data["items"]]
     assert "AAPL" in symbols
 
 
@@ -34,7 +35,7 @@ def test_query_tuples_with_include_filter(client: TestClient) -> None:
     assert r.status_code == 200
     data = r.json()
     assert data["total_count"] == 2
-    symbols = {item["values"][0] for item in data["items"]}
+    symbols = {item["symbol"] for item in data["items"]}
     assert symbols == {"AAPL", "GOOG"}
 
 
@@ -49,7 +50,7 @@ def test_query_tuples_with_exclude_filter(client: TestClient) -> None:
     r = client.post(f"/api/v1/datasets/{dataset_id}/query/tuples", json=body)
     assert r.status_code == 200
     data = r.json()
-    symbols = {item["values"][0] for item in data["items"]}
+    symbols = {item["symbol"] for item in data["items"]}
     assert "AAPL" not in symbols
     assert data["total_count"] == 4
 
@@ -106,8 +107,8 @@ def test_query_tuples_paging_offset(client: TestClient) -> None:
     body_page2 = {**body_page1, "paging": {"limit": 2, "offset": 2}}
     r1 = client.post(f"/api/v1/datasets/{dataset_id}/query/tuples", json=body_page1)
     r2 = client.post(f"/api/v1/datasets/{dataset_id}/query/tuples", json=body_page2)
-    page1_symbols = {item["values"][0] for item in r1.json()["items"]}
-    page2_symbols = {item["values"][0] for item in r2.json()["items"]}
+    page1_symbols = {item["symbol"] for item in r1.json()["items"]}
+    page2_symbols = {item["symbol"] for item in r2.json()["items"]}
     assert page1_symbols.isdisjoint(page2_symbols)
 
 
@@ -154,7 +155,7 @@ def test_query_tuples_sort_desc(client: TestClient) -> None:
     }
     r = client.post(f"/api/v1/datasets/{dataset_id}/query/tuples", json=body)
     assert r.status_code == 200
-    symbols = [item["values"][0] for item in r.json()["items"]]
+    symbols = [item["symbol"] for item in r.json()["items"]]
     assert symbols == sorted(symbols, reverse=True)
 
 

--- a/src/DataSet/TupleSet.js
+++ b/src/DataSet/TupleSet.js
@@ -468,7 +468,9 @@ export class TupleSet extends DataSetComponent {
   #remoteResponseToResultSet(apiResponse, axisItems, includeCountAll){
     const items = apiResponse.items || [];
     const totalCount = apiResponse.total_count !== null ? apiResponse.total_count : items.length;
-    const hasGroupingId = items.some((item) => { return item.grouping_id !== null; });
+    const hasGroupingId = items.some((item) => {
+      return item && Object.prototype.hasOwnProperty.call(item, 'grouping_id') && item.grouping_id !== null;
+    });
     const fields = [];
     if (hasGroupingId) fields.push({ name: TupleSet.groupingIdAlias });
     axisItems.forEach((item) => {
@@ -484,9 +486,8 @@ export class TupleSet extends DataSetComponent {
         const item = items[i];
         if (!item) return row;
         if (hasGroupingId) row[TupleSet.groupingIdAlias] = item.grouping_id !== null ? item.grouping_id : 0;
-        const vals = item.values || [];
         for (let j = 0; j < fieldNames.length; j++) {
-          row[fieldNames[j]] = vals[j];
+          row[fieldNames[j]] = item[fieldNames[j]];
         }
         if (includeCountAll) {
           row['__huey_count'] = i === 0 ? totalCount : (numRows > 0 ? totalCount : 0);

--- a/src/DataSet/TupleSet.js
+++ b/src/DataSet/TupleSet.js
@@ -468,9 +468,7 @@ export class TupleSet extends DataSetComponent {
   #remoteResponseToResultSet(apiResponse, axisItems, includeCountAll){
     const items = apiResponse.items || [];
     const totalCount = apiResponse.total_count !== null ? apiResponse.total_count : items.length;
-    const hasGroupingId = items.some((item) => {
-      return item && Object.prototype.hasOwnProperty.call(item, 'grouping_id') && item.grouping_id !== null;
-    });
+    const hasGroupingId = items.some((item) => item && item.grouping_id != null);
     const fields = [];
     if (hasGroupingId) fields.push({ name: TupleSet.groupingIdAlias });
     axisItems.forEach((item) => {

--- a/src/FilterUi/FilterUi.js
+++ b/src/FilterUi/FilterUi.js
@@ -1250,15 +1250,18 @@ export class FilterDialog {
         const apiResponse = await connection.fetchPicklist(dateRange, query);
         console.timeEnd(timeMessage);
         const hasTotalCount = apiResponse.total_count !== null && apiResponse.total_count !== undefined;
-        const totalCount = hasTotalCount ? apiResponse.total_count : (apiResponse.values || []).length;
-        const values = apiResponse.values || [];
+        const values = apiResponse.items || [];
+        const totalCount = hasTotalCount ? apiResponse.total_count : values.length;
         const fields = (offset === 0 ? [{ name: FilterDialog.#numRowsColumnName }] : []).concat([{ name: 'value', type: { typeId: 0 } }, { name: 'label', type: { typeId: 0 } }]);
         const resultSet = {
           numRows: values.length,
           schema: { fields: fields },
           get: function(i) {
             const v = values[i];
-            const row = { value: v ? v.value : null, label: v ? (v.label !== null ? v.label : v.value) : null };
+            const row = {
+              value: v ? v.value : null,
+              label: v && v.value !== null && v.value !== undefined ? String(v.value) : null
+            };
             if (offset === 0 && i === 0) row[FilterDialog.#numRowsColumnName] = totalCount;
             return row;
           }

--- a/tests/ui/remote-mode.spec.js
+++ b/tests/ui/remote-mode.spec.js
@@ -37,24 +37,41 @@ test.describe('Remote mode UI', () => {
     const tuplesResponse = {
       total_count: 3,
       items: [
-        { values: ['AAPL'], grouping_id: null },
-        { values: ['GOOG'], grouping_id: null },
-        { values: ['MSFT'], grouping_id: null },
+        { symbol: 'AAPL', grouping_id: null },
+        { symbol: 'GOOG', grouping_id: null },
+        { symbol: 'MSFT', grouping_id: null },
       ],
       paging: { limit: 100, offset: 0, returned: 3 },
+      meta: { execution_ms: 2, cache_status: 'miss', request_id: 'test-tuples' },
     };
     const cellsResponse = {
+      rows: [{ symbol: 'AAPL' }, { symbol: 'GOOG' }, { symbol: 'MSFT' }],
+      columns: [{}],
       cells: [
-        { row_index: 0, column_index: 0, values: { sum_volume_0: 1500 } },
-        { row_index: 1, column_index: 0, values: { sum_volume_0: 2200 } },
-        { row_index: 2, column_index: 0, values: { sum_volume_0: 1800 } },
+        { row: 0, col: 0, sum_volume_0: 1500 },
+        { row: 1, col: 0, sum_volume_0: 2200 },
+        { row: 2, col: 0, sum_volume_0: 1800 },
       ],
+      window: {
+        rows: { offset: 0, limit: 100, total: 3 },
+        columns: { offset: 0, limit: 1, total: 1 },
+      },
+      meta: { execution_ms: 3, cache_status: 'miss', request_id: 'test-cells' },
     };
 
     await page.route('**/api/v1/datasets/*/schema', (route) => route.fulfill({ status: 200, body: JSON.stringify(schemaResponse) }));
     await page.route('**/api/v1/datasets/*/query/tuples', (route) => route.fulfill({ status: 200, body: JSON.stringify(tuplesResponse) }));
     await page.route('**/api/v1/datasets/*/query/cells', (route) => route.fulfill({ status: 200, body: JSON.stringify(cellsResponse) }));
-    await page.route('**/api/v1/datasets/*/query/members', (route) => route.fulfill({ status: 200, body: JSON.stringify({ total_count: 3, values: [{ value: 'AAPL', label: 'AAPL' }], paging: { limit: 100, offset: 0, returned: 1 } }) }));
+    await page.route('**/api/v1/datasets/*/query/members', (route) => route.fulfill({
+      status: 200,
+      body: JSON.stringify({
+        field: 'symbol',
+        total_count: 3,
+        items: [{ value: 'AAPL', count: 1 }],
+        paging: { limit: 100, offset: 0, returned: 1 },
+        meta: { execution_ms: 1, cache_status: 'miss', request_id: 'test-members' },
+      }),
+    }));
 
     await waitForAppReady(page);
     await expect(page.locator('#addRemoteDatasource')).toBeVisible({ timeout: 10000 });

--- a/tests/unit/dataset-cache-limits.test.js
+++ b/tests/unit/dataset-cache-limits.test.js
@@ -36,7 +36,10 @@ describe('DataSet cache limits', () => {
         const paging = query.paging || {};
         const limit = paging.limit || allValues.length;
         const offset = paging.offset || 0;
-        const items = allValues.slice(offset, offset + limit).map((value) => ({ values: [value] }));
+        const items = allValues.slice(offset, offset + limit).map((value) => ({
+          city: value,
+          hugeint_field: value,
+        }));
         return { items, total_count: allValues.length };
       },
       getState() {
@@ -86,7 +89,10 @@ describe('DataSet cache limits', () => {
         const paging = query.paging || {};
         const limit = paging.limit || 1;
         const offset = paging.offset || 0;
-        const items = Array.from({ length: limit }, (_value, i) => ({ values: [BigInt(offset + i + 1)] }));
+        const items = Array.from({ length: limit }, (_value, i) => ({
+          city: BigInt(offset + i + 1),
+          hugeint_field: BigInt(offset + i + 1),
+        }));
         return { items, total_count: 2 };
       },
       getState() {
@@ -129,7 +135,10 @@ describe('DataSet cache limits', () => {
         const paging = query.paging || {};
         const limit = paging.limit || allValues.length;
         const offset = paging.offset || 0;
-        const items = allValues.slice(offset, offset + limit).map((value) => ({ values: [value] }));
+        const items = allValues.slice(offset, offset + limit).map((value) => ({
+          city: value,
+          hugeint_field: value,
+        }));
         return { items, total_count: allValues.length };
       },
       getState() {

--- a/tests/unit/tupleset-core.test.js
+++ b/tests/unit/tupleset-core.test.js
@@ -31,7 +31,11 @@ function makeRemoteDatasource(allValues) {
       const paging = query.paging || {};
       const limit = paging.limit || allValues.length;
       const offset = paging.offset || 0;
-      const items = allValues.slice(offset, offset + limit).map((value) => ({ values: [value] }));
+      const items = allValues.slice(offset, offset + limit).map((value) => ({
+        city: value,
+        letter: value,
+        hugeint_field: value,
+      }));
       return { items, total_count: allValues.length };
     },
     getState() { return 'open'; },
@@ -165,7 +169,7 @@ describe('TupleSet pagination', () => {
         const paging = query.paging || {};
         const limit = paging.limit || allValues.length;
         const offset = paging.offset || 0;
-        const items = allValues.slice(offset, offset + limit).map((value) => ({ values: [value] }));
+        const items = allValues.slice(offset, offset + limit).map((value) => ({ city: value }));
         return { items, total_count: allValues.length };
       },
       getState() { return 'open'; },


### PR DESCRIPTION
Fixes #409

## Summary
- return named tuple items and shared `meta` on tuples responses
- return `{ field, items[{ value, count }], meta }` on members responses
- update the remote frontend consumers, tests, and API docs to the new contract

## Validation
- `./.venv-server/bin/ruff check server/`
- `./.venv-server/bin/pytest server/tests -q`
- `./.venv-server/bin/pytest tests/test_backend_benchmark_runner.py -q`
- `npm run test:unit`
- `npm run lint:js`
- `npm run test:ui -- --grep "remote datasource pivot with measure renders without typeId error"` (Chromium passed; Firefox/WebKit unavailable locally because Playwright browsers are not installed)