### PR TITLE
Expand v1 filter operators

### DIFF
--- a/docs/server/api-reference.md
+++ b/docs/server/api-reference.md
@@ -238,7 +238,7 @@ Request body fields:
   - `include_totals` (optional)
 - `filters` (optional):
   - `field` (string)
-  - `operator` (`INCLUDE`, `EXCLUDE`, `LIKE`, `BETWEEN`)
+  - `operator` (`include`, `exclude`, `like`, `between`, `gt`, `gte`, `lt`, `lte`, `is_null`, `not_null`; case-insensitive)
   - `values` (array)
 - `paging` (optional):
   - `limit` (`1..10000`, default from config)
@@ -297,6 +297,7 @@ Request body fields:
   - `offset` (`>=0`)
   - `limit` (`>=1`)
 - `filters` (optional)
+- `filters[*].operator` supports the same 10 case-insensitive operators as tuples/cells
 
 Request example:
 

--- a/docs/server/api-reference.md
+++ b/docs/server/api-reference.md
@@ -239,7 +239,13 @@ Request body fields:
 - `filters` (optional):
   - `field` (string)
   - `operator` (`include`, `exclude`, `like`, `between`, `gt`, `gte`, `lt`, `lte`, `is_null`, `not_null`; case-insensitive)
-  - `values` (array)
+  - `values`:
+    - Required for: `include`, `exclude`, `like`, `between`, `gt`, `gte`, `lt`, `lte`
+    - Must be omitted or an empty array for: `is_null`, `not_null`
+    - Cardinality by operator:
+      - `gt`, `gte`, `lt`, `lte`, `like`: exactly 1 value
+      - `between`: exactly 2 values
+      - `include`, `exclude`: between 1 and 1000 values
 - `paging` (optional):
   - `limit` (`1..10000`, default from config)
   - `offset` (`>=0`)

--- a/server/main.py
+++ b/server/main.py
@@ -168,18 +168,21 @@ async def app_error_handler(request: Request, exc: AppError) -> JSONResponse:
 async def validation_error_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
     """Normalize FastAPI validation errors into the ErrorResponse envelope."""
     clean_errors = []
+    has_filter_error = False
     for err in exc.errors():
         entry = {
             "loc": list(err.get("loc", [])),
             "msg": err.get("msg", ""),
             "type": err.get("type", ""),
         }
+        if entry["type"] == "filter_invalid":
+            has_filter_error = True
         if "ctx" in err:
             entry["ctx"] = jsonable_encoder(err["ctx"])
         clean_errors.append(entry)
     body = ErrorResponse(
-        code="VALIDATION_ERROR",
-        message="Request validation failed",
+        code="FILTER_INVALID" if has_filter_error else "VALIDATION_ERROR",
+        message="Filter validation failed" if has_filter_error else "Request validation failed",
         request_id=get_request_id() or None,
         details={"errors": clean_errors},
     )

--- a/server/main.py
+++ b/server/main.py
@@ -175,7 +175,7 @@ async def validation_error_handler(request: Request, exc: RequestValidationError
             "msg": err.get("msg", ""),
             "type": err.get("type", ""),
         }
-        if entry["type"] == "filter_invalid":
+        if entry["type"] == "filter_invalid" or "filters" in entry["loc"]:
             has_filter_error = True
         if "ctx" in err:
             entry["ctx"] = jsonable_encoder(err["ctx"])

--- a/server/models.py
+++ b/server/models.py
@@ -14,7 +14,18 @@ from pydantic_core import PydanticCustomError
 from server.config import get_settings
 from server.errors import ValidationAppError
 
-FilterOperator = Literal["INCLUDE", "EXCLUDE", "LIKE", "BETWEEN"]
+FilterOperator = Literal[
+    "include",
+    "exclude",
+    "like",
+    "between",
+    "gt",
+    "gte",
+    "lt",
+    "lte",
+    "is_null",
+    "not_null",
+]
 SortDirection = Literal["ASC", "DESC"]
 ExportFormat = Literal["parquet", "csv", "sqlite", "duckdb", "csv_with_bom", "ndjson"]
 AggregationFunction = Literal["SUM", "COUNT", "AVG", "MIN", "MAX"]
@@ -156,7 +167,57 @@ class TupleFilter(BaseModel):
 
     field: str
     operator: FilterOperator
-    values: list[Any]
+    values: list[Any] = Field(default_factory=list)
+
+    @field_validator("operator", mode="before")
+    @classmethod
+    def normalize_operator(cls, value: str) -> str:
+        if isinstance(value, str):
+            return value.lower()
+        return value
+
+    @model_validator(mode="after")
+    def validate_operator_values(self) -> "TupleFilter":
+        operator = self.operator
+        value_count = len(self.values)
+
+        if operator in ("is_null", "not_null"):
+            if value_count != 0:
+                raise PydanticCustomError(
+                    "filter_invalid",
+                    "Operator {operator} does not accept values",
+                    {"operator": operator},
+                )
+            return self
+
+        if operator in ("gt", "gte", "lt", "lte", "like"):
+            if value_count != 1:
+                raise PydanticCustomError(
+                    "filter_invalid",
+                    "Operator {operator} requires exactly 1 value",
+                    {"operator": operator, "expected_values": 1, "actual_values": value_count},
+                )
+            return self
+
+        if operator == "between":
+            if value_count != 2:
+                raise PydanticCustomError(
+                    "filter_invalid",
+                    "Operator between requires exactly 2 values",
+                    {"operator": operator, "expected_values": 2, "actual_values": value_count},
+                )
+            return self
+
+        if operator in ("include", "exclude"):
+            if value_count < 1 or value_count > 1000:
+                raise PydanticCustomError(
+                    "filter_invalid",
+                    "Operator {operator} requires between 1 and 1000 values",
+                    {"operator": operator, "min_values": 1, "max_values": 1000, "actual_values": value_count},
+                )
+            return self
+
+        return self
 
 
 class PagingSpec(BaseModel):

--- a/server/query_builder.py
+++ b/server/query_builder.py
@@ -123,20 +123,36 @@ def _build_filter_clauses(
     clauses = []
     for f in filters:
         col = _quote(f.field)
-        if f.operator == "INCLUDE" and f.values:
+        if f.operator == "include" and f.values:
             placeholders = ", ".join("?" for _ in f.values)
             clauses.append(f"{col} IN ({placeholders})")
             params.extend(f.values)
-        elif f.operator == "EXCLUDE" and f.values:
+        elif f.operator == "exclude" and f.values:
             placeholders = ", ".join("?" for _ in f.values)
             clauses.append(f"{col} NOT IN ({placeholders})")
             params.extend(f.values)
-        elif f.operator == "LIKE" and f.values:
+        elif f.operator == "like" and f.values:
             clauses.append(f"{col} LIKE ?")
             params.append(f.values[0])
-        elif f.operator == "BETWEEN" and len(f.values) >= 2:
+        elif f.operator == "between" and len(f.values) >= 2:
             clauses.append(f"{col} BETWEEN ? AND ?")
             params.extend(f.values[:2])
+        elif f.operator == "gt" and f.values:
+            clauses.append(f"{col} > ?")
+            params.append(f.values[0])
+        elif f.operator == "gte" and f.values:
+            clauses.append(f"{col} >= ?")
+            params.append(f.values[0])
+        elif f.operator == "lt" and f.values:
+            clauses.append(f"{col} < ?")
+            params.append(f.values[0])
+        elif f.operator == "lte" and f.values:
+            clauses.append(f"{col} <= ?")
+            params.append(f.values[0])
+        elif f.operator == "is_null":
+            clauses.append(f"{col} IS NULL")
+        elif f.operator == "not_null":
+            clauses.append(f"{col} IS NOT NULL")
     return clauses
 
 

--- a/server/tests/test_error_contract.py
+++ b/server/tests/test_error_contract.py
@@ -244,7 +244,7 @@ class TestValidationErrorEnvelope:
         })
         assert r.status_code == 422
         body = r.json()
-        assert body["code"] == "VALIDATION_ERROR"
+        assert body["code"] == "FILTER_INVALID"
 
     def test_export_invalid_format(self, client: TestClient) -> None:
         r = client.post(_export_submit_path(), json={

--- a/server/tests/test_models.py
+++ b/server/tests/test_models.py
@@ -130,17 +130,40 @@ class TestTupleFieldSpec:
 
 class TestTupleFilter:
     def test_valid_operators(self) -> None:
-        for op in ("INCLUDE", "EXCLUDE", "LIKE", "BETWEEN"):
-            f = TupleFilter(field="symbol", operator=op, values=["x"])
+        for op in ("include", "exclude", "like", "between", "gt", "gte", "lt", "lte", "is_null", "not_null"):
+            if op in ("is_null", "not_null"):
+                f = TupleFilter(field="symbol", operator=op)
+            else:
+                f = TupleFilter(field="symbol", operator=op, values=["x"] if op != "between" else ["a", "b"])
             assert f.operator == op
 
     def test_invalid_operator_rejected(self) -> None:
         with pytest.raises(ValidationError, match="operator"):
             TupleFilter(field="symbol", operator="INVALID", values=["x"])
 
-    def test_lowercase_operator_rejected(self) -> None:
-        with pytest.raises(ValidationError, match="operator"):
-            TupleFilter(field="symbol", operator="include", values=["x"])
+    def test_operator_is_case_insensitive(self) -> None:
+        f = TupleFilter(field="symbol", operator="GTE", values=[100])
+        assert f.operator == "gte"
+
+    def test_null_operators_reject_values(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            TupleFilter(field="symbol", operator="is_null", values=["x"])
+        assert exc_info.value.errors()[0]["type"] == "filter_invalid"
+
+    def test_comparison_operators_require_single_value(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            TupleFilter(field="volume", operator="gt", values=[1, 2])
+        assert exc_info.value.errors()[0]["type"] == "filter_invalid"
+
+    def test_between_requires_two_values(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            TupleFilter(field="volume", operator="between", values=[1])
+        assert exc_info.value.errors()[0]["type"] == "filter_invalid"
+
+    def test_include_rejects_more_than_1000_values(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            TupleFilter(field="symbol", operator="include", values=list(range(1001)))
+        assert exc_info.value.errors()[0]["type"] == "filter_invalid"
 
 
 class TestPagingSpec:

--- a/server/tests/test_query_builder.py
+++ b/server/tests/test_query_builder.py
@@ -1,6 +1,7 @@
 """Unit tests for SQL query builder."""
 
 import pytest
+from pydantic import ValidationError
 
 from server.errors import ValidationAppError
 from server.models import (
@@ -70,7 +71,7 @@ class TestBuildTuplesSql:
     def test_like_filter(self) -> None:
         query = TuplesQueryBody(
             fields=[TupleFieldSpec(field="symbol")],
-            filters=[TupleFilter(field="symbol", operator="LIKE", values=["AA%"])],
+            filters=[TupleFilter(field="symbol", operator="like", values=["AA%"])],
         )
         sql, params = build_tuples_sql("trades_v1", query, DR_SINGLE, SCHEMA_FIELDS)
         assert '"symbol" LIKE ?' in sql
@@ -79,7 +80,7 @@ class TestBuildTuplesSql:
     def test_between_filter(self) -> None:
         query = TuplesQueryBody(
             fields=[TupleFieldSpec(field="volume")],
-            filters=[TupleFilter(field="volume", operator="BETWEEN", values=[1000, 2000])],
+            filters=[TupleFilter(field="volume", operator="between", values=[1000, 2000])],
         )
         sql, params = build_tuples_sql("trades_v1", query, DR_SINGLE, SCHEMA_FIELDS)
         assert '"volume" BETWEEN ? AND ?' in sql
@@ -87,12 +88,8 @@ class TestBuildTuplesSql:
         assert 2000 in params
 
     def test_between_filter_needs_two_values(self) -> None:
-        query = TuplesQueryBody(
-            fields=[TupleFieldSpec(field="volume")],
-            filters=[TupleFilter(field="volume", operator="BETWEEN", values=[1000])],
-        )
-        sql, params = build_tuples_sql("trades_v1", query, DR_SINGLE, SCHEMA_FIELDS)
-        assert "BETWEEN" not in sql
+        with pytest.raises(ValidationError):
+            TupleFilter(field="volume", operator="between", values=[1000])
 
     def test_sort_desc(self) -> None:
         query = TuplesQueryBody(fields=[TupleFieldSpec(field="symbol", sort="DESC")])
@@ -292,12 +289,32 @@ class TestBuildPicklistSql:
     def test_with_filter(self) -> None:
         query = PicklistQueryBody(
             field="symbol",
-            filters=[TupleFilter(field="symbol", operator="EXCLUDE", values=["TSLA"])],
+            filters=[TupleFilter(field="symbol", operator="exclude", values=["TSLA"])],
             paging=PagingSpec(limit=100, offset=0),
         )
         sql, params = build_picklist_sql("trades_v1", query, DR_SINGLE, SCHEMA_FIELDS)
         assert "NOT IN" in sql
         assert "TSLA" in params
+
+    @pytest.mark.parametrize(
+        ("operator", "values", "sql_fragment"),
+        [
+            ("gt", [10], '> ?'),
+            ("gte", [10], '>= ?'),
+            ("lt", [10], '< ?'),
+            ("lte", [10], '<= ?'),
+            ("is_null", [], 'IS NULL'),
+            ("not_null", [], 'IS NOT NULL'),
+        ],
+    )
+    def test_extended_filter_operators(self, operator: str, values: list, sql_fragment: str) -> None:
+        query = PicklistQueryBody(
+            field="symbol",
+            filters=[TupleFilter(field="volume", operator=operator, values=values)],
+            paging=PagingSpec(limit=100, offset=0),
+        )
+        sql, _ = build_picklist_sql("trades_v1", query, DR_SINGLE, SCHEMA_FIELDS)
+        assert sql_fragment in sql
 
 
 class TestBuildPicklistCountSql:

--- a/server/tests/test_query_tuples_api.py
+++ b/server/tests/test_query_tuples_api.py
@@ -79,8 +79,6 @@ def test_query_tuples_extended_filter_operators(
         "filters": [{"field": "symbol" if "null" in operator else "volume", "operator": operator, "values": values}],
         "paging": {"limit": 10, "offset": 0},
     }
-    if operator in ("is_null", "not_null"):
-        body["filters"][0]["field"] = "symbol"
     r = client.post("/api/v1/datasets/trades_v1/query/tuples", json=body)
     assert r.status_code == 200
     symbols = {item["symbol"] for item in r.json()["items"]}

--- a/server/tests/test_query_tuples_api.py
+++ b/server/tests/test_query_tuples_api.py
@@ -1,5 +1,6 @@
 """Tests for POST /api/v1/datasets/{dataset_id}/query/tuples."""
 
+import pytest
 from fastapi.testclient import TestClient
 
 from server.engine import db_manager
@@ -53,6 +54,37 @@ def test_query_tuples_with_exclude_filter(client: TestClient) -> None:
     symbols = {item["symbol"] for item in data["items"]}
     assert "AAPL" not in symbols
     assert data["total_count"] == 4
+
+
+@pytest.mark.parametrize(
+    ("operator", "values", "expected_symbols"),
+    [
+        ("gt", [2000], {"GOOG", "AMZN"}),
+        ("gte", [1800], {"GOOG", "MSFT", "AMZN"}),
+        ("lt", [1800], {"AAPL", "TSLA"}),
+        ("lte", [1500], {"AAPL", "TSLA"}),
+        ("is_null", [], set()),
+        ("not_null", [], {"AAPL", "GOOG", "MSFT", "AMZN", "TSLA"}),
+    ],
+)
+def test_query_tuples_extended_filter_operators(
+    client: TestClient,
+    operator: str,
+    values: list[object],
+    expected_symbols: set[str],
+) -> None:
+    body = {
+        "date_range": {"type": "single", "date": "2026-03-01"},
+        "fields": [{"field": "symbol"}],
+        "filters": [{"field": "symbol" if "null" in operator else "volume", "operator": operator, "values": values}],
+        "paging": {"limit": 10, "offset": 0},
+    }
+    if operator in ("is_null", "not_null"):
+        body["filters"][0]["field"] = "symbol"
+    r = client.post("/api/v1/datasets/trades_v1/query/tuples", json=body)
+    assert r.status_code == 200
+    symbols = {item["symbol"] for item in r.json()["items"]}
+    assert symbols == expected_symbols
 
 
 def test_query_tuples_date_range(client: TestClient) -> None:

--- a/server/tests/test_validation_errors.py
+++ b/server/tests/test_validation_errors.py
@@ -151,6 +151,20 @@ class TestTuplesValidation:
         r = client.post(_post_path("tuples"), json=body)
         assert r.status_code == 200
 
+    def test_unknown_filter_operator_returns_filter_invalid(self, client: TestClient) -> None:
+        body = _valid_body_for("tuples")
+        body["filters"] = [{"field": "volume", "operator": "NOPE", "values": [1500]}]
+        r = client.post(_post_path("tuples"), json=body)
+        assert r.status_code == 422
+        assert r.json()["code"] == "FILTER_INVALID"
+
+    def test_missing_filter_operator_returns_filter_invalid(self, client: TestClient) -> None:
+        body = _valid_body_for("tuples")
+        body["filters"] = [{"field": "volume", "values": [1500]}]
+        r = client.post(_post_path("tuples"), json=body)
+        assert r.status_code == 422
+        assert r.json()["code"] == "FILTER_INVALID"
+
 
 class TestCellsValidation:
     def test_missing_axes_rejected(self, client: TestClient) -> None:

--- a/server/tests/test_validation_errors.py
+++ b/server/tests/test_validation_errors.py
@@ -122,6 +122,35 @@ class TestTuplesValidation:
         r = client.post(_post_path("tuples"), json=body)
         assert r.status_code == 422
 
+    @pytest.mark.parametrize(
+        ("operator", "values"),
+        [
+            ("gt", []),
+            ("gt", [1, 2]),
+            ("gte", []),
+            ("lt", [1, 2]),
+            ("lte", []),
+            ("between", [1]),
+            ("include", []),
+            ("exclude", list(range(1001))),
+            ("is_null", ["x"]),
+            ("not_null", ["x"]),
+        ],
+    )
+    def test_invalid_filter_shapes_return_filter_invalid(self, client: TestClient, operator: str, values: list) -> None:
+        body = _valid_body_for("tuples")
+        body["filters"] = [{"field": "volume", "operator": operator, "values": values}]
+        r = client.post(_post_path("tuples"), json=body)
+        assert r.status_code == 422
+        payload = r.json()
+        assert payload["code"] == "FILTER_INVALID"
+
+    def test_filter_operators_are_case_insensitive(self, client: TestClient) -> None:
+        body = _valid_body_for("tuples")
+        body["filters"] = [{"field": "volume", "operator": "GT", "values": [1500]}]
+        r = client.post(_post_path("tuples"), json=body)
+        assert r.status_code == 200
+
 
 class TestCellsValidation:
     def test_missing_axes_rejected(self, client: TestClient) -> None:

--- a/src/DataSet/TupleSet.js
+++ b/src/DataSet/TupleSet.js
@@ -468,7 +468,7 @@ export class TupleSet extends DataSetComponent {
   #remoteResponseToResultSet(apiResponse, axisItems, includeCountAll){
     const items = apiResponse.items || [];
     const totalCount = apiResponse.total_count !== null ? apiResponse.total_count : items.length;
-    const hasGroupingId = items.some((item) => item && item.grouping_id != null);
+    const hasGroupingId = items.some((item) => item && item.grouping_id !== null && item.grouping_id !== undefined);
     const fields = [];
     if (hasGroupingId) fields.push({ name: TupleSet.groupingIdAlias });
     axisItems.forEach((item) => {

--- a/src/DataSource/remote/RemoteQueryAdapter.js
+++ b/src/DataSource/remote/RemoteQueryAdapter.js
@@ -1,9 +1,9 @@
 export class RemoteQueryAdapter {
   static #FILTER_OPERATOR_BY_TYPE = {
-    in: 'INCLUDE',
-    notin: 'EXCLUDE',
-    like: 'LIKE',
-    between: 'BETWEEN'
+    in: 'include',
+    notin: 'exclude',
+    like: 'like',
+    between: 'between'
   };
 
   static #AGGREGATION_BY_NAME = {
@@ -96,7 +96,7 @@ export class RemoteQueryAdapter {
     }
 
     let values;
-    if (operator === 'BETWEEN') {
+    if (operator === 'between') {
       if (valuesEntries.length !== 1) {
         throw new Error('Remote datasource supports exactly one BETWEEN range per field. Field: "' + field + '".');
       }
@@ -111,7 +111,7 @@ export class RemoteQueryAdapter {
         RemoteQueryAdapter.#extractFilterEntryValue(rangeEnd, rangeStart.key)
       ];
     }
-    else if (operator === 'LIKE') {
+    else if (operator === 'like') {
       if (valuesEntries.length !== 1) {
         throw new Error('Remote datasource supports exactly one LIKE pattern per field. Field: "' + field + '".');
       }

--- a/tests/unit/remote-query-adapter.test.js
+++ b/tests/unit/remote-query-adapter.test.js
@@ -26,7 +26,7 @@ describe('RemoteQueryAdapter', () => {
     return { columnName, filter };
   }
 
-  test('maps include filter to INCLUDE with enabled values only', () => {
+  test('maps include filter to lowercase include with enabled values only', () => {
     const filters = RemoteQueryAdapter.toRemoteFilters([
       makeFilterAxisItem('symbol', {
         filterType: FilterDialog.filterTypes.INCLUDE,
@@ -40,13 +40,13 @@ describe('RemoteQueryAdapter', () => {
     expect(filters).toEqual([
       {
         field: 'symbol',
-        operator: 'INCLUDE',
+        operator: 'include',
         values: ['AAPL'],
       },
     ]);
   });
 
-  test('maps notin filter to EXCLUDE', () => {
+  test('maps notin filter to lowercase exclude', () => {
     const filters = RemoteQueryAdapter.toRemoteFilters([
       makeFilterAxisItem('symbol', {
         filterType: FilterDialog.filterTypes.EXCLUDE,
@@ -56,7 +56,7 @@ describe('RemoteQueryAdapter', () => {
       }),
     ], 'test');
 
-    expect(filters[0].operator).toBe('EXCLUDE');
+    expect(filters[0].operator).toBe('exclude');
     expect(filters[0].values).toEqual(['TSLA']);
   });
 
@@ -76,7 +76,7 @@ describe('RemoteQueryAdapter', () => {
     expect(filters).toEqual([
       {
         field: 'date',
-        operator: 'BETWEEN',
+        operator: 'between',
         values: ['2026-01-01', '2026-01-31'],
       },
     ]);


### PR DESCRIPTION
Fixes #411

## Summary
- add gt/gte/lt/lte/is_null/not_null and normalize all API filter operators to lowercase
- return `FILTER_INVALID` for malformed filter payloads and validate value counts per operator
- update SQL generation, remote adapter mapping, docs, and tests for the new contract

## Validation
- `./.venv-server/bin/ruff check server/`
- `./.venv-server/bin/pytest server/tests -q`
- `./.venv-server/bin/pytest tests/test_backend_benchmark_runner.py -q`
- `npm run test:unit`
- `npm run lint:js`