### PR TITLE
Expand backend aggregation functions

### DIFF
--- a/docs/server/README.md
+++ b/docs/server/README.md
@@ -216,7 +216,7 @@ curl -X POST 'http://localhost:8000/api/v1/datasets/trades_v1/exports' \
     "query": {
       "axes": {
         "rows": [{"field": "symbol"}],
-        "measures": [{"field": "volume", "aggregation": "SUM", "alias": "total_volume"}]
+        "measures": [{"field": "volume", "aggregation": "sum", "alias": "total_volume"}]
       },
       "max_rows": 1000
     }

--- a/docs/server/api-reference.md
+++ b/docs/server/api-reference.md
@@ -297,8 +297,11 @@ Request body fields:
 - `axes.columns` (array of `{ "field": string }`)
 - `axes.measures` (array):
   - `field` (string)
-  - `aggregation` (`SUM`, `COUNT`, `AVG`, `MIN`, `MAX`)
+  - `aggregation`
+    - Supported: `sum`, `avg`, `min`, `max`, `count`, `distinct_count`, `median`, `mode`, `stdev`, `variance`, `geomean`, `entropy`, `kurtosis`, `skewness`, `mad`, `and`, `or`, `count_if_true`, `count_if_false`, `list`, `unique_list`, `first`, `last`
+    - Explicitly rejected: `histogram` (`AGGREGATION_NOT_SUPPORTED`)
   - `alias` (string, optional)
+  - `sort_by` (string, required only for `first` and `last`)
 - `window.rows` and `window.columns` (optional):
   - `offset` (`>=0`)
   - `limit` (`>=1`)
@@ -316,7 +319,7 @@ Request example:
   "axes": {
     "rows": [{"field": "symbol"}],
     "columns": [],
-    "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}]
+    "measures": [{"field": "volume", "aggregation": "sum", "alias": "sum_volume"}]
   }
 }
 ```
@@ -354,6 +357,8 @@ Error statuses:
 - `404` `DATASET_NOT_FOUND`
 - `409` `DATASET_UNAVAILABLE`
 - `422` `VALIDATION_ERROR`
+- `422` `SORT_BY_REQUIRED`
+- `422` `AGGREGATION_NOT_SUPPORTED`
 - `401` auth failure when auth enabled
 - `429` if rate limiting enabled and exceeded
 
@@ -432,7 +437,7 @@ Request example:
   "query": {
     "axes": {
       "rows": [{"field": "symbol"}],
-      "measures": [{"field": "volume", "aggregation": "SUM", "alias": "total_volume"}]
+      "measures": [{"field": "volume", "aggregation": "sum", "alias": "total_volume"}]
     },
     "max_rows": 1000,
     "format": "parquet"

--- a/server/benchmarks/workloads.json
+++ b/server/benchmarks/workloads.json
@@ -17,7 +17,7 @@
       "warmup_requests": 2,
       "body": {
         "fields": [{"field": "symbol"}],
-        "filters": [{"field": "symbol", "operator": "EXCLUDE", "values": ["AAPL"]}],
+        "filters": [{"field": "symbol", "operator": "exclude", "values": ["AAPL"]}],
         "paging": {"limit": 50, "offset": 0}
       }
     },
@@ -30,7 +30,7 @@
         "axes": {
           "rows": [{"field": "symbol"}],
           "columns": [],
-          "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}]
+          "measures": [{"field": "volume", "aggregation": "sum", "alias": "sum_volume"}]
         }
       }
     },
@@ -43,7 +43,7 @@
         "axes": {
           "rows": [{"field": "date"}],
           "columns": [{"field": "symbol"}],
-          "measures": [{"field": "volume", "aggregation": "SUM", "alias": "sum_volume"}]
+          "measures": [{"field": "volume", "aggregation": "sum", "alias": "sum_volume"}]
         }
       }
     },
@@ -80,7 +80,7 @@
           "export_type": "pivot_results",
           "axes": {
             "rows": [{"field": "symbol"}],
-            "measures": [{"field": "volume", "aggregation": "SUM", "alias": "total_volume"}]
+            "measures": [{"field": "volume", "aggregation": "sum", "alias": "total_volume"}]
           },
           "filters": [],
           "max_rows": 1000,

--- a/server/errors.py
+++ b/server/errors.py
@@ -49,6 +49,18 @@ class ValidationAppError(AppError):
         )
 
 
+class AggregationNotSupportedError(AppError):
+    """Raised when a requested aggregation is incompatible with the field/type."""
+
+    def __init__(self, errors: list[dict[str, Any]]) -> None:
+        super().__init__(
+            code="AGGREGATION_NOT_SUPPORTED",
+            message="Aggregation is not supported for this request",
+            status_code=422,
+            details={"errors": errors},
+        )
+
+
 class DatasetNotFoundError(AppError):
     """Raised when a requested dataset_id is not registered in the service."""
 

--- a/server/main.py
+++ b/server/main.py
@@ -169,6 +169,8 @@ async def validation_error_handler(request: Request, exc: RequestValidationError
     """Normalize FastAPI validation errors into the ErrorResponse envelope."""
     clean_errors = []
     has_filter_error = False
+    has_sort_by_error = False
+    has_aggregation_error = False
     for err in exc.errors():
         entry = {
             "loc": list(err.get("loc", [])),
@@ -177,12 +179,27 @@ async def validation_error_handler(request: Request, exc: RequestValidationError
         }
         if entry["type"] == "filter_invalid" or "filters" in entry["loc"]:
             has_filter_error = True
+        if entry["type"] == "sort_by_required":
+            has_sort_by_error = True
+        if entry["type"] == "aggregation_not_supported":
+            has_aggregation_error = True
         if "ctx" in err:
             entry["ctx"] = jsonable_encoder(err["ctx"])
         clean_errors.append(entry)
+    code = "VALIDATION_ERROR"
+    message = "Request validation failed"
+    if has_filter_error:
+        code = "FILTER_INVALID"
+        message = "Filter validation failed"
+    elif has_sort_by_error:
+        code = "SORT_BY_REQUIRED"
+        message = "sort_by is required for this aggregation"
+    elif has_aggregation_error:
+        code = "AGGREGATION_NOT_SUPPORTED"
+        message = "Aggregation is not supported for this request"
     body = ErrorResponse(
-        code="FILTER_INVALID" if has_filter_error else "VALIDATION_ERROR",
-        message="Filter validation failed" if has_filter_error else "Request validation failed",
+        code=code,
+        message=message,
         request_id=get_request_id() or None,
         details={"errors": clean_errors},
     )

--- a/server/models.py
+++ b/server/models.py
@@ -28,7 +28,32 @@ FilterOperator = Literal[
 ]
 SortDirection = Literal["ASC", "DESC"]
 ExportFormat = Literal["parquet", "csv", "sqlite", "duckdb", "csv_with_bom", "ndjson"]
-AggregationFunction = Literal["SUM", "COUNT", "AVG", "MIN", "MAX"]
+AggregationFunction = Literal[
+    "sum",
+    "avg",
+    "min",
+    "max",
+    "count",
+    "distinct_count",
+    "median",
+    "mode",
+    "stdev",
+    "variance",
+    "geomean",
+    "entropy",
+    "kurtosis",
+    "skewness",
+    "mad",
+    "and",
+    "or",
+    "count_if_true",
+    "count_if_false",
+    "list",
+    "unique_list",
+    "first",
+    "last",
+    "histogram",
+]
 
 MAX_PAGE_LIMIT = 10000
 MAX_EXPORT_ROWS = 100000
@@ -275,8 +300,39 @@ class MeasureSpec(BaseModel):
     """An aggregated measure with a required aggregation function and optional alias."""
 
     field: str
-    aggregation: AggregationFunction = "SUM"
+    aggregation: AggregationFunction = "sum"
     alias: str | None = None
+    sort_by: str | None = None
+
+    @field_validator("aggregation", mode="before")
+    @classmethod
+    def normalize_aggregation(cls, value: str) -> str:
+        if isinstance(value, str):
+            return value.lower()
+        return value
+
+    @model_validator(mode="after")
+    def validate_sort_by(self) -> "MeasureSpec":
+        if self.aggregation == "histogram":
+            raise PydanticCustomError(
+                "aggregation_not_supported",
+                "Aggregation histogram is not supported by the API response format",
+                {"aggregation": "histogram"},
+            )
+        if self.aggregation in ("first", "last"):
+            if not self.sort_by:
+                raise PydanticCustomError(
+                    "sort_by_required",
+                    "Aggregation {aggregation} requires sort_by",
+                    {"aggregation": self.aggregation},
+                )
+        elif self.sort_by is not None:
+            raise PydanticCustomError(
+                "sort_by_not_supported",
+                "Aggregation {aggregation} does not support sort_by",
+                {"aggregation": self.aggregation},
+            )
+        return self
 
 
 class AxesSpec(BaseModel):

--- a/server/query_builder.py
+++ b/server/query_builder.py
@@ -689,7 +689,6 @@ def build_export_sql(
     row_fields = [f.field for f in (axes.rows if axes else [])]
     col_fields = [f.field for f in (axes.columns if axes else [])]
     measures = axes.measures if axes else []
-    _validate_measure_specs(dataset_id, list(measures), schema_fields, ["body", "query", "axes", "measures"])
 
     dim_cols = [_quote(f) for f in row_fields + col_fields]
     dim_headers = row_fields + col_fields

--- a/server/query_builder.py
+++ b/server/query_builder.py
@@ -8,7 +8,8 @@ placeholders.
 
 from typing import Any
 
-from server.errors import ValidationAppError
+from server import datasets
+from server.errors import AggregationNotSupportedError, ValidationAppError
 from server.models import (
     AxesSpec,
     CellsQueryBody,
@@ -22,6 +23,186 @@ from server.models import (
 )
 from server.relation_builder import build_base_relation, required_relation_columns
 from server.utils import quote_identifier as _quote
+
+_NUMERIC_TYPES = {
+    "TINYINT",
+    "SMALLINT",
+    "INTEGER",
+    "BIGINT",
+    "HUGEINT",
+    "UTINYINT",
+    "USMALLINT",
+    "UINTEGER",
+    "UBIGINT",
+    "UHUGEINT",
+    "REAL",
+    "DOUBLE",
+    "FLOAT",
+    "INT64",
+    "INT32",
+    "INT16",
+    "INT8",
+    "UINT64",
+    "UINT32",
+    "UINT16",
+    "UINT8",
+    "FLOAT32",
+    "FLOAT64",
+}
+
+_BOOLEAN_TYPES = {"BOOLEAN", "BOOL"}
+_NUMERIC_ONLY_AGGREGATIONS = {
+    "sum",
+    "avg",
+    "stdev",
+    "variance",
+    "geomean",
+    "kurtosis",
+    "skewness",
+    "mad",
+}
+_BOOLEAN_ONLY_AGGREGATIONS = {"and", "or", "count_if_true", "count_if_false"}
+
+
+def _get_schema_field_types(dataset_id: str) -> dict[str, str]:
+    schema = datasets.get_schema(dataset_id) or {}
+    fields = schema.get("fields", []) if isinstance(schema, dict) else []
+    field_types: dict[str, str] = {}
+    for field in fields:
+        if isinstance(field, dict) and field.get("name") and field.get("type"):
+            field_types[str(field["name"])] = str(field["type"])
+    return field_types
+
+
+def _normalize_type_name(type_name: str | None) -> str:
+    if not type_name:
+        return ""
+    return str(type_name).upper().strip()
+
+
+def _is_numeric_type(type_name: str | None) -> bool:
+    normalized = _normalize_type_name(type_name)
+    if normalized in _NUMERIC_TYPES:
+        return True
+    if normalized.startswith(("DECIMAL", "NUMERIC", "FLOAT")):
+        return True
+    return False
+
+
+def _is_boolean_type(type_name: str | None) -> bool:
+    return _normalize_type_name(type_name) in _BOOLEAN_TYPES
+
+
+def _validate_measure_specs(
+    dataset_id: str,
+    measures: list[Any],
+    schema_fields: set[str],
+    loc_prefix: list[Any],
+) -> None:
+    schema_field_types = _get_schema_field_types(dataset_id)
+    errors: list[dict[str, Any]] = []
+    aggregation_errors: list[dict[str, Any]] = []
+
+    for index, measure in enumerate(measures):
+        field_type = schema_field_types.get(measure.field)
+        aggregation = measure.aggregation
+
+        if aggregation in _NUMERIC_ONLY_AGGREGATIONS and not _is_numeric_type(field_type):
+            aggregation_errors.append(
+                {
+                    "loc": [*loc_prefix, index, "aggregation"],
+                    "msg": f"Aggregation {aggregation} is not supported for field type {field_type or 'unknown'}",
+                    "type": "aggregation_not_supported",
+                    "ctx": {"aggregation": aggregation, "field": measure.field, "field_type": field_type},
+                }
+            )
+        elif aggregation in _BOOLEAN_ONLY_AGGREGATIONS and not _is_boolean_type(field_type):
+            aggregation_errors.append(
+                {
+                    "loc": [*loc_prefix, index, "aggregation"],
+                    "msg": f"Aggregation {aggregation} is only supported for boolean fields",
+                    "type": "aggregation_not_supported",
+                    "ctx": {"aggregation": aggregation, "field": measure.field, "field_type": field_type},
+                }
+            )
+
+        if aggregation in ("first", "last") and measure.sort_by not in schema_fields:
+            errors.append(
+                {
+                    "loc": [*loc_prefix, index, "sort_by"],
+                    "msg": f"Unknown field: {measure.sort_by}",
+                    "type": "value_error.unknown_field",
+                }
+            )
+
+    if aggregation_errors:
+        raise AggregationNotSupportedError(aggregation_errors)
+    _raise_if_unknown(errors)
+
+
+def _build_aggregation_expression(measure: Any) -> str:
+    field = measure.field
+    aggregation = measure.aggregation
+    alias = measure.alias or f"{aggregation}_{field}"
+    quoted_field = _quote(field)
+    quoted_alias = _quote(alias)
+
+    if aggregation == "sum":
+        return f"SUM({quoted_field}) AS {quoted_alias}"
+    if aggregation == "avg":
+        return f"AVG({quoted_field}) AS {quoted_alias}"
+    if aggregation == "min":
+        return f"MIN({quoted_field}) AS {quoted_alias}"
+    if aggregation == "max":
+        return f"MAX({quoted_field}) AS {quoted_alias}"
+    if aggregation == "count":
+        return f"COUNT({quoted_field}) AS {quoted_alias}"
+    if aggregation == "distinct_count":
+        return f"COUNT(DISTINCT {quoted_field}) AS {quoted_alias}"
+    if aggregation == "median":
+        return f"MEDIAN({quoted_field}) AS {quoted_alias}"
+    if aggregation == "mode":
+        return f"MODE({quoted_field}) AS {quoted_alias}"
+    if aggregation == "stdev":
+        return f"STDDEV_SAMP({quoted_field}) AS {quoted_alias}"
+    if aggregation == "variance":
+        return f"VAR_SAMP({quoted_field}) AS {quoted_alias}"
+    if aggregation == "geomean":
+        return f"GEOMEAN({quoted_field}) AS {quoted_alias}"
+    if aggregation == "entropy":
+        return f"ENTROPY({quoted_field}) AS {quoted_alias}"
+    if aggregation == "kurtosis":
+        return f"KURTOSIS({quoted_field}) AS {quoted_alias}"
+    if aggregation == "skewness":
+        return f"SKEWNESS({quoted_field}) AS {quoted_alias}"
+    if aggregation == "mad":
+        return f"MAD({quoted_field}) AS {quoted_alias}"
+    if aggregation == "and":
+        return f"BOOL_AND({quoted_field}) AS {quoted_alias}"
+    if aggregation == "or":
+        return f"BOOL_OR({quoted_field}) AS {quoted_alias}"
+    if aggregation == "count_if_true":
+        return f"COUNT({quoted_field}) FILTER (WHERE {quoted_field}) AS {quoted_alias}"
+    if aggregation == "count_if_false":
+        return f"COUNT({quoted_field}) FILTER (WHERE NOT {quoted_field}) AS {quoted_alias}"
+    if aggregation == "list":
+        return f"LIST({quoted_field}) AS {quoted_alias}"
+    if aggregation == "unique_list":
+        return f"LIST(DISTINCT {quoted_field} ORDER BY {quoted_field}) AS {quoted_alias}"
+    if aggregation == "first":
+        return f"FIRST({quoted_field} ORDER BY {_quote(measure.sort_by)}) AS {quoted_alias}"
+    if aggregation == "last":
+        return f"LAST({quoted_field} ORDER BY {_quote(measure.sort_by)}) AS {quoted_alias}"
+    raise ValidationAppError(
+        [
+            {
+                "loc": ["body", "axes", "measures", "aggregation"],
+                "msg": f"Unsupported aggregation: {aggregation}",
+                "type": "aggregation_not_supported",
+                "ctx": {"aggregation": aggregation, "field": field},
+            }
+        ]
+    )
 
 
 def _unknown_field_error(loc: list[Any], field: str) -> dict[str, Any]:
@@ -91,11 +272,21 @@ def validate_picklist_query_fields(query: PicklistQueryBody, schema_fields: set[
     _raise_if_unknown(errors)
 
 
-def validate_export_query_fields(query: ExportQueryBody, schema_fields: set[str]) -> None:
+def validate_export_query_fields(
+    dataset_id: str,
+    query: ExportQueryBody,
+    schema_fields: set[str],
+) -> None:
     errors: list[dict[str, Any]] = []
     _validate_axes_fields(query.axes, errors, schema_fields)
     _validate_filter_fields(query.filters, errors, schema_fields)
     _raise_if_unknown(errors)
+    _validate_measure_specs(
+        dataset_id,
+        list(query.axes.measures if query.axes else []),
+        schema_fields,
+        ["body", "query", "axes", "measures"],
+    )
 
 
 def _build_date_clause(date_range: DateRange | None, params: list[Any]) -> str:
@@ -276,20 +467,19 @@ def build_cells_sql(
     row_fields = [f.field for f in (axes.rows if axes else [])]
     col_fields = [f.field for f in (axes.columns if axes else [])]
     measures = axes.measures if axes else []
+    _validate_measure_specs(dataset_id, list(measures), schema_fields, ["body", "axes", "measures"])
 
     dim_cols = [_quote(f) for f in row_fields + col_fields]
     agg_exprs = []
     for m in measures:
-        field = m.field
-        agg = m.aggregation.upper()
-        alias = m.alias or f"{agg.lower()}_{field}"
-        agg_exprs.append(f"{agg}({_quote(field)}) AS {_quote(alias)}")
+        agg_exprs.append(_build_aggregation_expression(m))
 
     if not dim_cols and not agg_exprs:
         return f"SELECT 1 FROM {_quote(dataset_id)} WHERE FALSE", []
 
     required_columns = set(row_fields + col_fields)
     required_columns.update(m.field for m in measures)
+    required_columns.update(m.sort_by for m in measures if getattr(m, "sort_by", None))
     if query.filters:
         required_columns.update(f.field for f in query.filters)
     required_columns.update(required_relation_columns(dataset_id))
@@ -492,27 +682,27 @@ def build_export_sql(
     Returns (sql, params, headers) where headers is the list of column names
     for the CSV header row.
     """
-    validate_export_query_fields(query, schema_fields)
+    validate_export_query_fields(dataset_id, query, schema_fields)
     axes = query.axes
     max_rows = query.max_rows
 
     row_fields = [f.field for f in (axes.rows if axes else [])]
     col_fields = [f.field for f in (axes.columns if axes else [])]
     measures = axes.measures if axes else []
+    _validate_measure_specs(dataset_id, list(measures), schema_fields, ["body", "query", "axes", "measures"])
 
     dim_cols = [_quote(f) for f in row_fields + col_fields]
     dim_headers = row_fields + col_fields
     agg_exprs = []
     agg_headers: list[str] = []
     for m in measures:
-        field = m.field
-        agg = m.aggregation.upper()
-        alias = m.alias or f"{agg.lower()}_{field}"
-        agg_exprs.append(f"{agg}({_quote(field)}) AS {_quote(alias)}")
+        alias = m.alias or f"{m.aggregation}_{m.field}"
+        agg_exprs.append(_build_aggregation_expression(m))
         agg_headers.append(alias)
 
     required_columns = set(row_fields + col_fields)
     required_columns.update(m.field for m in measures)
+    required_columns.update(m.sort_by for m in measures if getattr(m, "sort_by", None))
     if query.filters:
         required_columns.update(f.field for f in query.filters)
     required_columns.update(required_relation_columns(dataset_id))

--- a/server/routers/export.py
+++ b/server/routers/export.py
@@ -119,7 +119,7 @@ async def post_export(
     settings = get_settings()
     if settings.execution_mode == "sample_table" and not db_manager.table_exists(dataset_id):
         raise DatasetUnavailableError(dataset_id)
-    validate_export_query_fields(body.query, datasets.get_schema_field_names(dataset_id))
+    validate_export_query_fields(dataset_id, body.query, datasets.get_schema_field_names(dataset_id))
 
     export_request = ExportRequest(dataset_id=dataset_id, date_range=body.date_range, query=body.query)
     service = get_export_service()

--- a/server/tests/test_models.py
+++ b/server/tests/test_models.py
@@ -338,12 +338,19 @@ class TestAxesModels:
 
     def test_measure_spec_defaults(self) -> None:
         m = MeasureSpec(field="volume")
-        assert m.aggregation == "SUM"
+        assert m.aggregation == "sum"
         assert m.alias is None
 
     def test_measure_spec_all_aggregations(self) -> None:
-        for agg in ("SUM", "COUNT", "AVG", "MIN", "MAX"):
-            m = MeasureSpec(field="volume", aggregation=agg)
+        for agg in (
+            "sum", "avg", "min", "max", "count", "distinct_count", "median", "mode",
+            "stdev", "variance", "geomean", "entropy", "kurtosis", "skewness", "mad",
+            "and", "or", "count_if_true", "count_if_false", "list", "unique_list", "first", "last",
+        ):
+            kwargs = {"field": "volume", "aggregation": agg}
+            if agg in ("first", "last"):
+                kwargs["sort_by"] = "date"
+            m = MeasureSpec(**kwargs)
             assert m.aggregation == agg
 
     def test_measure_spec_invalid_aggregation_raises(self) -> None:
@@ -351,8 +358,32 @@ class TestAxesModels:
             MeasureSpec(field="volume", aggregation="INVALID")
 
     def test_measure_spec_with_alias(self) -> None:
-        m = MeasureSpec(field="volume", aggregation="SUM", alias="vol")
+        m = MeasureSpec(field="volume", aggregation="sum", alias="vol")
         assert m.alias == "vol"
+
+    def test_measure_spec_is_case_insensitive(self) -> None:
+        m = MeasureSpec(field="volume", aggregation="AVG")
+        assert m.aggregation == "avg"
+
+    def test_first_requires_sort_by(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            MeasureSpec(field="volume", aggregation="first")
+        assert exc_info.value.errors()[0]["type"] == "sort_by_required"
+
+    def test_last_requires_sort_by(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            MeasureSpec(field="volume", aggregation="last")
+        assert exc_info.value.errors()[0]["type"] == "sort_by_required"
+
+    def test_sort_by_not_supported_for_other_aggregations(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            MeasureSpec(field="volume", aggregation="sum", sort_by="date")
+        assert exc_info.value.errors()[0]["type"] == "sort_by_not_supported"
+
+    def test_histogram_is_explicitly_rejected(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            MeasureSpec(field="volume", aggregation="histogram")
+        assert exc_info.value.errors()[0]["type"] == "aggregation_not_supported"
 
     def test_axes_spec_defaults(self) -> None:
         axes = AxesSpec()
@@ -376,12 +407,12 @@ class TestAxesModels:
         body = CellsQueryBody(axes={"rows": [{"field": "symbol"}], "measures": [{"field": "volume"}]})
         assert isinstance(body.axes, AxesSpec)
         assert body.axes.rows[0].field == "symbol"
-        assert body.axes.measures[0].aggregation == "SUM"
+        assert body.axes.measures[0].aggregation == "sum"
 
     def test_export_query_body_axes_coerced(self) -> None:
         body = ExportQueryBody(axes={"rows": [{"field": "date"}], "measures": [{"field": "volume", "aggregation": "COUNT"}]})
         assert isinstance(body.axes, AxesSpec)
-        assert body.axes.measures[0].aggregation == "COUNT"
+        assert body.axes.measures[0].aggregation == "count"
 
 
 class TestPagingModels:

--- a/server/tests/test_query_builder.py
+++ b/server/tests/test_query_builder.py
@@ -3,7 +3,7 @@
 import pytest
 from pydantic import ValidationError
 
-from server.errors import ValidationAppError
+from server.errors import AggregationNotSupportedError, ValidationAppError
 from server.models import (
     CellsQueryBody,
     DateRangeRange,
@@ -25,9 +25,27 @@ from server.query_builder import (
 )
 from server.relation_builder import BaseRelation
 
-SCHEMA_FIELDS = {"date", "symbol", "volume"}
+SCHEMA_TYPES = {
+    "date": "date",
+    "symbol": "string",
+    "volume": "int64",
+    "price": "float64",
+    "is_active": "boolean",
+}
+SCHEMA_FIELDS = set(SCHEMA_TYPES)
 DR_SINGLE = DateRangeSingle(type="single", date="2026-03-01")
 DR_RANGE = DateRangeRange(type="range", start="2026-03-01", end="2026-03-31")
+
+
+@pytest.fixture(autouse=True)
+def _mock_dataset_schema(monkeypatch: pytest.MonkeyPatch) -> None:
+    schema = {
+        "fields": [
+            {"name": name, "type": type_name}
+            for name, type_name in SCHEMA_TYPES.items()
+        ]
+    }
+    monkeypatch.setattr("server.query_builder.datasets.get_schema", lambda _dataset_id: schema)
 
 
 class TestBuildTuplesSql:
@@ -224,6 +242,89 @@ class TestBuildCellsSql:
         assert 'MIN("volume")' in sql
         assert 'MAX("volume")' in sql
 
+    @pytest.mark.parametrize(
+        ("aggregation", "field", "sql_fragment"),
+        [
+            ("sum", "volume", 'SUM("volume")'),
+            ("avg", "volume", 'AVG("volume")'),
+            ("min", "symbol", 'MIN("symbol")'),
+            ("max", "symbol", 'MAX("symbol")'),
+            ("count", "symbol", 'COUNT("symbol")'),
+            ("distinct_count", "symbol", 'COUNT(DISTINCT "symbol")'),
+            ("median", "volume", 'MEDIAN("volume")'),
+            ("mode", "symbol", 'MODE("symbol")'),
+            ("stdev", "volume", 'STDDEV_SAMP("volume")'),
+            ("variance", "volume", 'VAR_SAMP("volume")'),
+            ("geomean", "volume", 'GEOMEAN("volume")'),
+            ("entropy", "symbol", 'ENTROPY("symbol")'),
+            ("kurtosis", "volume", 'KURTOSIS("volume")'),
+            ("skewness", "volume", 'SKEWNESS("volume")'),
+            ("mad", "volume", 'MAD("volume")'),
+            ("and", "is_active", 'BOOL_AND("is_active")'),
+            ("or", "is_active", 'BOOL_OR("is_active")'),
+            ("count_if_true", "is_active", 'COUNT("is_active") FILTER (WHERE "is_active")'),
+            ("count_if_false", "is_active", 'COUNT("is_active") FILTER (WHERE NOT "is_active")'),
+            ("list", "symbol", 'LIST("symbol")'),
+            ("unique_list", "symbol", 'LIST(DISTINCT "symbol" ORDER BY "symbol")'),
+            ("first", "symbol", 'FIRST("symbol" ORDER BY "date")'),
+            ("last", "symbol", 'LAST("symbol" ORDER BY "date")'),
+        ],
+    )
+    def test_all_supported_aggregations_generate_sql(
+        self, aggregation: str, field: str, sql_fragment: str
+    ) -> None:
+        measure = {"field": field, "aggregation": aggregation, "alias": f"{aggregation}_{field}"}
+        if aggregation in ("first", "last"):
+            measure["sort_by"] = "date"
+        query = CellsQueryBody(
+            axes={
+                "rows": [{"field": "symbol"}],
+                "columns": [],
+                "measures": [measure],
+            },
+        )
+        sql, _ = build_cells_sql("trades_v1", query, DR_SINGLE, SCHEMA_FIELDS)
+        assert sql_fragment in sql
+
+    @pytest.mark.parametrize(
+        ("aggregation", "field"),
+        [
+            ("sum", "symbol"),
+            ("avg", "symbol"),
+            ("stdev", "symbol"),
+            ("variance", "symbol"),
+            ("geomean", "symbol"),
+            ("kurtosis", "symbol"),
+            ("skewness", "symbol"),
+            ("mad", "symbol"),
+            ("and", "volume"),
+            ("or", "volume"),
+            ("count_if_true", "volume"),
+            ("count_if_false", "volume"),
+        ],
+    )
+    def test_incompatible_aggregations_raise(self, aggregation: str, field: str) -> None:
+        query = CellsQueryBody(
+            axes={
+                "rows": [{"field": "symbol"}],
+                "columns": [],
+                "measures": [{"field": field, "aggregation": aggregation, "alias": "bad"}],
+            },
+        )
+        with pytest.raises(AggregationNotSupportedError):
+            build_cells_sql("trades_v1", query, DR_SINGLE, SCHEMA_FIELDS)
+
+    def test_first_last_unknown_sort_by_rejected(self) -> None:
+        query = CellsQueryBody(
+            axes={
+                "rows": [{"field": "symbol"}],
+                "columns": [],
+                "measures": [{"field": "symbol", "aggregation": "first", "alias": "first_symbol", "sort_by": "missing"}],
+            },
+        )
+        with pytest.raises(ValidationAppError):
+            build_cells_sql("trades_v1", query, DR_SINGLE, SCHEMA_FIELDS)
+
     def test_column_fields(self) -> None:
         query = CellsQueryBody(
             axes={
@@ -388,7 +489,7 @@ class TestBuildExportSql:
         sql, params, headers = build_export_sql("trades_v1", query, DR_SINGLE, SCHEMA_FIELDS)
         assert "GROUP BY" not in sql
         assert "LIMIT 100" in sql
-        assert set(headers) == {"date", "symbol", "volume"}
+        assert set(headers) == SCHEMA_FIELDS
 
     def test_dimensions_only_no_group_by(self) -> None:
         query = ExportQueryBody(

--- a/server/tests/test_query_cells_api.py
+++ b/server/tests/test_query_cells_api.py
@@ -55,6 +55,33 @@ def test_query_cells_multiple_aggregations(client: TestClient) -> None:
     assert len(cells[0].keys()) == 7
 
 
+def test_query_cells_extended_aggregations(client: TestClient) -> None:
+    body = {
+        "date_range": {"type": "range", "start": "2026-03-01", "end": "2026-03-02"},
+        "axes": {
+            "rows": [{"field": "symbol"}],
+            "columns": [],
+            "measures": [
+                {"field": "symbol", "aggregation": "distinct_count", "alias": "distinct_symbols"},
+                {"field": "volume", "aggregation": "median", "alias": "median_volume"},
+                {"field": "symbol", "aggregation": "list", "alias": "symbols_list"},
+                {"field": "symbol", "aggregation": "unique_list", "alias": "symbols_unique"},
+                {"field": "symbol", "aggregation": "first", "alias": "first_symbol", "sort_by": "date"},
+                {"field": "symbol", "aggregation": "last", "alias": "last_symbol", "sort_by": "date"},
+            ],
+        },
+    }
+    r = client.post("/api/v1/datasets/trades_v1/query/cells", json=body)
+    assert r.status_code == 200
+    cell = r.json()["cells"][0]
+    assert "distinct_symbols" in cell
+    assert "median_volume" in cell
+    assert "symbols_list" in cell
+    assert "symbols_unique" in cell
+    assert "first_symbol" in cell
+    assert "last_symbol" in cell
+
+
 def test_query_cells_with_filter(client: TestClient) -> None:
     dataset_id = "trades_v1"
     body = {

--- a/server/tests/test_validation_errors.py
+++ b/server/tests/test_validation_errors.py
@@ -189,6 +189,34 @@ class TestCellsValidation:
         r = client.post(_post_path("cells"), json=body)
         assert r.status_code == 422
 
+    def test_first_without_sort_by_returns_sort_by_required(self, client: TestClient) -> None:
+        body = _valid_body_for("cells")
+        body["axes"]["measures"] = [{"field": "volume", "aggregation": "first", "alias": "first_volume"}]
+        r = client.post(_post_path("cells"), json=body)
+        assert r.status_code == 422
+        assert r.json()["code"] == "SORT_BY_REQUIRED"
+
+    def test_histogram_returns_aggregation_not_supported(self, client: TestClient) -> None:
+        body = _valid_body_for("cells")
+        body["axes"]["measures"] = [{"field": "volume", "aggregation": "histogram", "alias": "volume_hist"}]
+        r = client.post(_post_path("cells"), json=body)
+        assert r.status_code == 422
+        assert r.json()["code"] == "AGGREGATION_NOT_SUPPORTED"
+
+    def test_incompatible_aggregation_returns_aggregation_not_supported(self, client: TestClient) -> None:
+        body = _valid_body_for("cells")
+        body["axes"]["measures"] = [{"field": "symbol", "aggregation": "sum", "alias": "sum_symbol"}]
+        r = client.post(_post_path("cells"), json=body)
+        assert r.status_code == 422
+        assert r.json()["code"] == "AGGREGATION_NOT_SUPPORTED"
+
+    def test_first_sort_by_field_must_exist(self, client: TestClient) -> None:
+        body = _valid_body_for("cells")
+        body["axes"]["measures"] = [{"field": "volume", "aggregation": "first", "alias": "first_volume", "sort_by": "missing"}]
+        r = client.post(_post_path("cells"), json=body)
+        assert r.status_code == 422
+        assert r.json()["code"] == "VALIDATION_ERROR"
+
 
 class TestMembersValidation:
     def test_unknown_members_field_rejected(self, client: TestClient) -> None:
@@ -225,3 +253,45 @@ class TestExportValidation:
             },
         )
         assert r.status_code == 422
+
+    def test_export_first_without_sort_by_returns_sort_by_required(self, client: TestClient) -> None:
+        r = client.post(
+            EXPORTS_ROOT,
+            json={
+                "date_range": {"type": "single", "date": "2026-03-01"},
+                "query": {
+                    "axes": {"measures": [{"field": "volume", "aggregation": "first", "alias": "first_volume"}]},
+                    "format": "csv",
+                },
+            },
+        )
+        assert r.status_code == 422
+        assert r.json()["code"] == "SORT_BY_REQUIRED"
+
+    def test_export_histogram_returns_aggregation_not_supported(self, client: TestClient) -> None:
+        r = client.post(
+            EXPORTS_ROOT,
+            json={
+                "date_range": {"type": "single", "date": "2026-03-01"},
+                "query": {
+                    "axes": {"measures": [{"field": "volume", "aggregation": "histogram", "alias": "volume_hist"}]},
+                    "format": "csv",
+                },
+            },
+        )
+        assert r.status_code == 422
+        assert r.json()["code"] == "AGGREGATION_NOT_SUPPORTED"
+
+    def test_export_incompatible_aggregation_returns_aggregation_not_supported(self, client: TestClient) -> None:
+        r = client.post(
+            EXPORTS_ROOT,
+            json={
+                "date_range": {"type": "single", "date": "2026-03-01"},
+                "query": {
+                    "axes": {"measures": [{"field": "symbol", "aggregation": "sum", "alias": "sum_symbol"}]},
+                    "format": "csv",
+                },
+            },
+        )
+        assert r.status_code == 422
+        assert r.json()["code"] == "AGGREGATION_NOT_SUPPORTED"

--- a/src/DataSource/remote/RemoteQueryAdapter.js
+++ b/src/DataSource/remote/RemoteQueryAdapter.js
@@ -7,11 +7,30 @@ export class RemoteQueryAdapter {
   };
 
   static #AGGREGATION_BY_NAME = {
-    sum: 'SUM',
-    count: 'COUNT',
-    avg: 'AVG',
-    min: 'MIN',
-    max: 'MAX'
+    sum: 'sum',
+    count: 'count',
+    avg: 'avg',
+    min: 'min',
+    max: 'max',
+    'distinct count': 'distinct_count',
+    median: 'median',
+    mode: 'mode',
+    stdev: 'stdev',
+    variance: 'variance',
+    geomean: 'geomean',
+    entropy: 'entropy',
+    kurtosis: 'kurtosis',
+    skewness: 'skewness',
+    mad: 'mad',
+    and: 'and',
+    or: 'or',
+    'count if true': 'count_if_true',
+    'count if false': 'count_if_false',
+    list: 'list',
+    'unique values': 'unique_list',
+    first: 'first',
+    last: 'last',
+    histogram: 'histogram'
   };
 
   static getDateRange(queryModel) {

--- a/tests/unit/remote-query-adapter.test.js
+++ b/tests/unit/remote-query-adapter.test.js
@@ -95,7 +95,7 @@ describe('RemoteQueryAdapter', () => {
     }).toThrow('does not support filter type');
   });
 
-  test('builds cells query with uppercase aggregation names', () => {
+  test('builds cells query with normalized lowercase aggregation ids', () => {
     const queryModel = {
       getRowsAxis: () => ({ getItems: () => [{ columnName: 'symbol' }] }),
       getColumnsAxis: () => ({ getItems: () => [{ columnName: 'exchange' }] }),
@@ -132,6 +132,20 @@ describe('RemoteQueryAdapter', () => {
       'unique_list',
       'histogram'
     ]);
+  });
+
+  test('throws on unknown aggregator name', () => {
+    const queryModel = {
+      getRowsAxis: () => ({ getItems: () => [] }),
+      getColumnsAxis: () => ({ getItems: () => [] }),
+      getFiltersAxis: () => ({ getItems: () => [] }),
+    };
+
+    expect(() => {
+      RemoteQueryAdapter.createRemoteCellsQuery(queryModel, 1, 1, [
+        { columnName: 'volume', aggregator: 'some unknown aggregator' },
+      ]);
+    }).toThrow('does not support aggregator');
   });
 
   test('returns undefined when query model has no date range', () => {

--- a/tests/unit/remote-query-adapter.test.js
+++ b/tests/unit/remote-query-adapter.test.js
@@ -107,23 +107,31 @@ describe('RemoteQueryAdapter', () => {
       { columnName: 'volume', aggregator: 'avg' },
     ]);
 
-    expect(query.axes.measures[0].aggregation).toBe('SUM');
-    expect(query.axes.measures[1].aggregation).toBe('AVG');
+    expect(query.axes.measures[0].aggregation).toBe('sum');
+    expect(query.axes.measures[1].aggregation).toBe('avg');
     expect(query.axes.measures[0].alias).not.toBe(query.axes.measures[1].alias);
   });
 
-  test('throws for unsupported cell aggregator', () => {
+  test('maps extended aggregator names to API ids', () => {
     const queryModel = {
       getRowsAxis: () => ({ getItems: () => [] }),
       getColumnsAxis: () => ({ getItems: () => [] }),
       getFiltersAxis: () => ({ getItems: () => [] }),
     };
 
-    expect(() => {
-      RemoteQueryAdapter.createRemoteCellsQuery(queryModel, 1, 1, [
-        { columnName: 'volume', aggregator: 'distinct count' },
-      ]);
-    }).toThrow('does not support aggregator');
+    const query = RemoteQueryAdapter.createRemoteCellsQuery(queryModel, 1, 1, [
+      { columnName: 'volume', aggregator: 'distinct count' },
+      { columnName: 'flag', aggregator: 'count if true' },
+      { columnName: 'symbol', aggregator: 'unique values' },
+      { columnName: 'volume', aggregator: 'histogram' },
+    ]);
+
+    expect(query.axes.measures.map((measure) => measure.aggregation)).toEqual([
+      'distinct_count',
+      'count_if_true',
+      'unique_list',
+      'histogram'
+    ]);
   });
 
   test('returns undefined when query model has no date range', () => {


### PR DESCRIPTION
Fixes #413

## Summary
- expand cells/export aggregation support to the full backend set and validate type compatibility
- add `SORT_BY_REQUIRED` and `AGGREGATION_NOT_SUPPORTED` error handling for aggregation-specific failures
- translate current frontend aggregator labels to stable snake_case API ids in the remote adapter

## Validation
- `./.venv-server/bin/ruff check server/`
- `./.venv-server/bin/pytest server/tests -q`
- `./.venv-server/bin/pytest tests/test_backend_benchmark_runner.py -q`
- `npm run test:unit`
- `npm run lint:js`