### PR TITLE
Add backend derivation support

### DIFF
--- a/docs/server/api-reference.md
+++ b/docs/server/api-reference.md
@@ -234,7 +234,8 @@ Request body fields:
 - `fields` (array of objects):
   - `field` (string, required)
   - `sort` (`ASC` or `DESC`, optional)
-  - `derivation` (optional)
+  - `derivation` (optional; e.g. `year`, `uppercase`, `month_name`)
+  - `alias` (optional; defaults to `field__derivation` when `derivation` is set)
   - `include_totals` (optional)
 - `filters` (optional):
   - `field` (string)
@@ -281,6 +282,7 @@ Error statuses:
 - `404` `DATASET_NOT_FOUND`
 - `409` `DATASET_UNAVAILABLE`
 - `422` `VALIDATION_ERROR`
+- `422` `DERIVATION_NOT_SUPPORTED`
 - `401` auth failure when auth enabled
 - `429` if rate limiting enabled and exceeded
 
@@ -293,8 +295,8 @@ Authentication: conditional API key.
 Request body fields:
 
 - `date_range` (optional)
-- `axes.rows` (array of `{ "field": string }`)
-- `axes.columns` (array of `{ "field": string }`)
+- `axes.rows` (array of `{ "field": string, "derivation"?: string, "alias"?: string }`)
+- `axes.columns` (array of `{ "field": string, "derivation"?: string, "alias"?: string }`)
 - `axes.measures` (array):
   - `field` (string)
   - `aggregation`
@@ -357,6 +359,7 @@ Error statuses:
 - `404` `DATASET_NOT_FOUND`
 - `409` `DATASET_UNAVAILABLE`
 - `422` `VALIDATION_ERROR`
+- `422` `DERIVATION_NOT_SUPPORTED`
 - `422` `SORT_BY_REQUIRED`
 - `422` `AGGREGATION_NOT_SUPPORTED`
 - `401` auth failure when auth enabled
@@ -372,6 +375,8 @@ Request body fields:
 
 - `date_range` (optional)
 - `field` (string)
+- `derivation` (optional)
+- `alias` (optional; defaults to `field__derivation` when `derivation` is set)
 - `search` (string, optional; `*` is translated to SQL `%` wildcard)
 - `filters` (optional)
 - `paging` (optional)
@@ -408,6 +413,7 @@ Error statuses:
 - `404` `DATASET_NOT_FOUND`
 - `409` `DATASET_UNAVAILABLE`
 - `422` `VALIDATION_ERROR`
+- `422` `DERIVATION_NOT_SUPPORTED`
 - `401` auth failure when auth enabled
 - `429` if rate limiting enabled and exceeded
 

--- a/server/derivations.py
+++ b/server/derivations.py
@@ -1,0 +1,101 @@
+"""Backend derivation registry for v1 query endpoints."""
+
+from typing import Any
+
+from server.errors import DerivationNotSupportedError
+from server.utils import quote_identifier as _quote
+
+_STRING_TYPES = {"VARCHAR", "TEXT", "STRING", "JSON"}
+_DATE_TYPES = {"DATE"}
+
+_DERIVATIONS: dict[str, dict[str, Any]] = {
+    "year": {"template": "CAST(YEAR({expr}) AS INT)", "kinds": {"date", "timestamp"}},
+    "iso_year": {"template": "CAST(ISOYEAR({expr}) AS INT)", "kinds": {"date", "timestamp"}},
+    "quarter": {"template": "'Q' || QUARTER({expr})", "kinds": {"date", "timestamp"}},
+    "month_num": {"template": "CAST(MONTH({expr}) AS UTINYINT)", "kinds": {"date", "timestamp"}},
+    "month_name": {"template": "CAST(MONTH({expr}) AS UTINYINT)", "kinds": {"date", "timestamp"}},
+    "month_shortname": {"template": "CAST(MONTH({expr}) AS UTINYINT)", "kinds": {"date", "timestamp"}},
+    "week_num": {"template": "CAST(WEEK({expr}) AS UTINYINT)", "kinds": {"date", "timestamp"}},
+    "day_of_year": {"template": "CAST(DAYOFYEAR({expr}) AS USMALLINT)", "kinds": {"date", "timestamp"}},
+    "day_of_month": {"template": "CAST(DAYOFMONTH({expr}) AS UTINYINT)", "kinds": {"date", "timestamp"}},
+    "day_of_week_num": {"template": "CAST(DAYOFWEEK({expr}) AS UTINYINT)", "kinds": {"date", "timestamp"}},
+    "iso_day_of_week": {"template": "CAST(ISODOW({expr}) AS UTINYINT)", "kinds": {"date", "timestamp"}},
+    "day_of_week_name": {"template": "CAST(DAYOFWEEK({expr}) AS UTINYINT)", "kinds": {"date", "timestamp"}},
+    "day_of_week_shortname": {"template": "CAST(DAYOFWEEK({expr}) AS UTINYINT)", "kinds": {"date", "timestamp"}},
+    "local_date": {"template": "{expr}::DATE", "kinds": {"date", "timestamp"}},
+    "iso_date": {"template": "strftime({expr}, '%x')", "kinds": {"date", "timestamp"}},
+    "hour": {"template": "CAST(HOUR({expr}) AS UTINYINT)", "kinds": {"timestamp"}},
+    "minute": {"template": "CAST(MINUTE({expr}) AS UTINYINT)", "kinds": {"timestamp"}},
+    "second": {"template": "CAST(SECOND({expr}) AS UTINYINT)", "kinds": {"timestamp"}},
+    "iso_time": {"template": "strftime({expr}, '%H:%M:%S')", "kinds": {"timestamp"}},
+    "epoch_secs": {"template": "epoch({expr})", "kinds": {"timestamp"}},
+    "epoch_millis": {"template": "epoch_ms({expr})", "kinds": {"timestamp"}},
+    "epoch_micros": {"template": "epoch_us({expr})", "kinds": {"timestamp"}},
+    "epoch_nanos": {"template": "epoch_ns({expr})", "kinds": {"timestamp"}},
+    "uppercase": {"template": "UPPER({expr})", "kinds": {"string"}},
+    "lowercase": {"template": "LOWER({expr})", "kinds": {"string"}},
+    "first_letter": {"template": "upper({expr}[1])", "kinds": {"string"}},
+    "length": {"template": "length({expr})", "kinds": {"string"}},
+    "noaccent": {"template": "{expr} COLLATE NOACCENT", "kinds": {"string"}},
+    "nocase": {"template": "{expr} COLLATE NOCASE", "kinds": {"string"}},
+    "hash": {"template": "hash({expr})", "kinds": {"any"}},
+    "md5_hex": {"template": "md5({expr})", "kinds": {"string"}},
+    "sha256": {"template": "sha256({expr})", "kinds": {"string"}},
+}
+
+
+def _type_kind(type_name: str | None) -> set[str]:
+    normalized = str(type_name or "").upper()
+    kinds = {"any"}
+    if normalized in _DATE_TYPES:
+        kinds.add("date")
+    if normalized.startswith("TIMESTAMP"):
+        kinds.add("timestamp")
+    if normalized in _STRING_TYPES:
+        kinds.add("string")
+    return kinds
+
+
+def get_output_name(field: str, derivation: str | None, alias: str | None) -> str:
+    if alias:
+        return alias
+    if derivation:
+        return f"{field}__{derivation}"
+    return field
+
+
+def apply_derivation(
+    derivation: str,
+    column_expression: str,
+    field_name: str,
+    field_type: str | None,
+    loc: list[Any],
+) -> str:
+    info = _DERIVATIONS.get(derivation)
+    if info is None:
+        raise DerivationNotSupportedError(
+            [
+                {
+                    "loc": loc,
+                    "msg": f"Unknown derivation: {derivation}",
+                    "type": "derivation_not_supported",
+                    "ctx": {"derivation": derivation, "field": field_name},
+                }
+            ]
+        )
+    if not (_type_kind(field_type) & set(info["kinds"])):
+        raise DerivationNotSupportedError(
+            [
+                {
+                    "loc": loc,
+                    "msg": f"Derivation {derivation} is not supported for field type {field_type or 'unknown'}",
+                    "type": "derivation_not_supported",
+                    "ctx": {"derivation": derivation, "field": field_name, "field_type": field_type},
+                }
+            ]
+        )
+    return str(info["template"]).format(expr=column_expression)
+
+
+def quote_output_name(field: str, derivation: str | None, alias: str | None) -> str:
+    return _quote(get_output_name(field, derivation, alias))

--- a/server/errors.py
+++ b/server/errors.py
@@ -61,6 +61,18 @@ class AggregationNotSupportedError(AppError):
         )
 
 
+class DerivationNotSupportedError(AppError):
+    """Raised when a requested derivation is unknown or incompatible."""
+
+    def __init__(self, errors: list[dict[str, Any]]) -> None:
+        super().__init__(
+            code="DERIVATION_NOT_SUPPORTED",
+            message="Derivation is not supported for this request",
+            status_code=422,
+            details={"errors": errors},
+        )
+
+
 class DatasetNotFoundError(AppError):
     """Raised when a requested dataset_id is not registered in the service."""
 

--- a/server/main.py
+++ b/server/main.py
@@ -171,6 +171,7 @@ async def validation_error_handler(request: Request, exc: RequestValidationError
     has_filter_error = False
     has_sort_by_error = False
     has_aggregation_error = False
+    has_derivation_error = False
     for err in exc.errors():
         entry = {
             "loc": list(err.get("loc", [])),
@@ -183,6 +184,8 @@ async def validation_error_handler(request: Request, exc: RequestValidationError
             has_sort_by_error = True
         if entry["type"] == "aggregation_not_supported":
             has_aggregation_error = True
+        if entry["type"] == "derivation_not_supported":
+            has_derivation_error = True
         if "ctx" in err:
             entry["ctx"] = jsonable_encoder(err["ctx"])
         clean_errors.append(entry)
@@ -191,6 +194,9 @@ async def validation_error_handler(request: Request, exc: RequestValidationError
     if has_filter_error:
         code = "FILTER_INVALID"
         message = "Filter validation failed"
+    elif has_derivation_error:
+        code = "DERIVATION_NOT_SUPPORTED"
+        message = "Derivation is not supported for this request"
     elif has_sort_by_error:
         code = "SORT_BY_REQUIRED"
         message = "sort_by is required for this aggregation"

--- a/server/models.py
+++ b/server/models.py
@@ -182,9 +182,17 @@ class TupleFieldSpec(BaseModel):
     """Dimension or measure requested in tuple queries, with sort/totals flags."""
 
     field: str
-    derivation: str | None = None  # reserved: tech spec derivation support
+    derivation: str | None = None
+    alias: str | None = None
     sort: SortDirection | None = None
     include_totals: bool | None = None  # reserved: tech spec totals support
+
+    @field_validator("derivation", mode="before")
+    @classmethod
+    def normalize_derivation(cls, value: str | None) -> str | None:
+        if isinstance(value, str):
+            return value.lower()
+        return value
 
 
 class TupleFilter(BaseModel):
@@ -294,6 +302,15 @@ class AxisField(BaseModel):
     """A dimension field referenced in a cells or export query axis."""
 
     field: str
+    derivation: str | None = None
+    alias: str | None = None
+
+    @field_validator("derivation", mode="before")
+    @classmethod
+    def normalize_derivation(cls, value: str | None) -> str | None:
+        if isinstance(value, str):
+            return value.lower()
+        return value
 
 
 class MeasureSpec(BaseModel):
@@ -366,6 +383,8 @@ class PicklistQueryBody(BaseModel):
     """Body for /api/v1/datasets/{dataset_id}/query/picklist."""
 
     field: str | None = None
+    derivation: str | None = None
+    alias: str | None = None
     search: str | None = ""
     filters: list[TupleFilter] | None = None
     paging: PagingSpec | None = None
@@ -423,6 +442,8 @@ class QueryPicklistRequest(BaseModel):
 
     date_range: DateRange | None = None
     field: str | None = None
+    derivation: str | None = None
+    alias: str | None = None
     search: str | None = ""
     filters: list[TupleFilter] | None = None
     paging: PagingSpec | None = None

--- a/server/query_builder.py
+++ b/server/query_builder.py
@@ -9,6 +9,7 @@ placeholders.
 from typing import Any
 
 from server import datasets
+from server.derivations import apply_derivation, get_output_name, quote_output_name
 from server.errors import AggregationNotSupportedError, ValidationAppError
 from server.models import (
     AxesSpec,
@@ -272,6 +273,39 @@ def validate_picklist_query_fields(query: PicklistQueryBody, schema_fields: set[
     _raise_if_unknown(errors)
 
 
+def _build_dimension_selects(
+    dataset_id: str,
+    items: list[Any],
+    schema_fields: set[str],
+    loc_prefix: list[Any],
+) -> list[dict[str, str]]:
+    schema_field_types = _get_schema_field_types(dataset_id)
+    selects = []
+    for index, item in enumerate(items):
+        output_name = get_output_name(item.field, getattr(item, "derivation", None), getattr(item, "alias", None))
+        if getattr(item, "derivation", None):
+            expression = apply_derivation(
+                item.derivation,
+                _quote(item.field),
+                item.field,
+                schema_field_types.get(item.field),
+                [*loc_prefix, index, "derivation"],
+            )
+        else:
+            expression = _quote(item.field)
+        selects.append(
+            {
+                "field": item.field,
+                "expression": expression,
+                "output_name": output_name,
+                "select_sql": f"{expression} AS {quote_output_name(item.field, getattr(item, 'derivation', None), getattr(item, 'alias', None))}",
+                "column_sql": quote_output_name(item.field, getattr(item, "derivation", None), getattr(item, "alias", None)),
+                "sort": getattr(item, "sort", None),
+            }
+        )
+    return selects
+
+
 def validate_export_query_fields(
     dataset_id: str,
     query: ExportQueryBody,
@@ -363,9 +397,8 @@ def build_tuples_sql(
     if not fields:
         return f"SELECT 1 FROM {_quote(dataset_id)} WHERE FALSE", []
 
-    select_cols = []
-    for f in fields:
-        select_cols.append(_quote(f.field))
+    dimension_selects = _build_dimension_selects(dataset_id, list(fields), schema_fields, ["body", "fields"])
+    select_cols = [select["column_sql"] for select in dimension_selects]
     if not select_cols:
         return f"SELECT 1 FROM {_quote(dataset_id)} WHERE FALSE", []
 
@@ -378,7 +411,7 @@ def build_tuples_sql(
     params: list[Any] = list(base.params)
     table = base.from_sql
 
-    select_clause = ", ".join(select_cols)
+    projection_clause = ", ".join(select["select_sql"] for select in dimension_selects)
     where_parts = []
 
     if not base.handles_date and base.requires_time_filter:
@@ -390,12 +423,12 @@ def build_tuples_sql(
 
     where_clause = (" WHERE " + " AND ".join(where_parts)) if where_parts else ""
 
+    projected_from = f"(SELECT {projection_clause} FROM {table}{where_clause}) AS projected"
     group_clause = " GROUP BY " + ", ".join(select_cols)
 
     order_parts = []
-    for f in fields:
-        col = _quote(f.field)
-        order_parts.append(f"{col} {f.sort or 'ASC'}")
+    for select in dimension_selects:
+        order_parts.append(f"{select['column_sql']} {select['sort'] or 'ASC'}")
     order_clause = (" ORDER BY " + ", ".join(order_parts)) if order_parts else ""
 
     paging = query.paging
@@ -403,7 +436,8 @@ def build_tuples_sql(
     offset = paging.offset if paging else 0
     limit_clause = f" LIMIT {limit} OFFSET {offset}"
 
-    base_sql = f"SELECT {select_clause} FROM {table}{where_clause}{group_clause}"
+    select_clause = ", ".join(select_cols)
+    base_sql = f"SELECT {select_clause} FROM {projected_from}{group_clause}"
     sql_body = (
         f"SELECT {select_clause}, COUNT(*) OVER() AS __count__ "
         f"FROM ({base_sql}) AS grouped{order_clause}{limit_clause}"
@@ -421,7 +455,8 @@ def build_tuples_count_sql(
     """Generate a COUNT query for total_count in tuples response."""
     validate_tuples_query_fields(query, schema_fields)
     fields = query.fields or []
-    select_cols = [_quote(f.field) for f in fields]
+    dimension_selects = _build_dimension_selects(dataset_id, list(fields), schema_fields, ["body", "fields"])
+    select_cols = [select["column_sql"] for select in dimension_selects]
     if not select_cols:
         return "SELECT 0", []
 
@@ -444,7 +479,9 @@ def build_tuples_count_sql(
 
     where_clause = (" WHERE " + " AND ".join(where_parts)) if where_parts else ""
 
-    sql_body = f"SELECT COUNT(*) FROM (SELECT {group_expr} FROM {table}{where_clause} GROUP BY {group_expr})"
+    projection_clause = ", ".join(select["select_sql"] for select in dimension_selects)
+    projected_from = f"(SELECT {projection_clause} FROM {table}{where_clause}) AS projected"
+    sql_body = f"SELECT COUNT(*) FROM (SELECT {group_expr} FROM {projected_from} GROUP BY {group_expr})"
     sql = f"{base.cte_sql + ' ' if base.cte_sql else ''}{sql_body}"
     return sql, params
 
@@ -464,12 +501,14 @@ def build_cells_sql(
     validate_cells_query_fields(query, schema_fields)
     axes = query.axes
 
-    row_fields = [f.field for f in (axes.rows if axes else [])]
-    col_fields = [f.field for f in (axes.columns if axes else [])]
+    row_specs = _build_dimension_selects(dataset_id, list(axes.rows if axes else []), schema_fields, ["body", "axes", "rows"])
+    col_specs = _build_dimension_selects(dataset_id, list(axes.columns if axes else []), schema_fields, ["body", "axes", "columns"])
+    row_fields = [spec["output_name"] for spec in row_specs]
+    col_fields = [spec["output_name"] for spec in col_specs]
     measures = axes.measures if axes else []
     _validate_measure_specs(dataset_id, list(measures), schema_fields, ["body", "axes", "measures"])
 
-    dim_cols = [_quote(f) for f in row_fields + col_fields]
+    dim_cols = [spec["column_sql"] for spec in row_specs + col_specs]
     agg_exprs = []
     for m in measures:
         agg_exprs.append(_build_aggregation_expression(m))
@@ -477,9 +516,12 @@ def build_cells_sql(
     if not dim_cols and not agg_exprs:
         return f"SELECT 1 FROM {_quote(dataset_id)} WHERE FALSE", []
 
-    required_columns = set(row_fields + col_fields)
-    required_columns.update(m.field for m in measures)
-    required_columns.update(m.sort_by for m in measures if getattr(m, "sort_by", None))
+    if not dim_cols and not agg_exprs:
+        required_columns = set(schema_fields)
+    else:
+        required_columns = {spec["field"] for spec in row_specs + col_specs}
+        required_columns.update(m.field for m in measures)
+        required_columns.update(m.sort_by for m in measures if getattr(m, "sort_by", None))
     if query.filters:
         required_columns.update(f.field for f in query.filters)
     required_columns.update(required_relation_columns(dataset_id))
@@ -507,6 +549,16 @@ def build_cells_sql(
     # preserved and matches the params list.
     ctes: list[str] = []
     root_table = "base"
+    projection_columns = []
+    included_source_columns = set()
+    for source_field in required_columns:
+        if source_field and source_field not in included_source_columns:
+            projection_columns.append(_quote(source_field))
+            included_source_columns.add(source_field)
+    for spec in row_specs + col_specs:
+        if spec["output_name"] != spec["field"] or spec["expression"] != _quote(spec["field"]):
+            projection_columns.append(spec["select_sql"])
+
     if base.cte_sql:
         base_def = base.cte_sql.strip()
         if base_def.upper().startswith("WITH "):
@@ -520,12 +572,15 @@ def build_cells_sql(
         # No existing CTE; construct base from the underlying table directly.
         ctes.append(f"base AS (SELECT * FROM {table}{filters_where})")
 
+    ctes.append(f"projected_base AS (SELECT {', '.join(projection_columns)} FROM {root_table})")
+    root_table = "projected_base"
+
     row_window = query.rows
     row_cte_name = None
     if row_fields:
         row_cte_name = "row_window"
-        row_select_cols = ", ".join(_quote(f) for f in row_fields)
-        row_order = " ORDER BY " + ", ".join(_quote(f) for f in row_fields)
+        row_select_cols = ", ".join(spec["column_sql"] for spec in row_specs)
+        row_order = " ORDER BY " + ", ".join(spec["column_sql"] for spec in row_specs)
         row_limit = ""
         if row_window:
             limit_val = row_window.count
@@ -542,8 +597,8 @@ def build_cells_sql(
     col_cte_name = None
     if col_fields:
         col_cte_name = "col_window"
-        col_select_cols = ", ".join(_quote(f) for f in col_fields)
-        col_order = " ORDER BY " + ", ".join(_quote(f) for f in col_fields)
+        col_select_cols = ", ".join(spec["column_sql"] for spec in col_specs)
+        col_order = " ORDER BY " + ", ".join(spec["column_sql"] for spec in col_specs)
         col_limit = ""
         if col_window:
             limit_val = col_window.count
@@ -560,9 +615,9 @@ def build_cells_sql(
 
     joins = []
     if row_cte_name:
-        joins.append(f"INNER JOIN {row_cte_name} USING ({', '.join(_quote(f) for f in row_fields)})")
+        joins.append(f"INNER JOIN {row_cte_name} USING ({', '.join(spec['column_sql'] for spec in row_specs)})")
     if col_cte_name:
-        joins.append(f"INNER JOIN {col_cte_name} USING ({', '.join(_quote(f) for f in col_fields)})")
+        joins.append(f"INNER JOIN {col_cte_name} USING ({', '.join(spec['column_sql'] for spec in col_specs)})")
 
     from_clause = f" FROM {root_table} " + " ".join(joins)
 
@@ -589,7 +644,9 @@ def build_picklist_sql(
     if not field:
         return f"SELECT 1 FROM {_quote(dataset_id)} WHERE FALSE", []
 
-    col = _quote(field)
+    field_spec = type("PicklistFieldSpec", (), {"field": field, "derivation": query.derivation, "alias": query.alias})()
+    select_spec = _build_dimension_selects(dataset_id, [field_spec], schema_fields, ["body"])[0]
+    output_col = select_spec["column_sql"]
     required_columns = {field}
     required_columns.update(required_relation_columns(dataset_id))
     if query.filters:
@@ -598,28 +655,36 @@ def build_picklist_sql(
     base = build_base_relation(dataset_id, date_range, required_columns)
     params: list[Any] = list(base.params)
     table = base.from_sql
-    where_parts = []
+    base_where_parts = []
 
     if not base.handles_date and base.requires_time_filter:
         date_clause = _build_date_clause(date_range, params)
         if date_clause:
-            where_parts.append(date_clause)
+            base_where_parts.append(date_clause)
 
+    base_where_parts.extend(_build_filter_clauses(query.filters, params, schema_fields))
+    base_where_clause = (" WHERE " + " AND ".join(base_where_parts)) if base_where_parts else ""
+
+    projection_columns = [_quote(source_field) for source_field in sorted(required_columns)]
+    if select_spec["output_name"] != field or select_spec["expression"] != _quote(field):
+        projection_columns.append(select_spec["select_sql"])
+
+    projected_from = f"(SELECT {', '.join(projection_columns)} FROM {table}{base_where_clause}) AS projected"
+
+    search_where_parts = []
     if query.search:
         search_val = query.search.replace("*", "%")
-        where_parts.append(f"{col} LIKE ?")
+        search_where_parts.append(f"{output_col} LIKE ?")
         params.append(search_val)
-
-    where_parts.extend(_build_filter_clauses(query.filters, params, schema_fields))
-    where_clause = (" WHERE " + " AND ".join(where_parts)) if where_parts else ""
+    where_clause = (" WHERE " + " AND ".join(search_where_parts)) if search_where_parts else ""
 
     paging = query.paging
     limit = paging.limit if paging else 100
     offset = paging.offset if paging else 0
 
     base_sql = (
-        f"SELECT {col} AS value, COUNT(*) AS value_count "
-        f"FROM {table}{where_clause} GROUP BY {col}"
+        f"SELECT {output_col} AS value, COUNT(*) AS value_count "
+        f"FROM {projected_from}{where_clause} GROUP BY {output_col}"
     )
     sql_body = (
         f"SELECT value, value_count, COUNT(*) OVER() AS __count__ "
@@ -641,7 +706,9 @@ def build_picklist_count_sql(
     if not field:
         return "SELECT 0", []
 
-    col = _quote(field)
+    field_spec = type("PicklistFieldSpec", (), {"field": field, "derivation": query.derivation, "alias": query.alias})()
+    select_spec = _build_dimension_selects(dataset_id, [field_spec], schema_fields, ["body"])[0]
+    output_col = select_spec["column_sql"]
     required_columns = {field}
     required_columns.update(required_relation_columns(dataset_id))
     if query.filters:
@@ -650,22 +717,31 @@ def build_picklist_count_sql(
     base = build_base_relation(dataset_id, date_range, required_columns)
     params: list[Any] = list(base.params)
     table = base.from_sql
-    where_parts = []
+    base_where_parts = []
 
     if not base.handles_date and base.requires_time_filter:
         date_clause = _build_date_clause(date_range, params)
         if date_clause:
-            where_parts.append(date_clause)
+            base_where_parts.append(date_clause)
+
+    base_where_parts.extend(_build_filter_clauses(query.filters, params, schema_fields))
+    base_where_clause = (" WHERE " + " AND ".join(base_where_parts)) if base_where_parts else ""
+
+    projection_columns = [_quote(source_field) for source_field in sorted(required_columns)]
+    if select_spec["output_name"] != field or select_spec["expression"] != _quote(field):
+        projection_columns.append(select_spec["select_sql"])
+
+    projected_from = f"(SELECT {', '.join(projection_columns)} FROM {table}{base_where_clause}) AS projected"
+
+    search_where_parts = []
 
     if query.search:
         search_val = query.search.replace("*", "%")
-        where_parts.append(f"{col} LIKE ?")
+        search_where_parts.append(f"{output_col} LIKE ?")
         params.append(search_val)
+    where_clause = (" WHERE " + " AND ".join(search_where_parts)) if search_where_parts else ""
 
-    where_parts.extend(_build_filter_clauses(query.filters, params, schema_fields))
-    where_clause = (" WHERE " + " AND ".join(where_parts)) if where_parts else ""
-
-    sql_body = f"SELECT COUNT(DISTINCT {col}) FROM {table}{where_clause}"
+    sql_body = f"SELECT COUNT(DISTINCT {output_col}) FROM {projected_from}{where_clause}"
     sql = f"{base.cte_sql + ' ' if base.cte_sql else ''}{sql_body}"
     return sql, params
 
@@ -686,12 +762,12 @@ def build_export_sql(
     axes = query.axes
     max_rows = query.max_rows
 
-    row_fields = [f.field for f in (axes.rows if axes else [])]
-    col_fields = [f.field for f in (axes.columns if axes else [])]
+    row_specs = _build_dimension_selects(dataset_id, list(axes.rows if axes else []), schema_fields, ["body", "query", "axes", "rows"])
+    col_specs = _build_dimension_selects(dataset_id, list(axes.columns if axes else []), schema_fields, ["body", "query", "axes", "columns"])
     measures = axes.measures if axes else []
 
-    dim_cols = [_quote(f) for f in row_fields + col_fields]
-    dim_headers = row_fields + col_fields
+    dim_cols = [spec["column_sql"] for spec in row_specs + col_specs]
+    dim_headers = [spec["output_name"] for spec in row_specs + col_specs]
     agg_exprs = []
     agg_headers: list[str] = []
     for m in measures:
@@ -699,9 +775,12 @@ def build_export_sql(
         agg_exprs.append(_build_aggregation_expression(m))
         agg_headers.append(alias)
 
-    required_columns = set(row_fields + col_fields)
-    required_columns.update(m.field for m in measures)
-    required_columns.update(m.sort_by for m in measures if getattr(m, "sort_by", None))
+    if not dim_cols and not agg_exprs:
+        required_columns = set(schema_fields)
+    else:
+        required_columns = {spec["field"] for spec in row_specs + col_specs}
+        required_columns.update(m.field for m in measures)
+        required_columns.update(m.sort_by for m in measures if getattr(m, "sort_by", None))
     if query.filters:
         required_columns.update(f.field for f in query.filters)
     required_columns.update(required_relation_columns(dataset_id))
@@ -709,6 +788,22 @@ def build_export_sql(
     base = build_base_relation(dataset_id, date_range, required_columns)
     params: list[Any] = list(base.params)
     table = base.from_sql
+
+    where_parts = []
+    if not base.handles_date and base.requires_time_filter:
+        date_clause = _build_date_clause(date_range, params)
+        if date_clause:
+            where_parts.append(date_clause)
+    where_parts.extend(_build_filter_clauses(query.filters, params, schema_fields))
+    where_clause = (" WHERE " + " AND ".join(where_parts)) if where_parts else ""
+
+    projection_source_fields = sorted(schema_fields) if not dim_cols and not agg_exprs else sorted(required_columns)
+    projection_columns = [_quote(source_field) for source_field in projection_source_fields]
+    for spec in row_specs + col_specs:
+        if spec["output_name"] != spec["field"] or spec["expression"] != _quote(spec["field"]):
+            projection_columns.append(spec["select_sql"])
+
+    projected_from = f"(SELECT {', '.join(projection_columns)} FROM {table}{where_clause}) AS projected"
 
     if not dim_cols and not agg_exprs:
         all_fields = sorted(schema_fields)
@@ -718,14 +813,6 @@ def build_export_sql(
         select_parts = dim_cols + agg_exprs
         select_clause = ", ".join(select_parts)
         headers = dim_headers + agg_headers
-
-    where_parts = []
-    if not base.handles_date and base.requires_time_filter:
-        date_clause = _build_date_clause(date_range, params)
-        if date_clause:
-            where_parts.append(date_clause)
-    where_parts.extend(_build_filter_clauses(query.filters, params, schema_fields))
-    where_clause = (" WHERE " + " AND ".join(where_parts)) if where_parts else ""
 
     group_clause = ""
     if dim_cols and agg_exprs:
@@ -737,6 +824,6 @@ def build_export_sql(
 
     limit_clause = f" LIMIT {max_rows}"
 
-    sql_body = f"SELECT {select_clause} FROM {table}{where_clause}{group_clause}{order_clause}{limit_clause}"
+    sql_body = f"SELECT {select_clause} FROM {projected_from}{group_clause}{order_clause}{limit_clause}"
     sql = f"{base.cte_sql + ' ' if base.cte_sql else ''}{sql_body}"
     return sql, params, headers

--- a/server/routers/query.py
+++ b/server/routers/query.py
@@ -11,6 +11,7 @@ from server import datasets
 from server.auth import require_api_key
 from server.cache import build_cache_key, get_query_cache
 from server.config import get_settings
+from server.derivations import get_output_name
 from server.engine import QueryCancelHandle, db_manager
 from server.errors import (
     CellsWindowTooLargeError,
@@ -135,7 +136,7 @@ def _validate_cells_measure_aliases(measures) -> None:
 async def _fetch_axis_window(
     request: Request,
     dataset_id: str,
-    field_names: list[str],
+    axis_items: list[object],
     filters,
     date_range,
     schema_fields: set[str],
@@ -143,6 +144,10 @@ async def _fetch_axis_window(
     offset: int | None,
     cancel_handle: QueryCancelHandle | None = None,
 ) -> tuple[list[dict[str, object]], int]:
+    field_names = [
+        get_output_name(item.field, getattr(item, "derivation", None), getattr(item, "alias", None))
+        for item in axis_items
+    ]
     if not field_names:
         total = 1
         if offset and offset > 0:
@@ -152,7 +157,15 @@ async def _fetch_axis_window(
         return [{}], total
 
     query = TuplesQueryBody(
-        fields=[{"field": field_name, "sort": "ASC"} for field_name in field_names],
+        fields=[
+            {
+                "field": item.field,
+                "derivation": getattr(item, "derivation", None),
+                "alias": getattr(item, "alias", None),
+                "sort": "ASC",
+            }
+            for item in axis_items
+        ],
         filters=filters,
         paging=PagingSpec(limit=limit or get_settings().tuples_default_limit, offset=offset or 0),
     )
@@ -189,7 +202,7 @@ async def _fetch_axis_window(
     return members, total
 
 
-@router.post("/tuples", response_model=TuplesResponse)
+@router.post("/tuples", response_model=TuplesResponse, response_model_exclude_none=True)
 @limiter.limit(lambda: get_settings().rate_limit_query)
 async def post_query_tuples(
     request: Request,
@@ -231,7 +244,10 @@ async def post_query_tuples(
             )
 
         rows, queue_wait_ms, execution_ms = await _execute_with_budget(request, _run_query, cancel_fn=cancel_handle.cancel)
-        field_names = [field.field for field in (query.fields or [])]
+        field_names = [
+            get_output_name(field.field, getattr(field, "derivation", None), getattr(field, "alias", None))
+            for field in (query.fields or [])
+        ]
         if rows:
             total_count = int(rows[0][-1])
             items = [
@@ -387,8 +403,10 @@ async def post_query_cells(
         start = time.perf_counter()
         effective_max = settings.max_cells_per_response
         axes = query.axes or CellsQueryBody().axes
-        row_fields = [item.field for item in (axes.rows if axes else [])]
-        col_fields = [item.field for item in (axes.columns if axes else [])]
+        row_items = list(axes.rows if axes else [])
+        col_items = list(axes.columns if axes else [])
+        row_fields = [get_output_name(item.field, item.derivation, item.alias) for item in row_items]
+        col_fields = [get_output_name(item.field, item.derivation, item.alias) for item in col_items]
         measures = list(axes.measures if axes else [])
         row_window_limit = body.window.rows.limit if body.window and body.window.rows else effective_max
         row_window_offset = body.window.rows.offset if body.window and body.window.rows else 0
@@ -398,7 +416,7 @@ async def post_query_cells(
         rows_payload, row_total = await _fetch_axis_window(
             request,
             dataset_id,
-            row_fields,
+            row_items,
             body.filters,
             body.date_range,
             schema_fields,
@@ -409,7 +427,7 @@ async def post_query_cells(
         columns_payload, col_total = await _fetch_axis_window(
             request,
             dataset_id,
-            col_fields,
+            col_items,
             body.filters,
             body.date_range,
             schema_fields,
@@ -579,6 +597,8 @@ async def post_query_members(
 
     query = PicklistQueryBody(
         field=body.field,
+        derivation=body.derivation,
+        alias=body.alias,
         search=body.search,
         filters=body.filters,
         paging=body.paging,
@@ -628,7 +648,7 @@ async def post_query_members(
         duration_ms = (time.perf_counter() - start) * 1000
         return {
             "response": {
-                "field": query.field,
+                "field": get_output_name(query.field, query.derivation, query.alias) if query.field else None,
                 "total_count": total_count,
                 "items": items,
                 "paging": {"limit": paging.limit, "offset": paging.offset, "returned": len(items)},

--- a/server/tests/test_derivations.py
+++ b/server/tests/test_derivations.py
@@ -1,0 +1,44 @@
+"""Tests for backend derivation registry and helpers."""
+
+import pytest
+
+from server.derivations import apply_derivation, get_output_name
+from server.errors import DerivationNotSupportedError
+
+
+def test_get_output_name_defaults_to_field() -> None:
+    assert get_output_name("symbol", None, None) == "symbol"
+
+
+def test_get_output_name_uses_derivation_suffix() -> None:
+    assert get_output_name("date", "year", None) == "date__year"
+
+
+def test_get_output_name_prefers_alias() -> None:
+    assert get_output_name("date", "year", "trade_year") == "trade_year"
+
+
+@pytest.mark.parametrize(
+    ("derivation", "field_type", "fragment"),
+    [
+        ("year", "date", "YEAR"),
+        ("month_name", "timestamp", "MONTH"),
+        ("uppercase", "string", "UPPER"),
+        ("first_letter", "string", "upper"),
+        ("hash", "string", "hash"),
+        ("sha256", "string", "sha256"),
+    ],
+)
+def test_apply_derivation_supported(derivation: str, field_type: str, fragment: str) -> None:
+    expression = apply_derivation(derivation, '"value"', "value", field_type, ["body", "field"])
+    assert fragment in expression
+
+
+def test_apply_derivation_unknown_raises() -> None:
+    with pytest.raises(DerivationNotSupportedError):
+        apply_derivation("not_real", '"value"', "value", "string", ["body", "field"])
+
+
+def test_apply_derivation_type_mismatch_raises() -> None:
+    with pytest.raises(DerivationNotSupportedError):
+        apply_derivation("year", '"symbol"', "symbol", "string", ["body", "field"])

--- a/server/tests/test_query_builder.py
+++ b/server/tests/test_query_builder.py
@@ -159,6 +159,24 @@ class TestBuildTuplesSql:
         assert '"date" =' not in sql
         assert params == ["s3://bucket/data/*.parquet"]
 
+    def test_derivation_uses_derived_expression_and_alias(self) -> None:
+        query = TuplesQueryBody(
+            fields=[TupleFieldSpec(field="date", derivation="year")],
+            paging=PagingSpec(limit=10, offset=0),
+        )
+        sql, _ = build_tuples_sql("trades_v1", query, DR_SINGLE, SCHEMA_FIELDS)
+        assert 'CAST(YEAR("date") AS INT) AS "date__year"' in sql
+        assert 'GROUP BY "date__year"' in sql
+
+    def test_derivation_alias_override(self) -> None:
+        query = TuplesQueryBody(
+            fields=[TupleFieldSpec(field="date", derivation="year", alias="trade_year")],
+            paging=PagingSpec(limit=10, offset=0),
+        )
+        sql, _ = build_tuples_sql("trades_v1", query, DR_SINGLE, SCHEMA_FIELDS)
+        assert 'AS "trade_year"' in sql
+        assert 'GROUP BY "trade_year"' in sql
+
 
 class TestBuildTuplesCountSql:
     def test_count_query(self) -> None:
@@ -396,6 +414,12 @@ class TestBuildPicklistSql:
         sql, params = build_picklist_sql("trades_v1", query, DR_SINGLE, SCHEMA_FIELDS)
         assert "NOT IN" in sql
         assert "TSLA" in params
+
+    def test_derivation_uses_derived_value(self) -> None:
+        query = PicklistQueryBody(field="symbol", derivation="uppercase", paging=PagingSpec(limit=100, offset=0))
+        sql, _ = build_picklist_sql("trades_v1", query, DR_SINGLE, SCHEMA_FIELDS)
+        assert 'UPPER("symbol") AS "symbol__uppercase"' in sql
+        assert 'SELECT "symbol__uppercase" AS value' in sql
 
     @pytest.mark.parametrize(
         ("operator", "values", "sql_fragment"),

--- a/server/tests/test_query_cells_api.py
+++ b/server/tests/test_query_cells_api.py
@@ -82,6 +82,37 @@ def test_query_cells_extended_aggregations(client: TestClient) -> None:
     assert "last_symbol" in cell
 
 
+def test_query_cells_row_derivation_default_alias(client: TestClient) -> None:
+    body = {
+        "date_range": {"type": "range", "start": "2026-03-01", "end": "2026-03-02"},
+        "axes": {
+            "rows": [{"field": "date", "derivation": "year"}],
+            "columns": [],
+            "measures": [{"field": "volume", "aggregation": "sum", "alias": "sum_volume"}],
+        },
+    }
+    r = client.post("/api/v1/datasets/trades_v1/query/cells", json=body)
+    assert r.status_code == 200
+    data = r.json()
+    assert data["rows"] == [{"date__year": 2026}]
+    assert data["cells"][0]["sum_volume"] > 0
+
+
+def test_query_cells_derivation_alias_override(client: TestClient) -> None:
+    body = {
+        "date_range": {"type": "range", "start": "2026-03-01", "end": "2026-03-02"},
+        "axes": {
+            "rows": [{"field": "date", "derivation": "year", "alias": "trade_year"}],
+            "columns": [],
+            "measures": [{"field": "volume", "aggregation": "sum", "alias": "sum_volume"}],
+        },
+    }
+    r = client.post("/api/v1/datasets/trades_v1/query/cells", json=body)
+    assert r.status_code == 200
+    data = r.json()
+    assert data["rows"] == [{"trade_year": 2026}]
+
+
 def test_query_cells_with_filter(client: TestClient) -> None:
     dataset_id = "trades_v1"
     body = {

--- a/server/tests/test_query_picklist_api.py
+++ b/server/tests/test_query_picklist_api.py
@@ -43,6 +43,33 @@ def test_query_members_search_wildcard(client: TestClient) -> None:
     assert "AMZN" in values
 
 
+def test_query_members_string_derivation_default_alias(client: TestClient) -> None:
+    body = {
+        "date_range": {"type": "single", "date": "2026-03-01"},
+        "field": "symbol",
+        "derivation": "uppercase",
+        "paging": {"limit": 100, "offset": 0},
+    }
+    r = client.post("/api/v1/datasets/trades_v1/query/members", json=body)
+    assert r.status_code == 200
+    data = r.json()
+    assert data["field"] == "symbol__uppercase"
+    assert "AAPL" in [item["value"] for item in data["items"]]
+
+
+def test_query_members_derivation_alias_override(client: TestClient) -> None:
+    body = {
+        "date_range": {"type": "single", "date": "2026-03-01"},
+        "field": "symbol",
+        "derivation": "uppercase",
+        "alias": "symbol_upper",
+        "paging": {"limit": 100, "offset": 0},
+    }
+    r = client.post("/api/v1/datasets/trades_v1/query/members", json=body)
+    assert r.status_code == 200
+    assert r.json()["field"] == "symbol_upper"
+
+
 def test_query_members_with_filter(client: TestClient) -> None:
     dataset_id = "trades_v1"
     body = {

--- a/server/tests/test_query_tuples_api.py
+++ b/server/tests/test_query_tuples_api.py
@@ -98,6 +98,30 @@ def test_query_tuples_date_range(client: TestClient) -> None:
     assert data["total_count"] == 5
 
 
+def test_query_tuples_date_derivation_default_alias(client: TestClient) -> None:
+    body = {
+        "date_range": {"type": "range", "start": "2026-03-01", "end": "2026-03-02"},
+        "fields": [{"field": "date", "derivation": "year"}],
+        "paging": {"limit": 10, "offset": 0},
+    }
+    r = client.post("/api/v1/datasets/trades_v1/query/tuples", json=body)
+    assert r.status_code == 200
+    data = r.json()
+    assert data["items"] == [{"date__year": 2026}]
+
+
+def test_query_tuples_derivation_alias_override(client: TestClient) -> None:
+    body = {
+        "date_range": {"type": "range", "start": "2026-03-01", "end": "2026-03-02"},
+        "fields": [{"field": "date", "derivation": "year", "alias": "trade_year"}],
+        "paging": {"limit": 10, "offset": 0},
+    }
+    r = client.post("/api/v1/datasets/trades_v1/query/tuples", json=body)
+    assert r.status_code == 200
+    data = r.json()
+    assert data["items"] == [{"trade_year": 2026}]
+
+
 def test_query_tuples_paging(client: TestClient) -> None:
     dataset_id = "trades_v1"
     body = {

--- a/server/tests/test_validation_errors.py
+++ b/server/tests/test_validation_errors.py
@@ -165,6 +165,20 @@ class TestTuplesValidation:
         assert r.status_code == 422
         assert r.json()["code"] == "FILTER_INVALID"
 
+    def test_unknown_tuple_derivation_returns_derivation_not_supported(self, client: TestClient) -> None:
+        body = _valid_body_for("tuples")
+        body["fields"] = [{"field": "date", "derivation": "not_real"}]
+        r = client.post(_post_path("tuples"), json=body)
+        assert r.status_code == 422
+        assert r.json()["code"] == "DERIVATION_NOT_SUPPORTED"
+
+    def test_type_incompatible_tuple_derivation_returns_derivation_not_supported(self, client: TestClient) -> None:
+        body = _valid_body_for("tuples")
+        body["fields"] = [{"field": "symbol", "derivation": "year"}]
+        r = client.post(_post_path("tuples"), json=body)
+        assert r.status_code == 422
+        assert r.json()["code"] == "DERIVATION_NOT_SUPPORTED"
+
 
 class TestCellsValidation:
     def test_missing_axes_rejected(self, client: TestClient) -> None:
@@ -217,6 +231,20 @@ class TestCellsValidation:
         assert r.status_code == 422
         assert r.json()["code"] == "VALIDATION_ERROR"
 
+    def test_unknown_cells_derivation_returns_derivation_not_supported(self, client: TestClient) -> None:
+        body = _valid_body_for("cells")
+        body["axes"]["rows"] = [{"field": "date", "derivation": "not_real"}]
+        r = client.post(_post_path("cells"), json=body)
+        assert r.status_code == 422
+        assert r.json()["code"] == "DERIVATION_NOT_SUPPORTED"
+
+    def test_type_incompatible_cells_derivation_returns_derivation_not_supported(self, client: TestClient) -> None:
+        body = _valid_body_for("cells")
+        body["axes"]["rows"] = [{"field": "symbol", "derivation": "year"}]
+        r = client.post(_post_path("cells"), json=body)
+        assert r.status_code == 422
+        assert r.json()["code"] == "DERIVATION_NOT_SUPPORTED"
+
 
 class TestMembersValidation:
     def test_unknown_members_field_rejected(self, client: TestClient) -> None:
@@ -231,6 +259,21 @@ class TestMembersValidation:
         body["paging"] = {"limit": 10, "offset": -1}
         r = client.post(_post_path("members"), json=body)
         assert r.status_code == 422
+
+    def test_unknown_members_derivation_returns_derivation_not_supported(self, client: TestClient) -> None:
+        body = _valid_body_for("members")
+        body["derivation"] = "not_real"
+        r = client.post(_post_path("members"), json=body)
+        assert r.status_code == 422
+        assert r.json()["code"] == "DERIVATION_NOT_SUPPORTED"
+
+    def test_type_incompatible_members_derivation_returns_derivation_not_supported(self, client: TestClient) -> None:
+        body = _valid_body_for("members")
+        body["field"] = "symbol"
+        body["derivation"] = "year"
+        r = client.post(_post_path("members"), json=body)
+        assert r.status_code == 422
+        assert r.json()["code"] == "DERIVATION_NOT_SUPPORTED"
 
 
 class TestExportValidation:

--- a/src/DataSet/TupleSet.js
+++ b/src/DataSet/TupleSet.js
@@ -473,10 +473,10 @@ export class TupleSet extends DataSetComponent {
     if (hasGroupingId) fields.push({ name: TupleSet.groupingIdAlias });
     axisItems.forEach((item) => {
       const typeId = TupleSet.#columnTypeToArrowTypeId(item.columnType);
-      fields.push({ name: item.columnName, type: { typeId: typeId } });
+      fields.push({ name: RemoteQueryAdapter.getRemoteOutputName(item), type: { typeId: typeId } });
     });
     if (includeCountAll) fields.push({ name: '__huey_count' });
-    const fieldNames = axisItems.map((item) => { return item.columnName; });
+    const fieldNames = axisItems.map((item) => { return RemoteQueryAdapter.getRemoteOutputName(item); });
     const numRows = items.length;
     const get = (function(items, fieldNames, totalCount, includeCountAll, hasGroupingId) {
       return function(i) {

--- a/src/DataSource/remote/RemoteQueryAdapter.js
+++ b/src/DataSource/remote/RemoteQueryAdapter.js
@@ -33,6 +33,42 @@ export class RemoteQueryAdapter {
     histogram: 'histogram'
   };
 
+  static #DERIVATION_BY_NAME = {
+    year: 'year',
+    'iso-year': 'iso_year',
+    quarter: 'quarter',
+    'month num': 'month_num',
+    'month name': 'month_name',
+    'month shortname': 'month_shortname',
+    'week num': 'week_num',
+    'day of year': 'day_of_year',
+    'day of month': 'day_of_month',
+    'day of week num': 'day_of_week_num',
+    'iso-day of week': 'iso_day_of_week',
+    'day of week name': 'day_of_week_name',
+    'day of week shortname': 'day_of_week_shortname',
+    'local-date': 'local_date',
+    'iso-date': 'iso_date',
+    hour: 'hour',
+    minute: 'minute',
+    second: 'second',
+    'iso-time': 'iso_time',
+    'timestamp (secs)': 'epoch_secs',
+    'timestamp (millis)': 'epoch_millis',
+    'timestamp (micros)': 'epoch_micros',
+    'timestamp (nanos)': 'epoch_nanos',
+    uppercase: 'uppercase',
+    lowercase: 'lowercase',
+    'first letter': 'first_letter',
+    length: 'length',
+    noaccent: 'noaccent',
+    nocase: 'nocase',
+    hash: 'hash',
+    'md5 (hex)': 'md5_hex',
+    sha256: 'sha256',
+    'sha-256': 'sha256',
+  };
+
   static getDateRange(queryModel) {
     if (queryModel && typeof queryModel.getDateRange === 'function') {
       const queryModelDateRange = queryModel.getDateRange();
@@ -47,10 +83,31 @@ export class RemoteQueryAdapter {
     if (!axisItem || typeof axisItem.columnName !== 'string' || !axisItem.columnName.length) {
       throw new Error('Remote datasource requires a valid columnName for ' + context + '.');
     }
-    if (axisItem.derivation) {
-      throw new Error('Remote datasource does not support derivation "' + axisItem.derivation + '" in ' + context + '.');
-    }
     return axisItem.columnName;
+  }
+
+  static #getRemoteDerivation(axisItem, context) {
+    if (!axisItem || !axisItem.derivation) {
+      return undefined;
+    }
+    const normalizedDerivation = String(axisItem.derivation).toLowerCase();
+    const derivation = RemoteQueryAdapter.#DERIVATION_BY_NAME[normalizedDerivation];
+    if (!derivation) {
+      throw new Error('Remote datasource does not support derivation "' + normalizedDerivation + '" in ' + context + '.');
+    }
+    return derivation;
+  }
+
+  static #getRemoteAlias(axisItem) {
+    if (!axisItem || !axisItem.derivation) {
+      return undefined;
+    }
+    const derivation = RemoteQueryAdapter.#getRemoteDerivation(axisItem, 'query');
+    return `${axisItem.columnName}__${derivation}`;
+  }
+
+  static getRemoteOutputName(axisItem) {
+    return RemoteQueryAdapter.#getRemoteAlias(axisItem) || axisItem.columnName;
   }
 
   static #normalizeLiteralToValue(literal) {
@@ -191,6 +248,8 @@ export class RemoteQueryAdapter {
     const fields = axisItems.map((item) => {
       return {
         field: RemoteQueryAdapter.#getRemoteFieldForAxisItem(item, 'tuples'),
+        derivation: RemoteQueryAdapter.#getRemoteDerivation(item, 'tuples'),
+        alias: RemoteQueryAdapter.#getRemoteAlias(item),
         sort: 'ASC',
         include_totals: item.includeTotals !== false
       };
@@ -217,10 +276,18 @@ export class RemoteQueryAdapter {
       },
       axes: {
         rows: rowsAxisItems.map((item) => {
-          return { field: RemoteQueryAdapter.#getRemoteFieldForAxisItem(item, 'cells rows') };
+          return {
+            field: RemoteQueryAdapter.#getRemoteFieldForAxisItem(item, 'cells rows'),
+            derivation: RemoteQueryAdapter.#getRemoteDerivation(item, 'cells rows'),
+            alias: RemoteQueryAdapter.#getRemoteAlias(item)
+          };
         }),
         columns: columnsAxisItems.map((item) => {
-          return { field: RemoteQueryAdapter.#getRemoteFieldForAxisItem(item, 'cells columns') };
+          return {
+            field: RemoteQueryAdapter.#getRemoteFieldForAxisItem(item, 'cells columns'),
+            derivation: RemoteQueryAdapter.#getRemoteDerivation(item, 'cells columns'),
+            alias: RemoteQueryAdapter.#getRemoteAlias(item)
+          };
         }),
         measures: (cellsAxisItemsToFetch || []).map((item, index) => {
           const field = RemoteQueryAdapter.#getRemoteFieldForAxisItem(item, 'cells measures');
@@ -238,6 +305,8 @@ export class RemoteQueryAdapter {
   static createRemotePicklistQuery(queryAxisItem, filterAxisItems, search, limit, offset) {
     return {
       field: RemoteQueryAdapter.#getRemoteFieldForAxisItem(queryAxisItem, 'picklist'),
+      derivation: RemoteQueryAdapter.#getRemoteDerivation(queryAxisItem, 'picklist'),
+      alias: RemoteQueryAdapter.#getRemoteAlias(queryAxisItem),
       search: search || undefined,
       filters: RemoteQueryAdapter.toRemoteFilters(filterAxisItems, 'picklist'),
       paging: { limit: limit, offset: offset }

--- a/tests/unit/remote-query-adapter.test.js
+++ b/tests/unit/remote-query-adapter.test.js
@@ -148,6 +148,48 @@ describe('RemoteQueryAdapter', () => {
     }).toThrow('does not support aggregator');
   });
 
+  test('maps derivation labels to API ids and aliases', () => {
+    const queryModel = {
+      getQueryAxis: () => ({
+        getItems: () => [{ columnName: 'date', derivation: 'month name' }],
+      }),
+      getRowsAxis: () => ({ getItems: () => [{ columnName: 'date', derivation: 'year' }] }),
+      getColumnsAxis: () => ({ getItems: () => [{ columnName: 'symbol', derivation: 'uppercase' }] }),
+      getFiltersAxis: () => ({ getItems: () => [] }),
+    };
+
+    const tuplesQuery = RemoteQueryAdapter.createRemoteTuplesQuery(queryModel, 'rows', 10, 0);
+    const cellsQuery = RemoteQueryAdapter.createRemoteCellsQuery(queryModel, 10, 10, []);
+    const picklistQuery = RemoteQueryAdapter.createRemotePicklistQuery(
+      { columnName: 'symbol', derivation: 'uppercase' },
+      [],
+      undefined,
+      10,
+      0
+    );
+
+    expect(tuplesQuery.fields[0]).toMatchObject({
+      field: 'date',
+      derivation: 'month_name',
+      alias: 'date__month_name',
+    });
+    expect(cellsQuery.axes.rows[0]).toMatchObject({
+      field: 'date',
+      derivation: 'year',
+      alias: 'date__year',
+    });
+    expect(cellsQuery.axes.columns[0]).toMatchObject({
+      field: 'symbol',
+      derivation: 'uppercase',
+      alias: 'symbol__uppercase',
+    });
+    expect(picklistQuery).toMatchObject({
+      field: 'symbol',
+      derivation: 'uppercase',
+      alias: 'symbol__uppercase',
+    });
+  });
+
   test('returns undefined when query model has no date range', () => {
     const dateRange = RemoteQueryAdapter.getDateRange({});
     expect(dateRange).toBeUndefined();


### PR DESCRIPTION
Fixes #414

## Summary
- add backend derivation registry and derivation-aware tuples/cells/members query building
- return derived output names using default `field__derivation` aliases or caller overrides
- translate current frontend derivation labels to stable API ids in the remote adapter

## Validation
- `./.venv-server/bin/ruff check server/`
- `./.venv-server/bin/pytest server/tests -q`
- `./.venv-server/bin/pytest tests/test_backend_benchmark_runner.py -q`
- `npm run test:unit`
- `npm run lint:js`